### PR TITLE
fix: remove Analytics option from Settings default view selector

### DIFF
--- a/components/home/Settings.tsx
+++ b/components/home/Settings.tsx
@@ -171,7 +171,6 @@ export default function Settings({
               <SelectItem value="day">{t.day}</SelectItem>
               <SelectItem value="week">{t.week}</SelectItem>
               <SelectItem value="month">{t.month}</SelectItem>
-              <SelectItem value="analytics">{t.analytics}</SelectItem>
             </SelectContent>
           </Select>
         </div>


### PR DESCRIPTION
### Motivation
- Remove the `Analytics` option from the Settings → `Default View` selector to match requested behavior so users can only choose `Day` / `Week` / `Month`.

### Description
- Deleted the `<SelectItem value="analytics">{t.analytics}</SelectItem>` entry in `components/home/Settings.tsx` and committed the change as `4594272`.

### Testing
- Ran a web lookup with `curl` which was blocked by the environment (HTTP 403). 
- Executed `bun run build` which failed because `next` is not available in the environment (`next: command not found`).
- Attempted a Playwright screenshot of `http://localhost:3000` which failed because the local app was not running (`net::ERR_EMPTY_RESPONSE`).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69892599a79c833299b94d2a22b852d4)

## Summary by Sourcery

Bug Fixes:
- 防止用户在“设置”默认视图选择器中选择已弃用的 Analytics 选项。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Bug Fixes:
- Prevent users from selecting the deprecated Analytics option in the Settings default view selector.

</details>