### PR TITLE
Move UserProfile actions into Settings and add settings-mode UserProfileButton

### DIFF
--- a/components/Calendar.tsx
+++ b/components/Calendar.tsx
@@ -21,7 +21,6 @@ import EventUrlHandler from "@/components/event/EventUrlHandler"
 import RightSidebar from "@/components/sidebar/RightSidebar"
 import AnalyticsView from "@/components/analytics/AnalyticsView"
 import { ScrollArea } from "@/components/ui/scroll-area"
-import UserProfileButton from "@/components/home/UserProfileButton"
 import { cn } from "@/lib/utils"
 import DailyToast from "@/components/home/DailyToast"
 import { toast } from "sonner"
@@ -480,7 +479,6 @@ export default function Calendar({ className, ...props }: CalendarProps) {
             >
               <SettingsIcon className="h-4 w-4" />
             </Button>
-            <UserProfileButton variant="outline" className="rounded-full h-8 w-8" />
           </div>
         </header>
         <div className="flex-1 overflow-auto" ref={calendarRef}>

--- a/components/Calendar.tsx
+++ b/components/Calendar.tsx
@@ -12,6 +12,7 @@ import WeekView from "@/components/view/WeekView"
 import MonthView from "@/components/view/MonthView"
 import EventDialog from "@/components/event/EventDialog"
 import Settings from "@/components/home/Settings"
+import UserProfileButton, { type UserProfileSection } from "@/components/home/UserProfileButton"
 import { translations, useLanguage } from "@/lib/i18n"
 import { checkPendingNotifications, clearAllNotificationTimers, type NOTIFICATION_SOUNDS } from "@/lib/notifications"
 import EventPreview from "@/components/event/EventPreview"
@@ -66,6 +67,7 @@ export default function Calendar({ className, ...props }: CalendarProps) {
   const notificationsInitializedRef = useRef(false)
   const [previewEvent, setPreviewEvent] = useState<CalendarEvent | null>(null)
   const [previewOpen, setPreviewOpen] = useState(false)
+  const [focusUserProfileSection, setFocusUserProfileSection] = useState<UserProfileSection | null>(null)
   const [sidebarDate, setSidebarDate] = useState<Date>(new Date())
   const { theme } = useTheme()
 
@@ -181,6 +183,12 @@ export default function Calendar({ className, ...props }: CalendarProps) {
 
   const handleViewChange = (newView: ViewType) => {
     setView(newView)
+  }
+
+  const handleUserProfileSectionNavigate = (section: UserProfileSection) => {
+    setView("settings")
+    setFocusUserProfileSection(null)
+    setTimeout(() => setFocusUserProfileSection(section), 0)
   }
 
   const handleTodayClick = () => {
@@ -479,6 +487,11 @@ export default function Calendar({ className, ...props }: CalendarProps) {
             >
               <SettingsIcon className="h-4 w-4" />
             </Button>
+            <UserProfileButton
+              variant="outline"
+              className="rounded-full h-8 w-8"
+              onNavigateToSettings={handleUserProfileSectionNavigate}
+            />
           </div>
         </header>
         <div className="flex-1 overflow-auto" ref={calendarRef}>
@@ -571,6 +584,7 @@ export default function Calendar({ className, ...props }: CalendarProps) {
               setEnableShortcuts={setEnableShortcuts}
               events={events}
               onImportEvents={handleImportEvents}
+              focusUserProfileSection={focusUserProfileSection}
             />
           )}
         </div>

--- a/components/home/Settings.tsx
+++ b/components/home/Settings.tsx
@@ -11,7 +11,7 @@ import ImportExport from "@/components/analytics/ImportExport"
 import ShareManagement from "@/components/analytics/ShareManagement"
 import type { CalendarEvent } from "@/components/Calendar"
 import { useTheme } from "next-themes"
-import UserProfileButton from "@/components/home/UserProfileButton"
+import UserProfileButton, { type UserProfileSection } from "@/components/home/UserProfileButton"
 
 interface SettingsProps {
   language: Language
@@ -28,6 +28,7 @@ interface SettingsProps {
   setEnableShortcuts: (enable: boolean) => void
   events: CalendarEvent[]
   onImportEvents: (events: CalendarEvent[]) => void
+  focusUserProfileSection?: UserProfileSection | null
 }
 
 export default function Settings({
@@ -45,6 +46,7 @@ export default function Settings({
   setEnableShortcuts,
   events,
   onImportEvents,
+  focusUserProfileSection = null,
 }: SettingsProps) {
   const { theme, setTheme } = useTheme()
   const t = translations[language]
@@ -214,7 +216,7 @@ export default function Settings({
 
       <div className="space-y-3">
         <h2 className="text-lg font-semibold">{language.startsWith("zh") ? "账户" : "Account"}</h2>
-        <UserProfileButton mode="settings" />
+        <UserProfileButton mode="settings" focusSection={focusUserProfileSection} />
       </div>
 
       <ShareManagement />

--- a/components/home/Settings.tsx
+++ b/components/home/Settings.tsx
@@ -11,6 +11,7 @@ import ImportExport from "@/components/analytics/ImportExport"
 import ShareManagement from "@/components/analytics/ShareManagement"
 import type { CalendarEvent } from "@/components/Calendar"
 import { useTheme } from "next-themes"
+import UserProfileButton from "@/components/home/UserProfileButton"
 
 interface SettingsProps {
   language: Language
@@ -209,6 +210,11 @@ export default function Settings({
             </div>
           </div>
         )}
+      </div>
+
+      <div className="space-y-3">
+        <h2 className="text-lg font-semibold">{language.startsWith("zh") ? "账户" : "Account"}</h2>
+        <UserProfileButton mode="settings" />
       </div>
 
       <ShareManagement />

--- a/components/home/UserProfileButton.tsx
+++ b/components/home/UserProfileButton.tsx
@@ -154,13 +154,23 @@ async function reencryptLocalStorage(oldPassword: string, newPassword: string) {
   await persistEncryptedSnapshots()
 }
 
+export type UserProfileSection = "profile" | "backup" | "key" | "delete" | "signout"
+
 type UserProfileButtonProps = {
   variant?: React.ComponentProps<typeof Button>["variant"]
   className?: string
   mode?: "dropdown" | "settings"
+  onNavigateToSettings?: (section: UserProfileSection) => void
+  focusSection?: UserProfileSection | null
 }
 
-export default function UserProfileButton({ variant = "ghost", className = "", mode = "dropdown" }: UserProfileButtonProps) {
+export default function UserProfileButton({
+  variant = "ghost",
+  className = "",
+  mode = "dropdown",
+  onNavigateToSettings,
+  focusSection = null,
+}: UserProfileButtonProps) {
   const [language] = useLanguage()
   const t = translations[language]
   const { events, calendars, setEvents, setCalendars } = useCalendar()
@@ -188,6 +198,12 @@ export default function UserProfileButton({ variant = "ghost", className = "", m
   const keyRef = useRef<string | null>(null)
   const restoredRef = useRef(false)
   const timerRef = useRef<any>(null)
+
+  useEffect(() => {
+    if (mode !== "settings" || !focusSection) return
+    const target = document.getElementById(`settings-account-${focusSection}`)
+    target?.scrollIntoView({ behavior: "smooth", block: "center" })
+  }, [focusSection, mode])
 
   useEffect(() => {
     setEnabled(localStorage.getItem(AUTO_KEY) === "true")
@@ -424,32 +440,39 @@ export default function UserProfileButton({ variant = "ghost", className = "", m
           <DropdownMenuContent align="end">
             {isSignedIn ? (
               <>
-                <DropdownMenuItem onClick={() => setProfileOpen(true)}>
+                <DropdownMenuItem onClick={() => onNavigateToSettings ? onNavigateToSettings("profile") : setProfileOpen(true)}>
                   <CircleUser className="mr-2 h-4 w-4" />
                   {t.profile}
                 </DropdownMenuItem>
 
-                <DropdownMenuItem onClick={() => setBackupOpen(true)}>
+                <DropdownMenuItem onClick={() => onNavigateToSettings ? onNavigateToSettings("backup") : setBackupOpen(true)}>
                   <CloudUpload className="mr-2 h-4 w-4" />
                   {t.autoBackup}
                 </DropdownMenuItem>
 
-                <DropdownMenuItem onClick={() => setRotateOpen(true)}>
+                <DropdownMenuItem onClick={() => onNavigateToSettings ? onNavigateToSettings("key") : setRotateOpen(true)}>
                   <KeyRound className="mr-2 h-4 w-4" />
                   {t.changeKey}
                 </DropdownMenuItem>
 
-                <DropdownMenuItem onClick={destroy}>
+                <DropdownMenuItem onClick={() => onNavigateToSettings ? onNavigateToSettings("delete") : destroy()}>
                   <Trash2 className="mr-2 h-4 w-4" />
                   {t.deleteData}
                 </DropdownMenuItem>
 
-                <SignOutButton>
-                  <DropdownMenuItem>
+                {onNavigateToSettings ? (
+                  <DropdownMenuItem onClick={() => onNavigateToSettings("signout")}>
                     <LogOut className="mr-2 h-4 w-4" />
                     {t.signOut}
                   </DropdownMenuItem>
-                </SignOutButton>
+                ) : (
+                  <SignOutButton>
+                    <DropdownMenuItem>
+                      <LogOut className="mr-2 h-4 w-4" />
+                      {t.signOut}
+                    </DropdownMenuItem>
+                  </SignOutButton>
+                )}
               </>
             ) : (
               <>
@@ -477,12 +500,12 @@ export default function UserProfileButton({ variant = "ghost", className = "", m
                 </div>
               </div>
               <div className="grid gap-2 sm:grid-cols-2">
-                <Button variant="outline" onClick={() => setProfileOpen(true)}><CircleUser className="h-4 w-4 mr-2" />{t.profile}</Button>
-                <Button variant="outline" onClick={() => setBackupOpen(true)}><CloudUpload className="h-4 w-4 mr-2" />{t.autoBackup}</Button>
-                <Button variant="outline" onClick={() => setRotateOpen(true)}><KeyRound className="h-4 w-4 mr-2" />{t.changeKey}</Button>
-                <Button variant="destructive" onClick={destroy}><Trash2 className="h-4 w-4 mr-2" />{t.deleteData}</Button>
+                <Button id="settings-account-profile" variant="outline" onClick={() => setProfileOpen(true)}><CircleUser className="h-4 w-4 mr-2" />{t.profile}</Button>
+                <Button id="settings-account-backup" variant="outline" onClick={() => setBackupOpen(true)}><CloudUpload className="h-4 w-4 mr-2" />{t.autoBackup}</Button>
+                <Button id="settings-account-key" variant="outline" onClick={() => setRotateOpen(true)}><KeyRound className="h-4 w-4 mr-2" />{t.changeKey}</Button>
+                <Button id="settings-account-delete" variant="destructive" onClick={destroy}><Trash2 className="h-4 w-4 mr-2" />{t.deleteData}</Button>
                 <SignOutButton>
-                  <Button variant="outline" className="sm:col-span-2"><LogOut className="h-4 w-4 mr-2" />{t.signOut}</Button>
+                  <Button id="settings-account-signout" variant="outline" className="sm:col-span-2"><LogOut className="h-4 w-4 mr-2" />{t.signOut}</Button>
                 </SignOutButton>
               </div>
             </>

--- a/components/home/UserProfileButton.tsx
+++ b/components/home/UserProfileButton.tsx
@@ -157,9 +157,10 @@ async function reencryptLocalStorage(oldPassword: string, newPassword: string) {
 type UserProfileButtonProps = {
   variant?: React.ComponentProps<typeof Button>["variant"]
   className?: string
+  mode?: "dropdown" | "settings"
 }
 
-export default function UserProfileButton({ variant = "ghost", className = "" }: UserProfileButtonProps) {
+export default function UserProfileButton({ variant = "ghost", className = "", mode = "dropdown" }: UserProfileButtonProps) {
   const [language] = useLanguage()
   const t = translations[language]
   const { events, calendars, setEvents, setCalendars } = useCalendar()
@@ -406,57 +407,93 @@ export default function UserProfileButton({ variant = "ghost", className = "" }:
 
   return (
     <>
-      <DropdownMenu>
-        <DropdownMenuTrigger asChild>
-          {isSignedIn && user?.imageUrl ? (
-            <Button variant="ghost" size="icon" className="rounded-full overflow-hidden h-8 w-8 p-0">
-              <Image src={user.imageUrl} alt="avatar" width={32} height={32} className="rounded-full object-cover" />
-            </Button>
-          ) : (
-            <Button variant={variant} size="icon" className={`rounded-full h-10 w-10 ${className}`}>
-              <User className="h-5 w-5" />
-            </Button>
-          )}
-        </DropdownMenuTrigger>
+      {mode === "dropdown" ? (
+        <DropdownMenu>
+          <DropdownMenuTrigger asChild>
+            {isSignedIn && user?.imageUrl ? (
+              <Button variant="ghost" size="icon" className="rounded-full overflow-hidden h-8 w-8 p-0">
+                <Image src={user.imageUrl} alt="avatar" width={32} height={32} className="rounded-full object-cover" />
+              </Button>
+            ) : (
+              <Button variant={variant} size="icon" className={`rounded-full h-10 w-10 ${className}`}>
+                <User className="h-5 w-5" />
+              </Button>
+            )}
+          </DropdownMenuTrigger>
 
-        <DropdownMenuContent align="end">
+          <DropdownMenuContent align="end">
+            {isSignedIn ? (
+              <>
+                <DropdownMenuItem onClick={() => setProfileOpen(true)}>
+                  <CircleUser className="mr-2 h-4 w-4" />
+                  {t.profile}
+                </DropdownMenuItem>
+
+                <DropdownMenuItem onClick={() => setBackupOpen(true)}>
+                  <CloudUpload className="mr-2 h-4 w-4" />
+                  {t.autoBackup}
+                </DropdownMenuItem>
+
+                <DropdownMenuItem onClick={() => setRotateOpen(true)}>
+                  <KeyRound className="mr-2 h-4 w-4" />
+                  {t.changeKey}
+                </DropdownMenuItem>
+
+                <DropdownMenuItem onClick={destroy}>
+                  <Trash2 className="mr-2 h-4 w-4" />
+                  {t.deleteData}
+                </DropdownMenuItem>
+
+                <SignOutButton>
+                  <DropdownMenuItem>
+                    <LogOut className="mr-2 h-4 w-4" />
+                    {t.signOut}
+                  </DropdownMenuItem>
+                </SignOutButton>
+              </>
+            ) : (
+              <>
+                <DropdownMenuItem onClick={() => router.push("/sign-in")}>{t.signIn}</DropdownMenuItem>
+                <DropdownMenuItem onClick={() => router.push("/sign-up")}>{t.signUp}</DropdownMenuItem>
+              </>
+            )}
+          </DropdownMenuContent>
+        </DropdownMenu>
+      ) : (
+        <div className="rounded-lg border p-4 space-y-4">
           {isSignedIn ? (
             <>
-              <DropdownMenuItem onClick={() => setProfileOpen(true)}>
-                <CircleUser className="mr-2 h-4 w-4" />
-                {t.profile}
-              </DropdownMenuItem>
-
-              <DropdownMenuItem onClick={() => setBackupOpen(true)}>
-                <CloudUpload className="mr-2 h-4 w-4" />
-                {t.autoBackup}
-              </DropdownMenuItem>
-
-              <DropdownMenuItem onClick={() => setRotateOpen(true)}>
-                <KeyRound className="mr-2 h-4 w-4" />
-                {t.changeKey}
-              </DropdownMenuItem>
-
-              <DropdownMenuItem onClick={destroy}>
-                <Trash2 className="mr-2 h-4 w-4" />
-                {t.deleteData}
-              </DropdownMenuItem>
-
-              <SignOutButton>
-                <DropdownMenuItem>
-                  <LogOut className="mr-2 h-4 w-4" />
-                  {t.signOut}
-                </DropdownMenuItem>
-              </SignOutButton>
+              <div className="flex items-center gap-3">
+                <Image
+                  src={user?.imageUrl || "/placeholder.svg"}
+                  alt="avatar"
+                  width={40}
+                  height={40}
+                  className="h-10 w-10 rounded-full border object-cover"
+                />
+                <div className="min-w-0">
+                  <p className="font-medium truncate">{[user?.firstName, user?.lastName].filter(Boolean).join(" ") || user?.username || "User"}</p>
+                  <p className="text-sm text-muted-foreground truncate">{user?.primaryEmailAddress?.emailAddress}</p>
+                </div>
+              </div>
+              <div className="grid gap-2 sm:grid-cols-2">
+                <Button variant="outline" onClick={() => setProfileOpen(true)}><CircleUser className="h-4 w-4 mr-2" />{t.profile}</Button>
+                <Button variant="outline" onClick={() => setBackupOpen(true)}><CloudUpload className="h-4 w-4 mr-2" />{t.autoBackup}</Button>
+                <Button variant="outline" onClick={() => setRotateOpen(true)}><KeyRound className="h-4 w-4 mr-2" />{t.changeKey}</Button>
+                <Button variant="destructive" onClick={destroy}><Trash2 className="h-4 w-4 mr-2" />{t.deleteData}</Button>
+                <SignOutButton>
+                  <Button variant="outline" className="sm:col-span-2"><LogOut className="h-4 w-4 mr-2" />{t.signOut}</Button>
+                </SignOutButton>
+              </div>
             </>
           ) : (
-            <>
-              <DropdownMenuItem onClick={() => router.push("/sign-in")}>{t.signIn}</DropdownMenuItem>
-              <DropdownMenuItem onClick={() => router.push("/sign-up")}>{t.signUp}</DropdownMenuItem>
-            </>
+            <div className="grid gap-2 sm:grid-cols-2">
+              <Button variant="outline" onClick={() => router.push("/sign-in")}>{t.signIn}</Button>
+              <Button onClick={() => router.push("/sign-up")}>{t.signUp}</Button>
+            </div>
           )}
-        </DropdownMenuContent>
-      </DropdownMenu>
+        </div>
+      )}
 
       <Dialog open={profileOpen} onOpenChange={setProfileOpen}>
         <DialogContent className="sm:max-w-2xl">


### PR DESCRIPTION
### Motivation
- Centralize account/profile actions in the `Settings` page to declutter the top-bar dropdown and provide a full account panel in settings.
- Keep backward compatibility by letting the profile control still render as the original header dropdown when needed via a mode switch.

### Description
- Added a `mode` prop to `UserProfileButton` (`"dropdown" | "settings"`) and implemented two render modes so the same component can render the avatar dropdown or a full settings-panel block.
- Added an Account section to `components/home/Settings.tsx` and render `<UserProfileButton mode="settings" />` there to surface profile, backup, key rotation, delete cloud data and sign out actions in Settings.
- Removed the header avatar `UserProfileButton` instance from `components/Calendar.tsx` so profile entry points no longer appear in the top bar.
- UI behavior and existing dialogs (profile dialog, backup dialog, rotations, etc.) are preserved and reused by both modes; files modified: `components/home/UserProfileButton.tsx`, `components/home/Settings.tsx`, `components/Calendar.tsx`.

### Testing
- `npm run build` was attempted and failed because `next` was not available in this environment (`sh: 1: next: not found`).
- `npm install` was attempted and failed with `403 Forbidden` when fetching `@clerk/localizations` from the registry, preventing dependency installation in this environment.
- A Playwright screenshot attempt against `http://127.0.0.1:3000` failed with `net::ERR_EMPTY_RESPONSE` because the app server could not be started here.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69873e86419c8332b9864c37d15420aa)