### PR TITLE
WEB-30: Remove dark-mode event transparency and update dark event palette

### DIFF
--- a/components/view/DayView.tsx
+++ b/components/view/DayView.tsx
@@ -100,6 +100,22 @@ export default function DayView({
     return colorMapping[color] || '#3A3A3A';
   }
 
+  function getEventBackgroundColor(color: string) {
+    if (!isDark) return undefined
+
+    const darkModeColorMapping: Record<string, string> = {
+      'bg-[#E6F6FD]': '#2F4655',
+      'bg-[#E7F8F2]': '#2D4935',
+      'bg-[#FEF5E6]': '#4F3F1B',
+      'bg-[#FFE4E6]': '#6C2920',
+      'bg-[#F3EEFE]': '#483A63',
+      'bg-[#FCE7F3]': '#5A334A',
+      'bg-[#E6FAF7]': '#1F4A47',
+    }
+
+    return darkModeColorMapping[color]
+  }
+
   // 判断事件是否为全天事件
   const isAllDayEvent = (event: CalendarEvent) => {
     if (event.isAllDay) return true
@@ -402,7 +418,8 @@ export default function DayView({
               position: "absolute",
               left: "0",
               right: "0",
-              opacity: isDark ? 0.68 : 0.9,
+              opacity: isDark ? 1 : 0.9,
+              backgroundColor: getEventBackgroundColor(event.color),
               zIndex: 10 + index,
             }}
             onMouseDown={(e) => handleEventDragStart(event, e)}
@@ -584,7 +601,8 @@ export default function DayView({
                     style={{
                       top: `${startMinutes}px`,
                       height: `${height}px`,
-                      opacity: isDark ? 0.68 : 0.9,
+                      opacity: isDark ? 1 : 0.9,
+                      backgroundColor: getEventBackgroundColor(event.color),
                       width,
                       left,
                       zIndex: column + 1,

--- a/components/view/MonthView.tsx
+++ b/components/view/MonthView.tsx
@@ -31,6 +31,20 @@ function getDarkerColorClass(color: string) {
   return colorMapping[color] || '#3A3A3A';
 }
 
+function getDarkModeEventBackgroundColor(color: string) {
+  const darkModeColorMapping: Record<string, string> = {
+    'bg-[#E6F6FD]': '#2F4655',
+    'bg-[#E7F8F2]': '#2D4935',
+    'bg-[#FEF5E6]': '#4F3F1B',
+    'bg-[#FFE4E6]': '#6C2920',
+    'bg-[#F3EEFE]': '#483A63',
+    'bg-[#FCE7F3]': '#5A334A',
+    'bg-[#E6FAF7]': '#1F4A47',
+  }
+
+  return darkModeColorMapping[color]
+}
+
 export default function MonthView({ date, events, onEventClick, language, firstDayOfWeek, timezone }: MonthViewProps) {
   const t = translations[language]
   const monthStart = startOfMonth(date)
@@ -89,7 +103,10 @@ export default function MonthView({ date, events, onEventClick, language, firstD
                   key={event.id}
                   className={cn("relative text-xs truncate rounded-md p-1 cursor-pointer text-white", event.color)}
                   onClick={() => onEventClick(event)}
-                  style={{ opacity: isDark ? 0.68 : 1 }}
+                  style={{
+                    opacity: 1,
+                    backgroundColor: isDark ? getDarkModeEventBackgroundColor(event.color) : undefined,
+                  }}
                 >
                   <div className={cn("absolute left-0 top-0 w-1 h-full rounded-l-md")} style={{ backgroundColor: getDarkerColorClass(event.color) }} />
                   <div className="pl-1.5" style={{ color: getDarkerColorClass(event.color) }}>{event.title}</div>

--- a/components/view/WeekView.tsx
+++ b/components/view/WeekView.tsx
@@ -101,6 +101,22 @@ export default function WeekView({
     return colorMapping[color] || '#3A3A3A';
   }
 
+  function getEventBackgroundColor(color: string) {
+    if (!isDark) return undefined
+
+    const darkModeColorMapping: Record<string, string> = {
+      'bg-[#E6F6FD]': '#2F4655',
+      'bg-[#E7F8F2]': '#2D4935',
+      'bg-[#FEF5E6]': '#4F3F1B',
+      'bg-[#FFE4E6]': '#6C2920',
+      'bg-[#F3EEFE]': '#483A63',
+      'bg-[#FCE7F3]': '#5A334A',
+      'bg-[#E6FAF7]': '#1F4A47',
+    }
+
+    return darkModeColorMapping[color]
+  }
+
   // 修改自动滚动到当前时间的效果,只在组件挂载时执行一次
   useEffect(() => {
     // 只在组件挂载时执行一次滚动
@@ -512,7 +528,8 @@ export default function WeekView({
               position: "absolute",
               left: "0",
               right: "0",
-              opacity: isDark ? 0.68 : 0.9,
+              opacity: isDark ? 1 : 0.9,
+              backgroundColor: getEventBackgroundColor(event.color),
               zIndex: 10 + index,
             }}
             onMouseDown={(e) => handleEventDragStart(event, e)}
@@ -682,7 +699,8 @@ export default function WeekView({
                           style={{
                             top: `${startMinutes}px`,
                             height: `${height}px`,
-                            opacity: isDark ? 0.68 : 0.92,
+                            opacity: isDark ? 1 : 0.92,
+                            backgroundColor: getEventBackgroundColor(event.color),
                             width,
                             left,
                             zIndex: column + 1,


### PR DESCRIPTION
### Motivation
- Make calendar event cards appear solid in dark mode (remove reduced transparency) so colors read clearly against dark backgrounds.
- Apply the requested dark-mode light-color mappings so each event uses a stable, legible fill in dark theme, including adding Teal and Pink mappings.

### Description
- Added dark-mode background mappings and helper functions (`getEventBackgroundColor` / `getDarkModeEventBackgroundColor`) in `DayView`, `WeekView` and `MonthView` to map light event classes to explicit dark fills.
- Replaced reduced opacity in dark mode with full opacity and set `backgroundColor` from the new dark-mode mapping for event cards and all-day event rows in the three views.
- Updated dark-mode color mappings to the requested hex values: Red `#6C2920`, Yellow `#4F3F1B`, Green `#2D4935`, Blue `#2F4655`, Purple `#483A63`, and added Teal `#1F4A47` and Pink `#5A334A`.
- Files changed: `components/view/DayView.tsx`, `components/view/WeekView.tsx`, `components/view/MonthView.tsx`.

### Testing
- Ran project build with `npm run -s build`, which failed because `next` is not available in the environment (not related to the code changes). 
- Ran TypeScript check with `npx tsc --noEmit`, which reported many module/type resolution errors because project dependencies/types are not installed in this environment and are unrelated to these changes. 
- Attempted an automated UI screenshot via Playwright against a local dev server, which failed with `net::ERR_EMPTY_RESPONSE` because the local server was not running in this environment.
- All code changes were committed locally and a PR was created; runtime/visual verification requires running the app with project dependencies installed and the dev server up to observe the dark-mode fills.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69893a1227948332803346706134b4f3)