### PR TITLE
Avoid unlock prompt when navigating to Settings via UserProfileButton and wire header UPB to Settings sections

### DIFF
--- a/components/Calendar.tsx
+++ b/components/Calendar.tsx
@@ -12,6 +12,7 @@ import WeekView from "@/components/view/WeekView"
 import MonthView from "@/components/view/MonthView"
 import EventDialog from "@/components/event/EventDialog"
 import Settings from "@/components/home/Settings"
+import UserProfileButton, { type UserProfileSection } from "@/components/home/UserProfileButton"
 import { translations, useLanguage } from "@/lib/i18n"
 import { checkPendingNotifications, clearAllNotificationTimers, type NOTIFICATION_SOUNDS } from "@/lib/notifications"
 import EventPreview from "@/components/event/EventPreview"
@@ -21,7 +22,6 @@ import EventUrlHandler from "@/components/event/EventUrlHandler"
 import RightSidebar from "@/components/sidebar/RightSidebar"
 import AnalyticsView from "@/components/analytics/AnalyticsView"
 import { ScrollArea } from "@/components/ui/scroll-area"
-import UserProfileButton from "@/components/home/UserProfileButton"
 import { cn } from "@/lib/utils"
 import DailyToast from "@/components/home/DailyToast"
 import { toast } from "sonner"
@@ -67,6 +67,7 @@ export default function Calendar({ className, ...props }: CalendarProps) {
   const notificationsInitializedRef = useRef(false)
   const [previewEvent, setPreviewEvent] = useState<CalendarEvent | null>(null)
   const [previewOpen, setPreviewOpen] = useState(false)
+  const [focusUserProfileSection, setFocusUserProfileSection] = useState<UserProfileSection | null>(null)
   const [sidebarDate, setSidebarDate] = useState<Date>(new Date())
   const { theme } = useTheme()
 
@@ -182,6 +183,12 @@ export default function Calendar({ className, ...props }: CalendarProps) {
 
   const handleViewChange = (newView: ViewType) => {
     setView(newView)
+  }
+
+  const handleUserProfileSectionNavigate = (section: UserProfileSection) => {
+    setView("settings")
+    setFocusUserProfileSection(null)
+    setTimeout(() => setFocusUserProfileSection(section), 0)
   }
 
   const handleTodayClick = () => {
@@ -480,7 +487,11 @@ export default function Calendar({ className, ...props }: CalendarProps) {
             >
               <SettingsIcon className="h-4 w-4" />
             </Button>
-            <UserProfileButton variant="outline" className="rounded-full h-8 w-8" />
+            <UserProfileButton
+              variant="outline"
+              className="rounded-full h-8 w-8"
+              onNavigateToSettings={handleUserProfileSectionNavigate}
+            />
           </div>
         </header>
         <div className="flex-1 overflow-auto" ref={calendarRef}>
@@ -573,6 +584,7 @@ export default function Calendar({ className, ...props }: CalendarProps) {
               setEnableShortcuts={setEnableShortcuts}
               events={events}
               onImportEvents={handleImportEvents}
+              focusUserProfileSection={focusUserProfileSection}
             />
           )}
         </div>

--- a/components/home/Settings.tsx
+++ b/components/home/Settings.tsx
@@ -11,6 +11,7 @@ import ImportExport from "@/components/analytics/ImportExport"
 import ShareManagement from "@/components/analytics/ShareManagement"
 import type { CalendarEvent } from "@/components/Calendar"
 import { useTheme } from "next-themes"
+import UserProfileButton, { type UserProfileSection } from "@/components/home/UserProfileButton"
 
 interface SettingsProps {
   language: Language
@@ -27,6 +28,7 @@ interface SettingsProps {
   setEnableShortcuts: (enable: boolean) => void
   events: CalendarEvent[]
   onImportEvents: (events: CalendarEvent[]) => void
+  focusUserProfileSection?: UserProfileSection | null
 }
 
 export default function Settings({
@@ -44,6 +46,7 @@ export default function Settings({
   setEnableShortcuts,
   events,
   onImportEvents,
+  focusUserProfileSection = null,
 }: SettingsProps) {
   const { theme, setTheme } = useTheme()
   const t = translations[language]
@@ -209,6 +212,11 @@ export default function Settings({
             </div>
           </div>
         )}
+      </div>
+
+      <div className="space-y-3">
+        <h2 className="text-lg font-semibold">{language.startsWith("zh") ? "账户" : "Account"}</h2>
+        <UserProfileButton mode="settings" focusSection={focusUserProfileSection} />
       </div>
 
       <ShareManagement />


### PR DESCRIPTION
### Motivation
- Prevent the unwanted password unlock prompt that appeared when clicking a `UserProfileButton` dropdown item which navigated the app into `Settings` while the unlock-check effect still ran. 
- Reuse the top-bar `UserProfileButton` as a navigation entry into specific account sections inside `Settings` so header menu items focus the corresponding settings controls.

### Description
- Added `UserProfileSection` type and new `UserProfileButton` props: `mode`, `onNavigateToSettings`, and `focusSection` to let the component either open dialogs (dropdown) or navigate/scroll to settings sections (`settings` mode). 
- Changed the unlock-check effect in `components/home/UserProfileButton.tsx` to skip when `mode === "settings"` and added `mode` to the effect dependencies so the unlock prompt is not triggered during settings navigation. 
- Added a scrolling effect in `UserProfileButton` that scrolls to `settings-account-<section>` when `focusSection` is provided. 
- Updated `components/Calendar.tsx` to render `UserProfileButton` with `onNavigateToSettings` and a new `focusUserProfileSection` state so header clicks switch the view to `settings` and focus the right account section. 
- Updated `components/home/Settings.tsx` to include `UserProfileButton` in `settings` mode, accept `focusUserProfileSection`, and kept anchor IDs (`settings-account-profile`, `settings-account-backup`, `settings-account-key`, `settings-account-delete`, `settings-account-signout`) so navigation can focus the matching control. 
- Reworked `UserProfileButton` rendering to show a dropdown when `mode === "dropdown"` and a full account block with buttons and anchor IDs when `mode === "settings"`; dropdown menu items call `onNavigateToSettings(section)` when provided and fall back to the original dialog behavior.

### Testing
- Ran `npm run build`, which failed in this environment because the `next` binary is not available (`sh: 1: next: not found`). No other automated test suite was available to run here.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69873e86419c8332b9864c37d15420aa)