### PR TITLE
fix: 修复日历分类在暗色模式下颜色不显示

### DIFF
--- a/components/sidebar/Sidebar.tsx
+++ b/components/sidebar/Sidebar.tsx
@@ -33,6 +33,18 @@ export interface CalendarCategory {
   keywords?: string[]
 }
 
+const CALENDAR_COLOR_MAP: Record<string, string> = {
+  "bg-blue-500": "#3b82f6",
+  "bg-green-500": "#22c55e",
+  "bg-purple-500": "#a855f7",
+  "bg-yellow-500": "#eab308",
+  "bg-red-500": "#ef4444",
+  "bg-pink-500": "#ec4899",
+  "bg-indigo-500": "#6366f1",
+  "bg-orange-500": "#f97316",
+  "bg-teal-500": "#14b8a6",
+}
+
 export default function Sidebar({
   onCreateEvent,
   onDateSelect,
@@ -143,10 +155,10 @@ export default function Sidebar({
                 <Checkbox
                   checked={selectedCategoryFilters.includes(calendar.id)}
                   onCheckedChange={(checked) => onCategoryFilterChange?.(calendar.id, checked === true)}
-                  className={cn(
-                    "h-4 w-4 rounded-md border data-[state=checked]:text-white",
-                    calendar.color,
-                  )}
+                  className="h-4 w-4 rounded-md border-0 data-[state=checked]:text-white"
+                  style={{
+                    backgroundColor: CALENDAR_COLOR_MAP[calendar.color] ?? "#3b82f6",
+                  }}
                 />
                 <span className="text-sm">{calendar.name}</span>
               </div>


### PR DESCRIPTION
### Motivation
- 修复 Linear issue WEB-27：侧边栏中的日历分类在暗色模式下颜色不可见的问题，原因是运行时使用动态 Tailwind 类（例如 `bg-blue-500`）在构建/暗色主题下可能无法被静态提取或应用。 

### Description
- 在 `components/sidebar/Sidebar.tsx` 新增 `CALENDAR_COLOR_MAP`，将常用 Tailwind 背景类名映射为稳定的十六进制颜色值。 
- 将分类筛选的 `Checkbox` 从依赖动态 Tailwind 类名改为通过 `style.backgroundColor` 设置颜色并移除默认边框以确保暗色模式下可见。 
- 保留原有的选择逻辑和勾选态样式，只有渲染颜色的实现方式做出调整以避免 Tailwind 动态类提取问题。 

### Testing
- 运行 `bun install` 以安装依赖但因对 npm registry 的访问返回 `403` 而失败，无法验证依赖安装。 
- 运行 `bun run build` 以执行 `next build` 但因依赖未安装且 `next` 不可用而失败。 
- 使用 Playwright 尝试访问 `http://localhost:3000` 并截屏以验证 UI 改动但因本地服务未能启动返回 `net::ERR_EMPTY_RESPONSE` 而失败。

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_698924756b988332af7b6ced7b3ec222)

## Summary by Sourcery

错误修复：
- 通过使用明确的十六进制颜色样式替代动态的 Tailwind 类，修复了侧边栏中日历类别复选框在深色模式下不显示其颜色的问题。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Bug Fixes:
- Fix calendar category checkboxes in the sidebar not showing their colors in dark mode by using explicit hex color styles instead of dynamic Tailwind classes.

</details>