### PR TITLE
Add avatar editing in profile dialog and align calendar event styles

### DIFF
--- a/components/view/DayView.tsx
+++ b/components/view/DayView.tsx
@@ -58,6 +58,10 @@ export default function DayView({
   const longPressTimeoutRef = useRef<NodeJS.Timeout | null>(null)
   const isDraggingRef = useRef(false)
 
+  const isDark =
+    typeof document !== "undefined" &&
+    document.documentElement.classList.contains("dark")
+
   const menuLabels = {
     edit: t.edit,
     share: t.share,
@@ -398,7 +402,7 @@ export default function DayView({
               position: "absolute",
               left: "0",
               right: "0",
-              opacity: 0.9,
+              opacity: isDark ? 0.5 : 0.9,
               zIndex: 10 + index,
             }}
             onMouseDown={(e) => handleEventDragStart(event, e)}
@@ -468,7 +472,7 @@ export default function DayView({
           style={{ backgroundColor: getDarkerColorClass(draggingEvent.color) }} 
         />
         <div className="pl-1">
-          <div className="font-medium truncate" style={{ color: getDarkerColorClass(event.color) }}>{draggingEvent.title}</div>
+          <div className="font-medium truncate" style={{ color: getDarkerColorClass(draggingEvent.color) }}>{draggingEvent.title}</div>
           {dragEventDuration >= 40 && (
             <div className="text-xs text-white/90 truncate">
               {formatTime(dragPreview.hour)}:{dragPreview.minute.toString().padStart(2, '0')} - {formatTime(Math.floor(endMinutes / 60))}:{(endMinutes % 60).toString().padStart(2, '0')}
@@ -580,7 +584,7 @@ export default function DayView({
                     style={{
                       top: `${startMinutes}px`,
                       height: `${height}px`,
-                      opacity: 0.9,
+                      opacity: isDark ? 0.5 : 0.9,
                       width,
                       left,
                       zIndex: column + 1,
@@ -599,7 +603,7 @@ export default function DayView({
                     <div className="pl-1">
                     <div className="font-medium truncate"  style={{ color: getDarkerColorClass(event.color) }}>{event.title}</div>
                     {height >= 40 && (
-                      <div className="text-xs text-white/90 truncate">
+                      <div className="text-xs truncate" style={{ color: getDarkerColorClass(event.color) }}>
                         {formatDateWithTimezone(start)} - {formatDateWithTimezone(end)}
                       </div>
                     )}

--- a/components/view/MonthView.tsx
+++ b/components/view/MonthView.tsx
@@ -36,6 +36,10 @@ export default function MonthView({ date, events, onEventClick, language, firstD
   const monthStart = startOfMonth(date)
   const monthEnd = endOfMonth(date)
   const monthDays = eachDayOfInterval({ start: monthStart, end: monthEnd })
+  const today = new Date()
+  const isDark =
+    typeof document !== "undefined" &&
+    document.documentElement.classList.contains("dark")
 
   const startWeekDay = monthStart.getDay()
   const leadingEmptyDays = (7 + (startWeekDay - firstDayOfWeek)) % 7
@@ -68,13 +72,24 @@ export default function MonthView({ date, events, onEventClick, language, firstD
             key={day.toString()}
             className="min-h-[100px] p-2 border rounded-xl border"
           >
-            <div className={cn("font-medium text-sm", isSameMonth(day, date) ? "" : "text-gray-400")}>{format(day, "d")}</div>
+            <div
+              className={cn(
+                "font-medium text-sm",
+                isSameMonth(day, date) ? "" : "text-gray-400",
+                isSameDay(day, today)
+                  ? "text-[#0066FF] font-bold green:text-[#24a854] orange:text-[#e26912] azalea:text-[#CD2F7B] pink:text-[#FFAFA5]"
+                  : "",
+              )}
+            >
+              {format(day, "d")}
+            </div>
             <div className="space-y-1">
               {visibleEvents.map((event) => (
                 <div
                   key={event.id}
                   className={cn("relative text-xs truncate rounded-md p-1 cursor-pointer text-white", event.color)}
                   onClick={() => onEventClick(event)}
+                  style={{ opacity: isDark ? 0.5 : 1 }}
                 >
                   <div className={cn("absolute left-0 top-0 w-1 h-full rounded-l-md")} style={{ backgroundColor: getDarkerColorClass(event.color) }} />
                   <div className="pl-1.5" style={{ color: getDarkerColorClass(event.color) }}>{event.title}</div>

--- a/components/view/WeekView.tsx
+++ b/components/view/WeekView.tsx
@@ -512,7 +512,7 @@ export default function WeekView({
               position: "absolute",
               left: "0",
               right: "0",
-              opacity: 0.9,
+              opacity: isDark ? 0.5 : 0.9,
               zIndex: 10 + index,
             }}
             onMouseDown={(e) => handleEventDragStart(event, e)}
@@ -529,7 +529,7 @@ export default function WeekView({
               className={cn("absolute left-0 top-0 w-2 h-full rounded-l-md")} 
               style={{ backgroundColor: getDarkerColorClass(event.color) }} 
             />
-            <div className="pl-1.5 truncate text-white">
+            <div className="pl-1.5 truncate" style={{ color: getDarkerColorClass(event.color) }}>
               {event.title}
             </div>
           </div>
@@ -585,7 +585,7 @@ export default function WeekView({
           style={{ backgroundColor: getDarkerColorClass(draggingEvent.color) }} 
         />
         <div className="pl-1">
-          <div className="font-medium truncate" style={{ color: getDarkerColorClass(event.color) }}>{draggingEvent.title}</div>
+          <div className="font-medium truncate" style={{ color: getDarkerColorClass(draggingEvent.color) }}>{draggingEvent.title}</div>
           {dragEventDuration >= 40 && (
             <div className="text-xs text-white/90 truncate">
               {formatTime(dragPreview.hour)}:{dragPreview.minute.toString().padStart(2, '0')} - {formatTime(Math.floor(endMinutes / 60))}:{(endMinutes % 60).toString().padStart(2, '0')}
@@ -682,7 +682,7 @@ export default function WeekView({
                           style={{
                             top: `${startMinutes}px`,
                             height: `${height}px`,
-                            opacity: 0.92,
+                            opacity: isDark ? 0.5 : 0.92,
                             width,
                             left,
                             zIndex: column + 1,


### PR DESCRIPTION
### Motivation
- Provide users a way to change their avatar from the Profile dialog and simplify profile fields by removing editable username.
- Improve visual consistency for event rendering in dark mode and ensure today/all-day styling matches across day/week/month views.

### Description
- Added avatar upload UI and handler to the Profile dialog using Clerk's `user.setProfileImage`, with upload state and localized toasts, and removed the Username input and save logic (file: `components/home/UserProfileButton.tsx`).
- Make all-day event and regular event blocks render with reduced opacity (`0.5`) in dark mode for Day, Week and Month views (files: `components/view/DayView.tsx`, `components/view/WeekView.tsx`, `components/view/MonthView.tsx`).
- In Month view, highlight today's date text with the same themed color classes used in Week view so today appears consistent (file: `components/view/MonthView.tsx`).
- Ensure all-day event text and event time text use the same darker accent color as the left color bar, and fix drag-preview title color to reference `draggingEvent.color` instead of the wrong variable (files: `components/view/DayView.tsx`, `components/view/WeekView.tsx`).

### Testing
- Attempted `npm run build` which failed in this environment because `next` is not installed (`next: not found`).
- Attempted `bun run build` which also failed due to the same missing `next` binary in this environment. 
- Attempted `bun install` but dependency resolution failed due to registry access returning 403 errors so dependencies could not be installed. 
- Attempted a Playwright navigation to `http://127.0.0.1:3000` for a visual check but the local server was not running and the request returned `ERR_EMPTY_RESPONSE`.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6986b61d69ac8332ac60758e73d8fb2e)

## Summary by Sourcery

在个人资料对话框中添加头像编辑功能，并统一日、周、月视图中日历事件的样式，特别是在深色模式下的表现。

新功能：
- 允许用户在个人资料对话框中直接上传和更改头像，并提供本地化的反馈。

改进：
- 通过从个人资料对话框中移除可编辑的用户名字段来简化个人资料编辑流程。
- 统一深色模式下日、周、月日历视图中的事件不透明度表现。
- 在月视图日历中使用与其他视图相同的主题配色方案高亮显示当前日期。
- 对齐事件文本颜色，包括“全天事件”和拖拽预览标题，使其与事件颜色条中使用的较深强调色保持一致，以改善视觉一致性。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Add avatar editing to the profile dialog and align calendar event styling across day, week, and month views, especially in dark mode.

New Features:
- Allow users to upload and change their avatar directly from the Profile dialog with localized feedback.

Enhancements:
- Simplify profile editing by removing the editable username field from the Profile dialog.
- Unify event opacity behavior in dark mode for day, week, and month calendar views.
- Highlight the current day in the month calendar view using the same themed color scheme as other views.
- Align event text colors, including all-day and drag-preview titles, with the darker accent color used by the event color bar for better visual consistency.

</details>