### PR TITLE
Fix sonner toast colors

### DIFF
--- a/components/ui/sonner.tsx
+++ b/components/ui/sonner.tsx
@@ -30,9 +30,9 @@ const Toaster = ({ ...props }: ToasterProps) => {
       }}
       style={
         {
-          "--normal-bg": "var(--popover)",
-          "--normal-text": "var(--popover-foreground)",
-          "--normal-border": "var(--border)",
+          "--normal-bg": "hsl(var(--popover))",
+          "--normal-text": "hsl(var(--popover-foreground))",
+          "--normal-border": "hsl(var(--border))",
           "--border-radius": "var(--radius)",
         } as React.CSSProperties
       }


### PR DESCRIPTION
### Motivation
- Sonner toasts were rendering as transparent because the component passed raw CSS custom properties instead of color strings, so the toast background, text, and border were not receiving valid color values.

### Description
- Change `components/ui/sonner.tsx` to provide HSL color strings by using `hsl(var(--popover))`, `hsl(var(--popover-foreground))`, and `hsl(var(--border))` for `--normal-bg`, `--normal-text`, and `--normal-border` respectively, while keeping `--border-radius` unchanged.

### Testing
- No automated tests were run for this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69832b60ae00833299de560ab61b751b)

## Summary by Sourcery

Bug Fixes:
- 通过将提示（toast）的背景、文本和边框颜色映射到 HSL 主题变量，而不是直接使用原始 CSS 自定义属性，来修正这些颜色设置。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Bug Fixes:
- Correct toast background, text, and border colors by mapping them to HSL theme variables instead of raw CSS custom properties.

</details>