### PR TITLE
feat: add sonner toasts + confirm/undo for event delete and account deletion cleanup

### DIFF
--- a/app/api/account/route.ts
+++ b/app/api/account/route.ts
@@ -1,0 +1,53 @@
+import { NextResponse } from "next/server"
+import { currentUser } from "@clerk/nextjs/server"
+import { Pool } from "pg"
+
+export const runtime = "nodejs"
+
+const pool = new Pool({
+  connectionString: process.env.POSTGRES_URL,
+  ssl: { rejectUnauthorized: false },
+})
+
+export async function DELETE() {
+  try {
+    const user = await currentUser()
+    if (!user) return NextResponse.json({ error: "Unauthorized" }, { status: 401 })
+
+    const client = await pool.connect()
+    try {
+      await client.query("BEGIN")
+
+      const hasCalendarEventsTable = await client.query(
+        `SELECT 1 FROM information_schema.tables WHERE table_schema = 'public' AND table_name = 'calendar_events' LIMIT 1`,
+      )
+      if (hasCalendarEventsTable.rowCount) {
+        await client.query(`DELETE FROM calendar_events WHERE user_id = $1`, [user.id])
+      }
+
+      const hasSharesTable = await client.query(
+        `SELECT 1 FROM information_schema.tables WHERE table_schema = 'public' AND table_name = 'shares' LIMIT 1`,
+      )
+      if (hasSharesTable.rowCount) {
+        await client.query(`DELETE FROM shares WHERE user_id = $1`, [user.id])
+      }
+
+      const hasBackupsTable = await client.query(
+        `SELECT 1 FROM information_schema.tables WHERE table_schema = 'public' AND table_name = 'calendar_backups' LIMIT 1`,
+      )
+      if (hasBackupsTable.rowCount) {
+        await client.query(`DELETE FROM calendar_backups WHERE user_id = $1`, [user.id])
+      }
+
+      await client.query("COMMIT")
+      return NextResponse.json({ success: true })
+    } catch (error) {
+      await client.query("ROLLBACK")
+      throw error
+    } finally {
+      client.release()
+    }
+  } catch (e: any) {
+    return NextResponse.json({ error: e?.message || "Internal error" }, { status: 500 })
+  }
+}


### PR DESCRIPTION
### Motivation

- Improve UX around destructive actions by adding confirmations and immediate feedback (toasts) for event create/update/delete flows.  
- Provide an Undo path after event deletion so users can quickly recover mistakes.  
- Allow users to delete their account and ensure server-side cleanup of user-scoped data (`calendar_events`, `shares`, backups) to respect data removal requests.

### Description

- Added Sonner feedback for event creation and update in `components/Calendar.tsx` via `toast(...)` with localized (zh/en) messages.  
- Reworked event deletion to show an `AlertDialog` confirmation before deleting, and emit a Sonner toast that includes an `Undo` action which restores the deleted event when clicked (`components/Calendar.tsx`).  
- Added account deletion UI in profile dropdown and settings with an `AlertDialog` confirmation and a loading state, calling a server cleanup endpoint and then deleting the Clerk user (`components/home/UserProfileButton.tsx`).  
- Created `DELETE /api/account` endpoint at `app/api/account/route.ts` which runs in a transaction and defensively deletes rows for the current user from `calendar_events`, `shares`, and `calendar_backups` only if those tables exist (to avoid runtime errors in environments where some tables are optional).  

### Testing

- Attempted to install and build the app with `bun install`, `bun build` and `bun run build`, but dependency registry access in this environment returned `403` and `next` was not available, so full compile/runtime checks could not be completed.  
- Attempted a Playwright navigation/screenshot to `http://127.0.0.1:3000`, but the app was not started in this runner (`ERR_EMPTY_RESPONSE`), so UI-run validation failed.  
- Performed targeted code inspection (searches and file diffs) to verify the new UI hooks, toast usage, and server-side SQL logic; these logical checks passed in-review.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69887d1ff2c083328ccaf86e62572b9b)

## Summary by Sourcery

在日历事件生命周期与账号删除流程中增加面向用户的确认提示和吐司通知，并新增一个在账号移除时清理用户数据的后端端点。

新功能：
- 为日历事件创建和更新显示本地化的吐司通知。
- 添加带有确认对话框和可通过吐司操作恢复的“可撤销事件删除”流程。
- 在个人资料下拉菜单和设置中新增删除用户账号的 UI 流程，包含确认和加载状态。
- 暴露 `DELETE /api/account` 端点，以事务方式删除与用户相关的日历事件、共享和备份数据。

增强：
- 通过基于 `AlertDialog` 的统一确认对话框，为事件和账号删除等破坏性操作改进用户体验。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Add user-facing confirmations and toast notifications around calendar event lifecycle and account deletion, and introduce a backend endpoint to clean up user data on account removal.

New Features:
- Show localized toast notifications for calendar event creation and update.
- Add an undoable event deletion flow with confirmation dialog and restoration via toast action.
- Introduce UI flows in the profile dropdown and settings to delete the user account with confirmation and loading state.
- Expose a DELETE /api/account endpoint to delete user-scoped calendar events, shares, and backup data in a transactional manner.

Enhancements:
- Improve destructive action UX with consistent AlertDialog-based confirmations for event and account deletion.

</details>