### PR TITLE
Refine sidebar cards, event title wrapping, and right-sheet UI

### DIFF
--- a/components/sidebar/BookmarkPanel.tsx
+++ b/components/sidebar/BookmarkPanel.tsx
@@ -117,7 +117,7 @@ export default function BookmarkPanel({ open, onOpenChange, onEventClick }: Book
 
   return (
     <Sheet open={open} onOpenChange={onOpenChange}>
-      <SheetContent side="right" className="w-[350px] sm:w-[400px] p-0">
+      <SheetContent side="right" className="w-[360px] sm:w-[420px] p-0">
         <SheetHeader className="p-4 border-b">
           <SheetTitle className="flex items-center">
             <Bookmark className="mr-2 h-5 w-5" />

--- a/components/sidebar/Countdown.tsx
+++ b/components/sidebar/Countdown.tsx
@@ -499,7 +499,7 @@ export function CountdownTool({ open, onOpenChange }: CountdownToolProps) {
 
   return (
     <Sheet open={open} onOpenChange={onOpenChange}>
-      <SheetContent className="p-0">
+      <SheetContent side="right" className="w-[360px] sm:w-[420px] p-0">
         {view === "list" && renderCountdownListView()}
         {view === "detail" && renderCountdownDetailView()}
         {view === "edit" && renderCountdownEditView()}

--- a/components/sidebar/MiniCalendarSheet.tsx
+++ b/components/sidebar/MiniCalendarSheet.tsx
@@ -3,7 +3,7 @@
 import { useState, useEffect } from "react"
 import { format, addDays, subDays, startOfWeek, endOfWeek, isSameDay, isToday } from "date-fns"
 import { zhCN, enUS } from "date-fns/locale"
-import { ChevronRight } from "lucide-react"
+import { CalendarDays, ChevronRight } from "lucide-react"
 import { Button } from "@/components/ui/button"
 import { ScrollArea } from "@/components/ui/scroll-area"
 import { Sheet, SheetContent, SheetHeader, SheetTitle } from "@/components/ui/sheet"
@@ -104,11 +104,12 @@ export default function MiniCalendarSheet({ open, onOpenChange, selectedDate, on
 
   return (
     <Sheet open={open} onOpenChange={onOpenChange}>
-      <SheetContent side="right" className="w-[350px] sm:w-[400px] p-0">
-        <SheetHeader className="p-4 border-b flex items-center justify-between">
-          <div className="flex items-center">
-            <SheetTitle>{t.calendar}</SheetTitle>
-          </div>
+      <SheetContent side="right" className="w-[360px] sm:w-[420px] p-0">
+        <SheetHeader className="p-4 border-b">
+          <SheetTitle className="flex items-center gap-2">
+            <CalendarDays className="h-5 w-5" />
+            {t.calendar}
+          </SheetTitle>
         </SheetHeader>
 
         <div className="p-4 border-b">

--- a/components/sidebar/Sidebar.tsx
+++ b/components/sidebar/Sidebar.tsx
@@ -124,7 +124,7 @@ export default function Sidebar({
               setLocalSelectedDate(date)
               date && onDateSelect(date)
             }}
-            className="rounded-md border"
+            className="rounded-lg border"
           />
         </div>
 

--- a/components/view/DayView.tsx
+++ b/components/view/DayView.tsx
@@ -402,7 +402,7 @@ export default function DayView({
               position: "absolute",
               left: "0",
               right: "0",
-              opacity: isDark ? 0.5 : 0.9,
+              opacity: isDark ? 0.68 : 0.9,
               zIndex: 10 + index,
             }}
             onMouseDown={(e) => handleEventDragStart(event, e)}
@@ -584,7 +584,7 @@ export default function DayView({
                     style={{
                       top: `${startMinutes}px`,
                       height: `${height}px`,
-                      opacity: isDark ? 0.5 : 0.9,
+                      opacity: isDark ? 0.68 : 0.9,
                       width,
                       left,
                       zIndex: column + 1,
@@ -601,7 +601,19 @@ export default function DayView({
                   >
                    <div className={cn("absolute left-0 top-0 w-1 h-full rounded-l-md")} style={{ backgroundColor: getDarkerColorClass(event.color) }} />
                     <div className="pl-1">
-                    <div className="font-medium truncate"  style={{ color: getDarkerColorClass(event.color) }}>{event.title}</div>
+                    <div
+                      className="font-medium leading-tight break-words"
+                      style={{
+                        color: getDarkerColorClass(event.color),
+                        display: "-webkit-box",
+                        WebkitBoxOrient: "vertical",
+                        WebkitLineClamp: Math.max(1, Math.floor((height - 8) / 16)),
+                        overflow: "hidden",
+                        textOverflow: "ellipsis",
+                      }}
+                    >
+                      {event.title}
+                    </div>
                     {height >= 40 && (
                       <div className="text-xs truncate" style={{ color: getDarkerColorClass(event.color) }}>
                         {formatDateWithTimezone(start)} - {formatDateWithTimezone(end)}

--- a/components/view/MonthView.tsx
+++ b/components/view/MonthView.tsx
@@ -89,7 +89,7 @@ export default function MonthView({ date, events, onEventClick, language, firstD
                   key={event.id}
                   className={cn("relative text-xs truncate rounded-md p-1 cursor-pointer text-white", event.color)}
                   onClick={() => onEventClick(event)}
-                  style={{ opacity: isDark ? 0.5 : 1 }}
+                  style={{ opacity: isDark ? 0.68 : 1 }}
                 >
                   <div className={cn("absolute left-0 top-0 w-1 h-full rounded-l-md")} style={{ backgroundColor: getDarkerColorClass(event.color) }} />
                   <div className="pl-1.5" style={{ color: getDarkerColorClass(event.color) }}>{event.title}</div>

--- a/components/view/WeekView.tsx
+++ b/components/view/WeekView.tsx
@@ -512,7 +512,7 @@ export default function WeekView({
               position: "absolute",
               left: "0",
               right: "0",
-              opacity: isDark ? 0.5 : 0.9,
+              opacity: isDark ? 0.68 : 0.9,
               zIndex: 10 + index,
             }}
             onMouseDown={(e) => handleEventDragStart(event, e)}
@@ -682,7 +682,7 @@ export default function WeekView({
                           style={{
                             top: `${startMinutes}px`,
                             height: `${height}px`,
-                            opacity: isDark ? 0.5 : 0.92,
+                            opacity: isDark ? 0.68 : 0.92,
                             width,
                             left,
                             zIndex: column + 1,
@@ -700,7 +700,19 @@ export default function WeekView({
 
                          <div className={cn("absolute left-0 top-0 w-1 h-full rounded-l-md")} style={{ backgroundColor: getDarkerColorClass(event.color) }} />
                           <div className="pl-1">
-                          <div className="font-medium truncate" style={{ color: getDarkerColorClass(event.color) }}>{event.title}</div>
+                          <div
+                            className="font-medium leading-tight break-words"
+                            style={{
+                              color: getDarkerColorClass(event.color),
+                              display: "-webkit-box",
+                              WebkitBoxOrient: "vertical",
+                              WebkitLineClamp: Math.max(1, Math.floor((height - 8) / 16)),
+                              overflow: "hidden",
+                              textOverflow: "ellipsis",
+                            }}
+                          >
+                            {event.title}
+                          </div>
                           {height >= 40 && (
                             <div className="text-xs truncate" style={{ color: getDarkerColorClass(event.color) }}>
                               {formatDateWithTimezone(start)} - {formatDateWithTimezone(end)}


### PR DESCRIPTION
### Motivation
- Improve visual consistency of the sidebar calendar card by increasing the outer border radius. 
- Make event items in dark mode more readable by increasing their opacity for better contrast. 
- Allow event titles to wrap to multiple lines when there is enough vertical space, and clamp with an ellipsis when space is limited, and standardize the right-side sheet UI for a cohesive appearance.

### Description
- Changed the left sidebar mini-calendar outer card from `rounded-md` to `rounded-lg` in `components/sidebar/Sidebar.tsx`.
- Unified dark-mode event opacity to `0.68` in `components/view/DayView.tsx`, `components/view/WeekView.tsx`, and `components/view/MonthView.tsx`.
- Reworked event title rendering in `DayView` and `WeekView` to use a multi-line, WebKit-clamp-based layout that computes an approximate line clamp from the event card height and falls back to a single-line truncation when space is tight (`display: -webkit-box`, `WebkitLineClamp`, `overflow: hidden`, `textOverflow: ellipsis`).
- Standardized right-side sheets (Mini Calendar, Bookmarks, Countdown) by aligning widths and header structure and adding a small calendar icon to the Mini Calendar sheet; changes in `components/sidebar/MiniCalendarSheet.tsx`, `components/sidebar/BookmarkPanel.tsx`, and `components/sidebar/Countdown.tsx` set `SheetContent` to `side="right"` with `className="w-[360px] sm:w-[420px] p-0"` and normalized header markup.

### Testing
- Attempted to build the app with `npm run build`, but the build failed in this environment because the `next` binary / dependencies are not available (`sh: 1: next: not found`).
- Attempted to take a UI screenshot via Playwright against `http://127.0.0.1:3000`, but no local dev server was reachable resulting in `ERR_EMPTY_RESPONSE`.
- All changes are limited to UI rendering logic and component class/inline-style updates; no automated unit tests were present or executed in this environment.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6986c90e3158833285a6821cff02810d)