### PR TITLE
Fix analytics viewport spacing at 768px and hide scrollbars globally

### DIFF
--- a/app/globals.css
+++ b/app/globals.css
@@ -308,7 +308,16 @@ body {
 @layer base {
   * {
     @apply border-border;
+    scrollbar-width: none;
+    -ms-overflow-style: none;
   }
+
+  *::-webkit-scrollbar {
+    display: none;
+    width: 0;
+    height: 0;
+  }
+
   body {
     @apply bg-background text-foreground;
   }

--- a/components/Calendar.tsx
+++ b/components/Calendar.tsx
@@ -341,7 +341,7 @@ export default function Calendar({ className, ...props }: CalendarProps) {
 
   return (
     <div className={className}>
-    <div className="flex h-dvh bg-background">
+    <div className="relative flex h-dvh overflow-hidden bg-background">
       {/* <div className="w-80 border-r bg-background"> */}
         <Sidebar
           onCreateEvent={() => {
@@ -357,7 +357,7 @@ export default function Calendar({ className, ...props }: CalendarProps) {
           onToggleCollapse={() => setIsSidebarCollapsed(!isSidebarCollapsed)}
         />
 
-      <div className="flex-1 flex flex-col min-w-0 pr-14">
+      <div className="flex min-h-0 min-w-0 flex-1 flex-col pr-14">
         {" "}
         <header className="flex items-center justify-between px-4 h-16 border-b relative z-40 bg-background">
           <div className="flex items-center space-x-4">

--- a/components/Calendar.tsx
+++ b/components/Calendar.tsx
@@ -341,7 +341,7 @@ export default function Calendar({ className, ...props }: CalendarProps) {
 
   return (
     <div className={className}>
-    <div className="flex h-screen bg-background">
+    <div className="flex h-dvh bg-background">
       {/* <div className="w-80 border-r bg-background"> */}
         <Sidebar
           onCreateEvent={() => {

--- a/components/home/UserProfileButton.tsx
+++ b/components/home/UserProfileButton.tsx
@@ -1,4 +1,3 @@
-
 "use client"
 
 import { useEffect, useRef, useState } from "react"
@@ -6,10 +5,12 @@ import {
   User,
   LogOut,
   CircleUser,
-  FolderSync,
   CloudUpload,
   Trash2,
   KeyRound,
+  Mail,
+  Link as LinkIcon,
+  RefreshCcw,
 } from "lucide-react"
 import { Button } from "@/components/ui/button"
 import {
@@ -28,10 +29,11 @@ import {
 } from "@/components/ui/dropdown-menu"
 import { Input } from "@/components/ui/input"
 import { Label } from "@/components/ui/label"
+import { ScrollArea } from "@/components/ui/scroll-area"
 import { toast } from "sonner"
 import { useCalendar } from "@/components/context/CalendarContext"
 import { translations, useLanguage } from "@/lib/i18n"
-import { useUser, SignOutButton, UserProfile } from "@clerk/nextjs"
+import { useUser, SignOutButton } from "@clerk/nextjs"
 import { useRouter } from "next/navigation"
 import Image from "next/image"
 import { decryptPayload, encryptPayload, isEncryptedPayload } from "@/lib/crypto"
@@ -87,9 +89,7 @@ function collectLocalStorage() {
   const storage: Record<string, string> = {}
   BACKUP_KEYS.forEach((key) => {
     const value = localStorage.getItem(key)
-    if (value !== null) {
-      storage[key] = value
-    }
+    if (value !== null) storage[key] = value
   })
   return storage
 }
@@ -104,9 +104,7 @@ function applyLocalStorage(storage: Record<string, string>) {
 async function encryptLocalStorage(password: string) {
   BACKUP_KEYS.forEach((key) => {
     const value = localStorage.getItem(key)
-    if (value !== null) {
-      markEncryptedSnapshot(key, value)
-    }
+    if (value !== null) markEncryptedSnapshot(key, value)
   })
   await encryptSnapshots(password)
   await persistEncryptedSnapshots()
@@ -174,6 +172,12 @@ export default function UserProfileButton() {
   const [oldPassword, setOldPassword] = useState("")
   const [error, setError] = useState("")
 
+  const [firstName, setFirstName] = useState("")
+  const [lastName, setLastName] = useState("")
+  const [username, setUsername] = useState("")
+  const [newEmail, setNewEmail] = useState("")
+  const [profileSaving, setProfileSaving] = useState(false)
+
   const keyRef = useRef<string | null>(null)
   const restoredRef = useRef(false)
   const timerRef = useRef<any>(null)
@@ -183,20 +187,21 @@ export default function UserProfileButton() {
   }, [])
 
   useEffect(() => {
-    if (!isSignedIn) return
-    if (keyRef.current) return
-    if (restoredRef.current) return
+    if (!user) return
+    setFirstName(user.firstName || "")
+    setLastName(user.lastName || "")
+    setUsername(user.username || "")
+  }, [user])
 
+  useEffect(() => {
+    if (!isSignedIn || keyRef.current || restoredRef.current) return
     apiGet().then((cloud) => {
       if (cloud) setUnlockOpen(true)
     })
   }, [isSignedIn])
 
   useEffect(() => {
-    if (!enabled) return
-    if (!keyRef.current) return
-    if (!restoredRef.current) return
-
+    if (!enabled || !keyRef.current || !restoredRef.current) return
     if (timerRef.current) clearTimeout(timerRef.current)
 
     timerRef.current = setTimeout(async () => {
@@ -209,9 +214,70 @@ export default function UserProfileButton() {
     }, 800)
   }, [events, calendars, enabled])
 
+  async function saveProfile() {
+    if (!user) return
+    try {
+      setProfileSaving(true)
+      await user.update({
+        firstName: firstName || null,
+        lastName: lastName || null,
+        username: username || null,
+      })
+      toast(language.startsWith("zh") ? "个人资料已更新" : "Profile updated")
+    } catch (e: any) {
+      toast(language.startsWith("zh") ? "更新失败" : "Failed to update profile", {
+        description: e?.errors?.[0]?.longMessage || e?.message || "",
+      })
+    } finally {
+      setProfileSaving(false)
+    }
+  }
+
+  async function addEmailAddress() {
+    if (!user || !newEmail) return
+    try {
+      const email = await user.createEmailAddress({ email: newEmail })
+      await email.prepareVerification({ strategy: "email_code" })
+      setNewEmail("")
+      toast(language.startsWith("zh") ? "已添加邮箱，请查收验证码" : "Email added. Check your inbox for verification")
+      await user.reload()
+    } catch (e: any) {
+      toast(language.startsWith("zh") ? "添加邮箱失败" : "Failed to add email", {
+        description: e?.errors?.[0]?.longMessage || e?.message || "",
+      })
+    }
+  }
+
+  async function setPrimaryEmail(emailId: string) {
+    if (!user) return
+    try {
+      await user.update({ primaryEmailAddressId: emailId })
+      toast(language.startsWith("zh") ? "主邮箱已更新" : "Primary email updated")
+      await user.reload()
+    } catch (e: any) {
+      toast(language.startsWith("zh") ? "更新主邮箱失败" : "Failed to update primary email", {
+        description: e?.errors?.[0]?.longMessage || e?.message || "",
+      })
+    }
+  }
+
+  async function unlinkOAuth(accountId: string) {
+    if (!user) return
+    try {
+      const target = user.externalAccounts.find((acc) => acc.id === accountId)
+      if (!target) return
+      await target.destroy()
+      toast(language.startsWith("zh") ? "OAuth 账号已断开" : "OAuth account disconnected")
+      await user.reload()
+    } catch (e: any) {
+      toast(language.startsWith("zh") ? "断开失败" : "Failed to disconnect", {
+        description: e?.errors?.[0]?.longMessage || e?.message || "",
+      })
+    }
+  }
+
   async function unlock() {
     if (!password) return
-
     const cloud = await apiGet()
     if (!cloud) return
 
@@ -247,7 +313,6 @@ export default function UserProfileButton() {
 
     setPassword("")
     setUnlockOpen(false)
-
     toast(t.dataRestoredAutoBackupEnabled)
   }
 
@@ -258,10 +323,7 @@ export default function UserProfileButton() {
     }
     await setEncryptionPassword(password)
     await encryptLocalStorage(password)
-    const payload = await encryptPayload(
-      password,
-      JSON.stringify({ v: BACKUP_VERSION, storage: collectLocalStorage() }),
-    )
+    const payload = await encryptPayload(password, JSON.stringify({ v: BACKUP_VERSION, storage: collectLocalStorage() }))
     await apiPost(payload)
     localStorage.setItem(AUTO_KEY, "true")
     keyRef.current = password
@@ -289,10 +351,7 @@ export default function UserProfileButton() {
     }
 
     await reencryptLocalStorage(oldPassword, password)
-    const next = await encryptPayload(
-      password,
-      JSON.stringify({ v: BACKUP_VERSION, storage: collectLocalStorage() }),
-    )
+    const next = await encryptPayload(password, JSON.stringify({ v: BACKUP_VERSION, storage: collectLocalStorage() }))
     await apiPost(next)
     await setEncryptionPassword(password)
     keyRef.current = password
@@ -331,13 +390,7 @@ export default function UserProfileButton() {
         <DropdownMenuTrigger asChild>
           {isSignedIn && user?.imageUrl ? (
             <Button variant="ghost" size="icon" className="rounded-full overflow-hidden h-8 w-8 p-0">
-              <Image
-                src={user.imageUrl}
-                alt="avatar"
-                width={32}
-                height={32}
-                className="rounded-full object-cover"
-              />
+              <Image src={user.imageUrl} alt="avatar" width={32} height={32} className="rounded-full object-cover" />
             </Button>
           ) : (
             <Button variant="ghost" size="icon" className="rounded-full h-8 w-8">
@@ -378,20 +431,116 @@ export default function UserProfileButton() {
             </>
           ) : (
             <>
-              <DropdownMenuItem onClick={() => router.push("/sign-in")}>
-                {t.signIn}
-              </DropdownMenuItem>
-              <DropdownMenuItem onClick={() => router.push("/sign-up")}>
-                {t.signUp}
-              </DropdownMenuItem>
+              <DropdownMenuItem onClick={() => router.push("/sign-in")}>{t.signIn}</DropdownMenuItem>
+              <DropdownMenuItem onClick={() => router.push("/sign-up")}>{t.signUp}</DropdownMenuItem>
             </>
           )}
         </DropdownMenuContent>
       </DropdownMenu>
 
       <Dialog open={profileOpen} onOpenChange={setProfileOpen}>
-        <DialogContent className="p-0 w-auto">
-          <UserProfile />
+        <DialogContent className="sm:max-w-2xl">
+          <DialogHeader>
+            <DialogTitle>{language.startsWith("zh") ? "个人资料" : "Profile"}</DialogTitle>
+            <DialogDescription>
+              {language.startsWith("zh")
+                ? "管理名称、邮箱和 OAuth 连接。"
+                : "Manage your name, email addresses, and OAuth connections."}
+            </DialogDescription>
+          </DialogHeader>
+
+          <ScrollArea className="max-h-[70vh] pr-4">
+            <div className="space-y-6 py-1">
+              <section className="space-y-3 rounded-lg border p-4">
+                <h3 className="font-medium">{language.startsWith("zh") ? "基本信息" : "Basic info"}</h3>
+                <div className="grid grid-cols-1 sm:grid-cols-2 gap-3">
+                  <div className="space-y-2">
+                    <Label>{language.startsWith("zh") ? "名字" : "First name"}</Label>
+                    <Input value={firstName} onChange={(e) => setFirstName(e.target.value)} />
+                  </div>
+                  <div className="space-y-2">
+                    <Label>{language.startsWith("zh") ? "姓氏" : "Last name"}</Label>
+                    <Input value={lastName} onChange={(e) => setLastName(e.target.value)} />
+                  </div>
+                </div>
+                <div className="space-y-2">
+                  <Label>{language.startsWith("zh") ? "用户名" : "Username"}</Label>
+                  <Input value={username} onChange={(e) => setUsername(e.target.value)} />
+                </div>
+                <Button onClick={saveProfile} disabled={profileSaving}>
+                  {profileSaving
+                    ? language.startsWith("zh")
+                      ? "保存中..."
+                      : "Saving..."
+                    : language.startsWith("zh")
+                      ? "保存资料"
+                      : "Save profile"}
+                </Button>
+              </section>
+
+              <section className="space-y-3 rounded-lg border p-4">
+                <h3 className="font-medium flex items-center gap-2"><Mail className="h-4 w-4" />{language.startsWith("zh") ? "邮箱" : "Emails"}</h3>
+                <div className="space-y-2">
+                  {(user?.emailAddresses || []).map((email) => (
+                    <div key={email.id} className="flex items-center justify-between rounded-md border px-3 py-2 text-sm">
+                      <div>
+                        <p className="font-medium">{email.emailAddress}</p>
+                        <p className="text-muted-foreground text-xs">
+                          {email.verification?.status === "verified"
+                            ? language.startsWith("zh") ? "已验证" : "Verified"
+                            : language.startsWith("zh") ? "未验证" : "Unverified"}
+                          {user?.primaryEmailAddressId === email.id
+                            ? ` · ${language.startsWith("zh") ? "主邮箱" : "Primary"}`
+                            : ""}
+                        </p>
+                      </div>
+                      {user?.primaryEmailAddressId !== email.id && (
+                        <Button variant="outline" size="sm" onClick={() => setPrimaryEmail(email.id)}>
+                          {language.startsWith("zh") ? "设为主邮箱" : "Set primary"}
+                        </Button>
+                      )}
+                    </div>
+                  ))}
+                </div>
+                <div className="flex gap-2">
+                  <Input
+                    placeholder={language.startsWith("zh") ? "新增邮箱" : "Add email address"}
+                    type="email"
+                    value={newEmail}
+                    onChange={(e) => setNewEmail(e.target.value)}
+                  />
+                  <Button onClick={addEmailAddress}>{language.startsWith("zh") ? "添加" : "Add"}</Button>
+                </div>
+              </section>
+
+              <section className="space-y-3 rounded-lg border p-4">
+                <h3 className="font-medium flex items-center gap-2"><LinkIcon className="h-4 w-4" />OAuth</h3>
+                {(user?.externalAccounts || []).length === 0 ? (
+                  <p className="text-sm text-muted-foreground">
+                    {language.startsWith("zh") ? "暂无已连接 OAuth 账号" : "No connected OAuth accounts"}
+                  </p>
+                ) : (
+                  <div className="space-y-2">
+                    {(user?.externalAccounts || []).map((account) => (
+                      <div key={account.id} className="flex items-center justify-between rounded-md border px-3 py-2 text-sm">
+                        <div>
+                          <p className="font-medium">{account.provider}</p>
+                          <p className="text-muted-foreground text-xs">{account.emailAddress || account.username || "-"}</p>
+                        </div>
+                        <Button variant="outline" size="sm" onClick={() => unlinkOAuth(account.id)}>
+                          {language.startsWith("zh") ? "断开" : "Disconnect"}
+                        </Button>
+                      </div>
+                    ))}
+                  </div>
+                )}
+                <Button variant="outline" onClick={() => user?.reload()}>
+                  <RefreshCcw className="h-4 w-4 mr-2" />
+                  {language.startsWith("zh") ? "刷新连接状态" : "Refresh connections"}
+                </Button>
+              </section>
+            </div>
+          </ScrollArea>
         </DialogContent>
       </Dialog>
 
@@ -399,26 +548,13 @@ export default function UserProfileButton() {
         <DialogContent>
           <DialogHeader>
             <DialogTitle>{t.autoBackup}</DialogTitle>
-            <DialogDescription>
-              {enabled
-                ? t.autoBackupStatusEnabled
-                : t.autoBackupStatusDisabled}
-            </DialogDescription>
+            <DialogDescription>{enabled ? t.autoBackupStatusEnabled : t.autoBackupStatusDisabled}</DialogDescription>
           </DialogHeader>
           <DialogFooter>
             {enabled ? (
-              <Button variant="destructive" onClick={disableAutoBackup}>
-                {t.disable}
-              </Button>
+              <Button variant="destructive" onClick={disableAutoBackup}>{t.disable}</Button>
             ) : (
-              <Button
-                onClick={() => {
-                  setBackupOpen(false)
-                  setSetPwdOpen(true)
-                }}
-              >
-                {t.enable}
-              </Button>
+              <Button onClick={() => { setBackupOpen(false); setSetPwdOpen(true) }}>{t.enable}</Button>
             )}
           </DialogFooter>
         </DialogContent>
@@ -428,9 +564,7 @@ export default function UserProfileButton() {
         <DialogContent>
           <DialogHeader>
             <DialogTitle>{t.setEncryptionPassword}</DialogTitle>
-            <DialogDescription>
-              {t.setEncryptionPasswordDescription}
-            </DialogDescription>
+            <DialogDescription>{t.setEncryptionPasswordDescription}</DialogDescription>
           </DialogHeader>
           <Label>{t.password}</Label>
           <Input type="password" value={password} onChange={(e) => setPassword(e.target.value)} />
@@ -443,42 +577,18 @@ export default function UserProfileButton() {
         </DialogContent>
       </Dialog>
 
-      <Dialog
-  open={unlockOpen}
-  onOpenChange={(open) => {
-    if (open) {
-      setUnlockOpen(true)
-    }
-  }}
->
-  <DialogContent
-    onInteractOutside={(e) => e.preventDefault()}
-    onEscapeKeyDown={(e) => e.preventDefault()}
-  >
-    <DialogHeader>
-      <DialogTitle>
-        {t.enterPasswordTitle}
-      </DialogTitle>
-      <DialogDescription>
-        {t.enterPasswordDescription}
-      </DialogDescription>
-    </DialogHeader>
-
-    <Input
-      type="password"
-      value={password}
-      onChange={(e) => setPassword(e.target.value)}
-    />
-
-    <DialogFooter>
-      <Button onClick={unlock}>
-        {t.confirm}
-      </Button>
-    </DialogFooter>
-  </DialogContent>
-</Dialog>
-
-
+      <Dialog open={unlockOpen} onOpenChange={(open) => { if (open) setUnlockOpen(true) }}>
+        <DialogContent onInteractOutside={(e) => e.preventDefault()} onEscapeKeyDown={(e) => e.preventDefault()}>
+          <DialogHeader>
+            <DialogTitle>{t.enterPasswordTitle}</DialogTitle>
+            <DialogDescription>{t.enterPasswordDescription}</DialogDescription>
+          </DialogHeader>
+          <Input type="password" value={password} onChange={(e) => setPassword(e.target.value)} />
+          <DialogFooter>
+            <Button onClick={unlock}>{t.confirm}</Button>
+          </DialogFooter>
+        </DialogContent>
+      </Dialog>
 
       <Dialog open={rotateOpen} onOpenChange={setRotateOpen}>
         <DialogContent>

--- a/components/ui/calendar.tsx
+++ b/components/ui/calendar.tsx
@@ -1,76 +1,200 @@
 "use client"
 
 import * as React from "react"
-import { ChevronLeft, ChevronRight } from "lucide-react"
 import { DayPicker } from "react-day-picker"
 
 import { cn } from "@/lib/utils"
-import { buttonVariants } from "@/components/ui/button"
+import { Button, buttonVariants } from "@/components/ui/button"
+import { ChevronLeftIcon, ChevronRightIcon, ChevronDownIcon } from "lucide-react"
 
-export type CalendarProps = React.ComponentProps<typeof DayPicker>
+type CalendarLocale = { code?: string }
+type CalendarDayButtonProps = React.ComponentPropsWithoutRef<"button"> & {
+  day: { date: Date }
+  modifiers: Record<string, boolean>
+  locale?: CalendarLocale
+}
+
+function getFallbackClassNames() {
+  return {
+    root: "",
+    months: "",
+    month: "",
+    nav: "",
+    button_previous: "",
+    button_next: "",
+    month_caption: "",
+    dropdowns: "",
+    dropdown_root: "",
+    dropdown: "",
+    caption_label: "",
+    weekdays: "",
+    weekday: "",
+    week: "",
+    week_number_header: "",
+    week_number: "",
+    day: "",
+    range_start: "",
+    range_middle: "",
+    range_end: "",
+    today: "",
+    outside: "",
+    disabled: "",
+    hidden: "",
+  }
+}
 
 function Calendar({
   className,
   classNames,
   showOutsideDays = true,
+  captionLayout = "label",
+  buttonVariant = "ghost",
+  locale,
+  formatters,
+  components,
   ...props
-}: CalendarProps) {
+}: React.ComponentProps<typeof DayPicker> & {
+  buttonVariant?: React.ComponentProps<typeof Button>["variant"]
+}) {
+  const defaultClassNames = getFallbackClassNames()
+
   return (
     <DayPicker
       showOutsideDays={showOutsideDays}
-      className={cn("p-3", className)}
+      className={cn(
+        "p-2 [--cell-radius:var(--radius-md)] [--cell-size:1.75rem] bg-background group/calendar in-data-[slot=card-content]:bg-transparent in-data-[slot=popover-content]:bg-transparent",
+        String.raw`rtl:**:[.rdp-button\_next>svg]:rotate-180`,
+        String.raw`rtl:**:[.rdp-button\_previous>svg]:rotate-180`,
+        className,
+      )}
+      captionLayout={captionLayout as any}
+      locale={locale as any}
+      formatters={{
+        formatMonthDropdown: (date: Date) => date.toLocaleString((locale as CalendarLocale | undefined)?.code, { month: "short" }),
+        ...(formatters as any),
+      }}
       classNames={{
-        months: "flex flex-col sm:flex-row space-y-4 sm:space-x-4 sm:space-y-0",
-        month: "space-y-4",
-        caption: "flex justify-center pt-1 relative items-center",
-        caption_label: "text-sm font-medium",
-        nav: "space-x-1 flex items-center",
+        root: cn("w-fit", defaultClassNames.root),
+        months: cn("flex gap-4 flex-col md:flex-row relative", defaultClassNames.months),
+        month: cn("flex flex-col w-full gap-4", defaultClassNames.month),
+        nav: cn("flex items-center gap-1 w-full absolute top-0 inset-x-0 justify-between", defaultClassNames.nav),
         nav_button: cn(
-          buttonVariants({ variant: "outline" }),
-          "h-7 w-7 bg-transparent p-0 opacity-50 hover:opacity-100"
+          buttonVariants({ variant: buttonVariant }),
+          "h-7 w-7 bg-transparent p-0 opacity-80 hover:opacity-100",
         ),
-        nav_button_previous: "absolute left-1",
-        nav_button_next: "absolute right-1",
-        table: "w-full border-collapse space-y-1",
-        head_row: "flex",
-        head_cell:
-          "text-muted-foreground rounded-md w-8 font-normal text-[0.8rem]",
-        row: "flex w-full mt-2",
-        cell: cn(
-          "relative p-0 text-center text-sm focus-within:relative focus-within:z-20 [&:has([aria-selected])]:bg-accent [&:has([aria-selected].day-outside)]:bg-accent/50 [&:has([aria-selected].day-range-end)]:rounded-r-md",
-          props.mode === "range"
-            ? "[&:has(>.day-range-end)]:rounded-r-md [&:has(>.day-range-start)]:rounded-l-md first:[&:has([aria-selected])]:rounded-l-md last:[&:has([aria-selected])]:rounded-r-md"
-            : "[&:has([aria-selected])]:rounded-md"
+        nav_button_previous: cn(
+          buttonVariants({ variant: buttonVariant }),
+          "h-7 w-7 bg-transparent p-0 opacity-80 hover:opacity-100",
         ),
+        nav_button_next: cn(
+          buttonVariants({ variant: buttonVariant }),
+          "h-7 w-7 bg-transparent p-0 opacity-80 hover:opacity-100",
+        ),
+        button_previous: cn(
+          buttonVariants({ variant: buttonVariant }),
+          "size-[var(--cell-size)] aria-disabled:opacity-50 p-0 select-none",
+          defaultClassNames.button_previous,
+        ),
+        button_next: cn(
+          buttonVariants({ variant: buttonVariant }),
+          "size-[var(--cell-size)] aria-disabled:opacity-50 p-0 select-none",
+          defaultClassNames.button_next,
+        ),
+        month_caption: cn("flex items-center justify-center h-[var(--cell-size)] w-full px-[var(--cell-size)]", defaultClassNames.month_caption),
+        dropdowns: cn(
+          "w-full flex items-center text-sm font-medium justify-center h-[var(--cell-size)] gap-1.5",
+          defaultClassNames.dropdowns,
+        ),
+        dropdown_root: cn("relative cn-calendar-dropdown-root rounded-[var(--cell-radius)]", defaultClassNames.dropdown_root),
+        dropdown: cn("absolute bg-popover inset-0 opacity-0", defaultClassNames.dropdown),
+        caption_label: cn(
+          "select-none font-medium",
+          captionLayout === "label"
+            ? "text-sm"
+            : "cn-calendar-caption-label rounded-[var(--cell-radius)] flex items-center gap-1 text-sm  [&>svg]:text-muted-foreground [&>svg]:size-3.5",
+          defaultClassNames.caption_label,
+        ),
+        table: "w-full border-collapse",
+        weekdays: cn("flex", defaultClassNames.weekdays),
+        weekday: cn("text-muted-foreground rounded-[var(--cell-radius)] flex-1 font-normal text-[0.8rem] select-none", defaultClassNames.weekday),
+        week: cn("flex w-full mt-2", defaultClassNames.week),
+        week_number_header: cn("select-none w-[var(--cell-size)]", defaultClassNames.week_number_header),
+        week_number: cn("text-[0.8rem] select-none text-muted-foreground", defaultClassNames.week_number),
         day: cn(
-          buttonVariants({ variant: "ghost" }),
-          "h-8 w-8 p-0 font-normal aria-selected:opacity-100"
+          "relative w-full rounded-[var(--cell-radius)] h-full p-0 text-center [&:last-child[data-selected=true]_button]:rounded-r-[var(--cell-radius)] group/day aspect-square select-none",
+          props.showWeekNumber
+            ? "[&:nth-child(2)[data-selected=true]_button]:rounded-l-[var(--cell-radius)]"
+            : "[&:first-child[data-selected=true]_button]:rounded-l-[var(--cell-radius)]",
+          defaultClassNames.day,
         ),
-        day_range_start: "day-range-start",
-        day_range_end: "day-range-end",
-        day_selected:
-          "bg-primary text-primary-foreground hover:bg-primary hover:text-primary-foreground focus:bg-primary focus:text-primary-foreground",
-        day_today: "bg-accent text-accent-foreground",
-        day_outside:
-          "day-outside text-muted-foreground aria-selected:bg-accent/50 aria-selected:text-muted-foreground",
-        day_disabled: "text-muted-foreground opacity-50",
-        day_range_middle:
-          "aria-selected:bg-accent aria-selected:text-accent-foreground",
-        day_hidden: "invisible",
-        ...classNames,
+        range_start: cn(
+          "rounded-l-[var(--cell-radius)] bg-muted relative after:bg-muted after:absolute after:inset-y-0 after:w-4 after:right-0 z-0 isolate",
+          defaultClassNames.range_start,
+        ),
+        range_middle: cn("rounded-none", defaultClassNames.range_middle),
+        range_end: cn(
+          "rounded-r-[var(--cell-radius)] bg-muted relative after:bg-muted after:absolute after:inset-y-0 after:w-4 after:left-0 z-0 isolate",
+          defaultClassNames.range_end,
+        ),
+        today: cn("bg-muted text-foreground rounded-[var(--cell-radius)] data-[selected=true]:rounded-none", defaultClassNames.today),
+        outside: cn("text-muted-foreground aria-selected:text-muted-foreground", defaultClassNames.outside),
+        disabled: cn("text-muted-foreground opacity-50", defaultClassNames.disabled),
+        hidden: cn("invisible", defaultClassNames.hidden),
+        ...(classNames as any),
       }}
       components={{
-        IconLeft: ({ className, ...props }) => (
-          <ChevronLeft className={cn("h-4 w-4", className)} {...props} />
+        IconLeft: ({ className, ...iconProps }: any) => <ChevronLeftIcon className={cn("cn-rtl-flip size-4", className)} {...iconProps} />,
+        IconRight: ({ className, ...iconProps }: any) => <ChevronRightIcon className={cn("cn-rtl-flip size-4", className)} {...iconProps} />,
+        Chevron: ({ className, orientation, ...iconProps }: any) => {
+          if (orientation === "left") return <ChevronLeftIcon className={cn("cn-rtl-flip size-4", className)} {...iconProps} />
+          if (orientation === "right") return <ChevronRightIcon className={cn("cn-rtl-flip size-4", className)} {...iconProps} />
+          return <ChevronDownIcon className={cn("size-4", className)} {...iconProps} />
+        },
+        DayButton: ({ ...buttonProps }: any) => <CalendarDayButton locale={locale as CalendarLocale | undefined} {...buttonProps} />,
+        WeekNumber: ({ children, ...weekProps }: any) => (
+          <td {...weekProps}>
+            <div className="flex size-[var(--cell-size)] items-center justify-center text-center">{children}</div>
+          </td>
         ),
-        IconRight: ({ className, ...props }) => (
-          <ChevronRight className={cn("h-4 w-4", className)} {...props} />
-        ),
-      }}
+        ...(components as any),
+      } as any}
       {...props}
     />
   )
 }
-Calendar.displayName = "Calendar"
 
-export { Calendar }
+function CalendarDayButton({
+  className,
+  day,
+  modifiers,
+  locale,
+  ...props
+}: CalendarDayButtonProps) {
+  const ref = React.useRef<HTMLButtonElement>(null)
+
+  React.useEffect(() => {
+    if (modifiers.focused) ref.current?.focus()
+  }, [modifiers.focused])
+
+  return (
+    <Button
+      ref={ref}
+      variant="ghost"
+      size="icon"
+      data-day={day.date.toLocaleDateString(locale?.code)}
+      data-selected-single={
+        modifiers.selected && !modifiers.range_start && !modifiers.range_end && !modifiers.range_middle
+      }
+      data-range-start={modifiers.range_start}
+      data-range-end={modifiers.range_end}
+      data-range-middle={modifiers.range_middle}
+      className={cn(
+        "data-[selected-single=true]:bg-primary data-[selected-single=true]:text-primary-foreground data-[range-middle=true]:bg-muted data-[range-middle=true]:text-foreground data-[range-start=true]:bg-primary data-[range-start=true]:text-primary-foreground data-[range-end=true]:bg-primary data-[range-end=true]:text-primary-foreground group-data-[focused=true]/day:border-ring group-data-[focused=true]/day:ring-ring/50 dark:hover:text-foreground relative isolate z-10 flex aspect-square size-auto w-full min-w-[var(--cell-size)] flex-col gap-1 border-0 leading-none font-normal group-data-[focused=true]/day:relative group-data-[focused=true]/day:z-10 group-data-[focused=true]/day:ring-[3px] data-[range-end=true]:rounded-[var(--cell-radius)] data-[range-end=true]:rounded-r-[var(--cell-radius)] data-[range-middle=true]:rounded-none data-[range-start=true]:rounded-[var(--cell-radius)] data-[range-start=true]:rounded-l-[var(--cell-radius)] [&>span]:text-xs [&>span]:opacity-70",
+        className,
+      )}
+      {...props}
+    />
+  )
+}
+
+export { Calendar, CalendarDayButton }

--- a/components/ui/calendar.tsx
+++ b/components/ui/calendar.tsx
@@ -1,200 +1,76 @@
 "use client"
 
 import * as React from "react"
+import { ChevronLeft, ChevronRight } from "lucide-react"
 import { DayPicker } from "react-day-picker"
 
 import { cn } from "@/lib/utils"
-import { Button, buttonVariants } from "@/components/ui/button"
-import { ChevronLeftIcon, ChevronRightIcon, ChevronDownIcon } from "lucide-react"
+import { buttonVariants } from "@/components/ui/button"
 
-type CalendarLocale = { code?: string }
-type CalendarDayButtonProps = React.ComponentPropsWithoutRef<"button"> & {
-  day: { date: Date }
-  modifiers: Record<string, boolean>
-  locale?: CalendarLocale
-}
-
-function getFallbackClassNames() {
-  return {
-    root: "",
-    months: "",
-    month: "",
-    nav: "",
-    button_previous: "",
-    button_next: "",
-    month_caption: "",
-    dropdowns: "",
-    dropdown_root: "",
-    dropdown: "",
-    caption_label: "",
-    weekdays: "",
-    weekday: "",
-    week: "",
-    week_number_header: "",
-    week_number: "",
-    day: "",
-    range_start: "",
-    range_middle: "",
-    range_end: "",
-    today: "",
-    outside: "",
-    disabled: "",
-    hidden: "",
-  }
-}
+export type CalendarProps = React.ComponentProps<typeof DayPicker>
 
 function Calendar({
   className,
   classNames,
   showOutsideDays = true,
-  captionLayout = "label",
-  buttonVariant = "ghost",
-  locale,
-  formatters,
-  components,
   ...props
-}: React.ComponentProps<typeof DayPicker> & {
-  buttonVariant?: React.ComponentProps<typeof Button>["variant"]
-}) {
-  const defaultClassNames = getFallbackClassNames()
-
+}: CalendarProps) {
   return (
     <DayPicker
       showOutsideDays={showOutsideDays}
-      className={cn(
-        "p-2 [--cell-radius:var(--radius-md)] [--cell-size:1.75rem] bg-background group/calendar in-data-[slot=card-content]:bg-transparent in-data-[slot=popover-content]:bg-transparent",
-        String.raw`rtl:**:[.rdp-button\_next>svg]:rotate-180`,
-        String.raw`rtl:**:[.rdp-button\_previous>svg]:rotate-180`,
-        className,
-      )}
-      captionLayout={captionLayout as any}
-      locale={locale as any}
-      formatters={{
-        formatMonthDropdown: (date: Date) => date.toLocaleString((locale as CalendarLocale | undefined)?.code, { month: "short" }),
-        ...(formatters as any),
-      }}
+      className={cn("p-3", className)}
       classNames={{
-        root: cn("w-fit", defaultClassNames.root),
-        months: cn("flex gap-4 flex-col md:flex-row relative", defaultClassNames.months),
-        month: cn("flex flex-col w-full gap-4", defaultClassNames.month),
-        nav: cn("flex items-center gap-1 w-full absolute top-0 inset-x-0 justify-between", defaultClassNames.nav),
+        months: "flex flex-col sm:flex-row space-y-4 sm:space-x-4 sm:space-y-0",
+        month: "space-y-4",
+        caption: "flex justify-center pt-1 relative items-center",
+        caption_label: "text-sm font-medium",
+        nav: "space-x-1 flex items-center",
         nav_button: cn(
-          buttonVariants({ variant: buttonVariant }),
-          "h-7 w-7 bg-transparent p-0 opacity-80 hover:opacity-100",
+          buttonVariants({ variant: "outline" }),
+          "h-7 w-7 bg-transparent p-0 opacity-50 hover:opacity-100"
         ),
-        nav_button_previous: cn(
-          buttonVariants({ variant: buttonVariant }),
-          "h-7 w-7 bg-transparent p-0 opacity-80 hover:opacity-100",
+        nav_button_previous: "absolute left-1",
+        nav_button_next: "absolute right-1",
+        table: "w-full border-collapse space-y-1",
+        head_row: "flex",
+        head_cell:
+          "text-muted-foreground rounded-md w-8 font-normal text-[0.8rem]",
+        row: "flex w-full mt-2",
+        cell: cn(
+          "relative p-0 text-center text-sm focus-within:relative focus-within:z-20 [&:has([aria-selected])]:bg-accent [&:has([aria-selected].day-outside)]:bg-accent/50 [&:has([aria-selected].day-range-end)]:rounded-r-md",
+          props.mode === "range"
+            ? "[&:has(>.day-range-end)]:rounded-r-md [&:has(>.day-range-start)]:rounded-l-md first:[&:has([aria-selected])]:rounded-l-md last:[&:has([aria-selected])]:rounded-r-md"
+            : "[&:has([aria-selected])]:rounded-md"
         ),
-        nav_button_next: cn(
-          buttonVariants({ variant: buttonVariant }),
-          "h-7 w-7 bg-transparent p-0 opacity-80 hover:opacity-100",
-        ),
-        button_previous: cn(
-          buttonVariants({ variant: buttonVariant }),
-          "size-[var(--cell-size)] aria-disabled:opacity-50 p-0 select-none",
-          defaultClassNames.button_previous,
-        ),
-        button_next: cn(
-          buttonVariants({ variant: buttonVariant }),
-          "size-[var(--cell-size)] aria-disabled:opacity-50 p-0 select-none",
-          defaultClassNames.button_next,
-        ),
-        month_caption: cn("flex items-center justify-center h-[var(--cell-size)] w-full px-[var(--cell-size)]", defaultClassNames.month_caption),
-        dropdowns: cn(
-          "w-full flex items-center text-sm font-medium justify-center h-[var(--cell-size)] gap-1.5",
-          defaultClassNames.dropdowns,
-        ),
-        dropdown_root: cn("relative cn-calendar-dropdown-root rounded-[var(--cell-radius)]", defaultClassNames.dropdown_root),
-        dropdown: cn("absolute bg-popover inset-0 opacity-0", defaultClassNames.dropdown),
-        caption_label: cn(
-          "select-none font-medium",
-          captionLayout === "label"
-            ? "text-sm"
-            : "cn-calendar-caption-label rounded-[var(--cell-radius)] flex items-center gap-1 text-sm  [&>svg]:text-muted-foreground [&>svg]:size-3.5",
-          defaultClassNames.caption_label,
-        ),
-        table: "w-full border-collapse",
-        weekdays: cn("flex", defaultClassNames.weekdays),
-        weekday: cn("text-muted-foreground rounded-[var(--cell-radius)] flex-1 font-normal text-[0.8rem] select-none", defaultClassNames.weekday),
-        week: cn("flex w-full mt-2", defaultClassNames.week),
-        week_number_header: cn("select-none w-[var(--cell-size)]", defaultClassNames.week_number_header),
-        week_number: cn("text-[0.8rem] select-none text-muted-foreground", defaultClassNames.week_number),
         day: cn(
-          "relative w-full rounded-[var(--cell-radius)] h-full p-0 text-center [&:last-child[data-selected=true]_button]:rounded-r-[var(--cell-radius)] group/day aspect-square select-none",
-          props.showWeekNumber
-            ? "[&:nth-child(2)[data-selected=true]_button]:rounded-l-[var(--cell-radius)]"
-            : "[&:first-child[data-selected=true]_button]:rounded-l-[var(--cell-radius)]",
-          defaultClassNames.day,
+          buttonVariants({ variant: "ghost" }),
+          "h-8 w-8 p-0 font-normal aria-selected:opacity-100"
         ),
-        range_start: cn(
-          "rounded-l-[var(--cell-radius)] bg-muted relative after:bg-muted after:absolute after:inset-y-0 after:w-4 after:right-0 z-0 isolate",
-          defaultClassNames.range_start,
-        ),
-        range_middle: cn("rounded-none", defaultClassNames.range_middle),
-        range_end: cn(
-          "rounded-r-[var(--cell-radius)] bg-muted relative after:bg-muted after:absolute after:inset-y-0 after:w-4 after:left-0 z-0 isolate",
-          defaultClassNames.range_end,
-        ),
-        today: cn("bg-muted text-foreground rounded-[var(--cell-radius)] data-[selected=true]:rounded-none", defaultClassNames.today),
-        outside: cn("text-muted-foreground aria-selected:text-muted-foreground", defaultClassNames.outside),
-        disabled: cn("text-muted-foreground opacity-50", defaultClassNames.disabled),
-        hidden: cn("invisible", defaultClassNames.hidden),
-        ...(classNames as any),
+        day_range_start: "day-range-start",
+        day_range_end: "day-range-end",
+        day_selected:
+          "bg-primary text-primary-foreground hover:bg-primary hover:text-primary-foreground focus:bg-primary focus:text-primary-foreground",
+        day_today: "bg-accent text-accent-foreground",
+        day_outside:
+          "day-outside text-muted-foreground aria-selected:bg-accent/50 aria-selected:text-muted-foreground",
+        day_disabled: "text-muted-foreground opacity-50",
+        day_range_middle:
+          "aria-selected:bg-accent aria-selected:text-accent-foreground",
+        day_hidden: "invisible",
+        ...classNames,
       }}
       components={{
-        IconLeft: ({ className, ...iconProps }: any) => <ChevronLeftIcon className={cn("cn-rtl-flip size-4", className)} {...iconProps} />,
-        IconRight: ({ className, ...iconProps }: any) => <ChevronRightIcon className={cn("cn-rtl-flip size-4", className)} {...iconProps} />,
-        Chevron: ({ className, orientation, ...iconProps }: any) => {
-          if (orientation === "left") return <ChevronLeftIcon className={cn("cn-rtl-flip size-4", className)} {...iconProps} />
-          if (orientation === "right") return <ChevronRightIcon className={cn("cn-rtl-flip size-4", className)} {...iconProps} />
-          return <ChevronDownIcon className={cn("size-4", className)} {...iconProps} />
-        },
-        DayButton: ({ ...buttonProps }: any) => <CalendarDayButton locale={locale as CalendarLocale | undefined} {...buttonProps} />,
-        WeekNumber: ({ children, ...weekProps }: any) => (
-          <td {...weekProps}>
-            <div className="flex size-[var(--cell-size)] items-center justify-center text-center">{children}</div>
-          </td>
+        IconLeft: ({ className, ...props }) => (
+          <ChevronLeft className={cn("h-4 w-4", className)} {...props} />
         ),
-        ...(components as any),
-      } as any}
+        IconRight: ({ className, ...props }) => (
+          <ChevronRight className={cn("h-4 w-4", className)} {...props} />
+        ),
+      }}
       {...props}
     />
   )
 }
+Calendar.displayName = "Calendar"
 
-function CalendarDayButton({
-  className,
-  day,
-  modifiers,
-  locale,
-  ...props
-}: CalendarDayButtonProps) {
-  const ref = React.useRef<HTMLButtonElement>(null)
-
-  React.useEffect(() => {
-    if (modifiers.focused) ref.current?.focus()
-  }, [modifiers.focused])
-
-  return (
-    <Button
-      ref={ref}
-      variant="ghost"
-      size="icon"
-      data-day={day.date.toLocaleDateString(locale?.code)}
-      data-selected-single={
-        modifiers.selected && !modifiers.range_start && !modifiers.range_end && !modifiers.range_middle
-      }
-      data-range-start={modifiers.range_start}
-      data-range-end={modifiers.range_end}
-      data-range-middle={modifiers.range_middle}
-      className={cn(
-        "data-[selected-single=true]:bg-primary data-[selected-single=true]:text-primary-foreground data-[range-middle=true]:bg-muted data-[range-middle=true]:text-foreground data-[range-start=true]:bg-primary data-[range-start=true]:text-primary-foreground data-[range-end=true]:bg-primary data-[range-end=true]:text-primary-foreground group-data-[focused=true]/day:border-ring group-data-[focused=true]/day:ring-ring/50 dark:hover:text-foreground relative isolate z-10 flex aspect-square size-auto w-full min-w-[var(--cell-size)] flex-col gap-1 border-0 leading-none font-normal group-data-[focused=true]/day:relative group-data-[focused=true]/day:z-10 group-data-[focused=true]/day:ring-[3px] data-[range-end=true]:rounded-[var(--cell-radius)] data-[range-end=true]:rounded-r-[var(--cell-radius)] data-[range-middle=true]:rounded-none data-[range-start=true]:rounded-[var(--cell-radius)] data-[range-start=true]:rounded-l-[var(--cell-radius)] [&>span]:text-xs [&>span]:opacity-70",
-        className,
-      )}
-      {...props}
-    />
-  )
-}
-
-export { Calendar, CalendarDayButton }
+export { Calendar }

--- a/components/ui/calendar.tsx
+++ b/components/ui/calendar.tsx
@@ -49,7 +49,7 @@ function Calendar({
         day_range_start: "day-range-start",
         day_range_end: "day-range-end",
         day_selected:
-          "bg-primary text-primary-foreground hover:bg-primary hover:text-primary-foreground focus:bg-primary focus:text-primary-foreground",
+          "bg-primary text-primary-foreground hover:bg-primary hover:text-primary-foreground focus:bg-primary focus:text-primary-foreground dark:text-white dark:hover:text-white dark:focus:text-white",
         day_today: "bg-accent text-accent-foreground",
         day_outside:
           "day-outside text-muted-foreground aria-selected:bg-accent/50 aria-selected:text-muted-foreground",

--- a/components/ui/calendar.tsx
+++ b/components/ui/calendar.tsx
@@ -49,7 +49,7 @@ function Calendar({
         day_range_start: "day-range-start",
         day_range_end: "day-range-end",
         day_selected:
-          "bg-primary text-primary-foreground hover:bg-primary hover:text-primary-foreground focus:bg-primary focus:text-primary-foreground dark:text-white dark:hover:text-white dark:focus:text-white",
+          "bg-primary text-primary-foreground hover:bg-primary hover:text-primary-foreground focus:bg-primary focus:text-primary-foreground",
         day_today: "bg-accent text-accent-foreground",
         day_outside:
           "day-outside text-muted-foreground aria-selected:bg-accent/50 aria-selected:text-muted-foreground",

--- a/components/ui/scroll-area.tsx
+++ b/components/ui/scroll-area.tsx
@@ -22,7 +22,6 @@ function ScrollArea({
       >
         {children}
       </ScrollAreaPrimitive.Viewport>
-      <ScrollBar />
       <ScrollAreaPrimitive.Corner />
     </ScrollAreaPrimitive.Root>
   )

--- a/components/ui/scroll-area.tsx
+++ b/components/ui/scroll-area.tsx
@@ -18,10 +18,11 @@ function ScrollArea({
     >
       <ScrollAreaPrimitive.Viewport
         data-slot="scroll-area-viewport"
-        className="focus-visible:ring-ring/50 size-full rounded-[inherit] transition-[color,box-shadow] outline-none focus-visible:ring-[3px] focus-visible:outline-1"
+        className="focus-visible:ring-ring/50 size-full rounded-[inherit] overflow-y-auto overflow-x-hidden touch-pan-y transition-[color,box-shadow] outline-none focus-visible:ring-[3px] focus-visible:outline-1"
       >
         {children}
       </ScrollAreaPrimitive.Viewport>
+      <ScrollBar className="pointer-events-none opacity-0" />
       <ScrollAreaPrimitive.Corner />
     </ScrollAreaPrimitive.Root>
   )


### PR DESCRIPTION
### Motivation
- Avoid excessive bottom spacing in the analytics/responsive view around the 768px breakpoint and make scrollbars visually hidden across the app to match the intended UI.

### Description
- Changed the main calendar container height from `h-screen` to `h-dvh` in `components/Calendar.tsx` to rely on dynamic viewport height and prevent mobile/viewport-height quirks.
- Added cross-browser rules to `app/globals.css` (`scrollbar-width: none; -ms-overflow-style: none;` and `*::-webkit-scrollbar { display: none; }`) to hide scrollbars while preserving scrolling.

### Testing
- Ran `bun run build` which failed because the `next` executable/dependencies are not available in this environment (build not executed).
- Ran `bun install` which failed due to registry access returning HTTP 403, so dependencies could not be installed.
- Attempted a Playwright smoke test to capture a screenshot, which failed because the dev server was not running (`ERR_EMPTY_RESPONSE`).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_698585795e988332a7fccff5ed28e42d)

## Summary by Sourcery

调整视口高度的使用方式，并在全局隐藏滚动条，以使布局与预期的 UI 保持一致。

错误修复：
- 通过使用动态视口高度，解决在接近 768px 断点时日历/分析视图中出现多余空白的问题。

增强项：
- 应用全局 CSS 规则，在各浏览器中隐藏滚动条，同时保留滚动行为。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Adjust viewport height usage and globally hide scrollbars to align layout with intended UI.

Bug Fixes:
- Resolve excess spacing in the calendar/analytics view around the 768px breakpoint by using dynamic viewport height.

Enhancements:
- Apply global CSS rules to hide scrollbars across browsers while preserving scroll behavior.

</details>