### PR TITLE
Replace sidebar color dots with checkbox squares and add multi-select calendar filtering

### DIFF
--- a/components/Calendar.tsx
+++ b/components/Calendar.tsx
@@ -102,27 +102,26 @@ export default function Calendar({ className, ...props }: CalendarProps) {
   useEffect(() => {
     const nextCalendarIds = calendars.map((calendar) => calendar.id)
 
-    if (!calendarSelectionInitializedRef.current) {
-      setSelectedCalendarIds(nextCalendarIds)
-      previousCalendarIdsRef.current = nextCalendarIds
-      calendarSelectionInitializedRef.current = true
-      return
-    }
-
-    const previousCalendarIds = previousCalendarIdsRef.current
-    const wasAllSelected =
-      previousCalendarIds.length > 0 &&
-      previousCalendarIds.every((id) => selectedCalendarIds.includes(id))
-
     setSelectedCalendarIds((current) => {
-      if (wasAllSelected) {
+      if (!calendarSelectionInitializedRef.current) {
+        calendarSelectionInitializedRef.current = true
+        previousCalendarIdsRef.current = nextCalendarIds
         return nextCalendarIds
       }
-      return current.filter((id) => nextCalendarIds.includes(id))
-    })
 
-    previousCalendarIdsRef.current = nextCalendarIds
-  }, [calendars, selectedCalendarIds])
+      const previousCalendarIds = previousCalendarIdsRef.current
+      const wasAllSelected =
+        previousCalendarIds.length > 0 &&
+        previousCalendarIds.every((id) => current.includes(id))
+
+      const nextSelected = wasAllSelected
+        ? nextCalendarIds
+        : current.filter((id) => nextCalendarIds.includes(id))
+
+      previousCalendarIdsRef.current = nextCalendarIds
+      return nextSelected
+    })
+  }, [calendars])
   
   // 新增：快速创建事件的初始时间
   const [quickCreateStartTime, setQuickCreateStartTime] = useState<Date | null>(null)

--- a/components/sidebar/Sidebar.tsx
+++ b/components/sidebar/Sidebar.tsx
@@ -21,6 +21,8 @@ interface SidebarProps {
   selectedDate?: Date
   isCollapsed?: boolean
   onToggleCollapse?: () => void
+  selectedCalendarIds: string[]
+  onToggleCalendar: (calendarId: string) => void
 }
 
 export interface CalendarCategory {
@@ -38,6 +40,8 @@ export default function Sidebar({
   selectedDate,
   isCollapsed = false,
   onToggleCollapse,
+  selectedCalendarIds,
+  onToggleCalendar,
 }: SidebarProps) {
 
   const { calendars, addCategory: addCategoryToContext, removeCategory: removeCategoryFromContext } = useCalendar()
@@ -134,10 +138,26 @@ export default function Sidebar({
           </div>
           {calendars.map((calendar) => (
             <div key={calendar.id} className="flex items-center justify-between">
-              <div className="flex items-center space-x-2">
-                <div className={cn("h-3 w-3 rounded-full", calendar.color)} />
+              <label
+                className="flex items-center space-x-2 cursor-pointer"
+                htmlFor={`calendar-${calendar.id}`}
+              >
+                <input
+                  id={`calendar-${calendar.id}`}
+                  type="checkbox"
+                  checked={selectedCalendarIds.includes(calendar.id)}
+                  onChange={() => onToggleCalendar(calendar.id)}
+                  className={cn(
+                    "h-4 w-4 rounded-[3px] border-2 appearance-none cursor-pointer transition-colors focus:outline-none focus-visible:ring-2 focus-visible:ring-ring",
+                    selectedCalendarIds.includes(calendar.id) ? calendar.color : "bg-transparent",
+                    selectedCalendarIds.includes(calendar.id)
+                      ? "border-transparent"
+                      : calendar.color.replace("bg-", "border-"),
+                  )}
+                  aria-label={calendar.name}
+                />
                 <span className="text-sm">{calendar.name}</span>
-              </div>
+              </label>
               <Button variant="ghost" size="sm" onClick={() => handleDeleteClick(calendar.id)}>
                 <X className="h-4 w-4" />
               </Button>


### PR DESCRIPTION
### Motivation

- Replace the small colored circle UI in the left sidebar with a checkbox-sized square that acts as a real checkbox for selecting calendars. 
- Ensure calendar selection is multi-select and that selecting calendars filters events in all views (day/week/month) and analytics consistently. 
- Keep calendar selection in memory (not persisted) so plaintext selection state only exists in-memory to align with end-to-end encrypted event storage.

### Description

- Updated `components/sidebar/Sidebar.tsx` to replace the color dot with a square `input type="checkbox"` and added new props `selectedCalendarIds` and `onToggleCalendar` to control selection from parent. 
- Updated `components/Calendar.tsx` to add `selectedCalendarIds` state, `handleToggleCalendar`, and an initialization/sync `useEffect` so selection follows category list changes while preserving user choices. 
- Changed event filtering to compute `filteredEvents` by applying calendar selection (`.filter((event) => selectedCalendarIds.includes(event.calendarId))`) before search filtering and passed `filteredEvents` into views and `AnalyticsView`. 
- Minor UI styling: checkbox is square-sized, fills with category color when checked, and uses a colored border when unchecked via Tailwind class composition.

### Testing

- Attempted dependency install with `bun install` to run the app, but it failed due to registry access errors (`403`), so the app was not started and runtime verification could not be performed. 
- No automated test suites were executed as part of this change because dependencies could not be installed.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69833d9420748332b93050f952dffad8)

## Summary by Sourcery

引入内存多选日历过滤功能，并将其连接到侧边栏选择和所有日历视图。

新功能：
- 允许用户通过侧边栏中的复选框控件选择多个日历。
- 按所选日历过滤主视图和分析视图中的日历事件，同时仅在内存中保留选择状态。

增强：
- 将侧边栏中的颜色圆点替换为复选框样式的彩色方块，用于指示和控制日历选择。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Introduce in-memory multi-select calendar filtering and connect it to sidebar selection and all calendar views.

New Features:
- Allow users to select multiple calendars via checkbox controls in the sidebar.
- Filter calendar events by selected calendars across main views and analytics while keeping selection state in memory only.

Enhancements:
- Replace sidebar color dots with checkbox-style colored squares to indicate and control calendar selection.

</details>