### PR TITLE
feat: 将日历分类颜色统一为 7 个深色并同步新建日程默认色

### DIFF
--- a/components/event/EventDialog.tsx
+++ b/components/event/EventDialog.tsx
@@ -17,16 +17,16 @@ import { useCalendar } from "@/components/context/CalendarContext"
 import { ArrowRight, Calendar as CalendarIcon, Clock } from "lucide-react"
 
 const colorOptions = [
-  { value: "bg-[#E6F6FD]", label: "Blue" },
-  { value: "bg-[#E7F8F2]", label: "Green" },
-  { value: "bg-[#FEF5E6]", label: "Amber" },
-  { value: "bg-[#FFE4E6]", label: "Red" },
-  { value: "bg-[#F3EEFE]", label: "Purple" },
-  { value: "bg-[#FCE7F3]", label: "Pink" },
-  // { value: "bg-[#EEF2FF]", label: "Indigo" },
-  // { value: "bg-[#FFF0E5]", label: "Orange" },
-  { value: "bg-[#E6FAF7]", label: "Teal" },
+  { value: "bg-[#E6F6FD]", label: "Blue", calendarColor: "bg-blue-500" },
+  { value: "bg-[#E7F8F2]", label: "Green", calendarColor: "bg-green-500" },
+  { value: "bg-[#FEF5E6]", label: "Amber", calendarColor: "bg-yellow-500" },
+  { value: "bg-[#FFE4E6]", label: "Red", calendarColor: "bg-red-500" },
+  { value: "bg-[#F3EEFE]", label: "Purple", calendarColor: "bg-purple-500" },
+  { value: "bg-[#FCE7F3]", label: "Pink", calendarColor: "bg-pink-500" },
+  { value: "bg-[#E6FAF7]", label: "Teal", calendarColor: "bg-teal-500" },
 ]
+
+const calendarColorToEventColor = Object.fromEntries(colorOptions.map((option) => [option.calendarColor, option.value]))
 
 const colorMapping: Record<string, string> = {
   'bg-[#E6F6FD]': '#3B82F6',
@@ -35,8 +35,6 @@ const colorMapping: Record<string, string> = {
   'bg-[#FFE4E6]': '#EF4444',
   'bg-[#F3EEFE]': '#8B5CF6',
   'bg-[#FCE7F3]': '#EC4899',
-  'bg-[#EEF2FF]': '#6366F1',
-  'bg-[#FFF0E5]': '#FB923C',
   'bg-[#E6FAF7]': '#14B8A6',
 }
 
@@ -129,6 +127,12 @@ export default function EventDialog({
   const t = translations[language]
   const isZh = isZhLanguage(language)
   const calendarSelectValue = selectedCalendar || (calendars.length > 0 ? "__uncategorized__" : "")
+  const getEventColorByCalendarId = (calendarId: string) => {
+    const calendar = calendars.find((item) => item.id === calendarId)
+    if (!calendar) return colorOptions[0].value
+    return calendarColorToEventColor[calendar.color] ?? colorOptions[0].value
+  }
+
 
   // 合并日期和时间
   const combineDateTime = (date: Date, timeInput: TimeInput): Date => {
@@ -259,6 +263,9 @@ export default function EventDialog({
         resetForm()
         if (initialDate) {
           setStartDate(initialDate)
+          if (calendars.length > 0) {
+            setColor(getEventColorByCalendarId(calendars[0].id))
+          }
           setEndDate(initialDate)
           
           const initialHour = getHours(initialDate);
@@ -741,7 +748,15 @@ export default function EventDialog({
 
           <div>
             <Label htmlFor="calendar">{t.calendar}</Label>
-            <Select value={calendarSelectValue} onValueChange={setSelectedCalendar}>
+            <Select
+              value={calendarSelectValue}
+              onValueChange={(value) => {
+                setSelectedCalendar(value)
+                if (value !== "__uncategorized__") {
+                  setColor(getEventColorByCalendarId(value))
+                }
+              }}
+            >
               <SelectTrigger>
                 <SelectValue placeholder={t.selectCalendar} />
               </SelectTrigger>

--- a/components/sidebar/Sidebar.tsx
+++ b/components/sidebar/Sidebar.tsx
@@ -33,17 +33,17 @@ export interface CalendarCategory {
   keywords?: string[]
 }
 
-const CALENDAR_COLOR_MAP: Record<string, string> = {
-  "bg-blue-500": "#3b82f6",
-  "bg-green-500": "#22c55e",
-  "bg-purple-500": "#a855f7",
-  "bg-yellow-500": "#eab308",
-  "bg-red-500": "#ef4444",
-  "bg-pink-500": "#ec4899",
-  "bg-indigo-500": "#6366f1",
-  "bg-orange-500": "#f97316",
-  "bg-teal-500": "#14b8a6",
-}
+const CALENDAR_COLOR_OPTIONS = [
+  { value: "bg-blue-500", hex: "#3b82f6" },
+  { value: "bg-green-500", hex: "#10b981" },
+  { value: "bg-yellow-500", hex: "#f59e0b" },
+  { value: "bg-red-500", hex: "#ef4444" },
+  { value: "bg-purple-500", hex: "#8b5cf6" },
+  { value: "bg-pink-500", hex: "#ec4899" },
+  { value: "bg-teal-500", hex: "#14b8a6" },
+]
+
+const CALENDAR_COLOR_MAP = Object.fromEntries(CALENDAR_COLOR_OPTIONS.map((option) => [option.value, option.hex]))
 
 export default function Sidebar({
   onCreateEvent,
@@ -240,24 +240,15 @@ export default function Sidebar({
             <div className="space-y-2">
               <Label>{t.color}</Label>
               <div className="flex flex-wrap gap-2">
-                {[
-                  "blue-500",
-                  "green-500",
-                  "purple-500",
-                  "yellow-500",
-                  "red-500",
-                  "pink-500",
-                  "indigo-500",
-                  "orange-500",
-                  "teal-500",
-                ].map((color) => (
+                {CALENDAR_COLOR_OPTIONS.map((option) => (
                   <div
-                    key={color}
+                    key={option.value}
                     className={cn(
-                      `bg-${color} w-6 h-6 rounded-full cursor-pointer`,
-                      newCategoryColor === `bg-${color}` ? "ring-2 ring-offset-2 ring-black" : "",
+                      option.value,
+                      "w-6 h-6 rounded-full cursor-pointer",
+                      newCategoryColor === option.value ? "ring-2 ring-offset-2 ring-black" : "",
                     )}
-                    onClick={() => setNewCategoryColor(`bg-${color}`)}
+                    onClick={() => setNewCategoryColor(option.value)}
                   />
                 ))}
               </div>


### PR DESCRIPTION
### Motivation
- 统一日历分类与事件使用相同的深色调（7 种）以保持视觉一致性并减少颜色重复。 
- 创建日历分类时复用相同颜色配置以避免分类色与事件色体系不一致。 
- 新建日程时应默认使用所选日历分类对应的事件颜色，同时仍允许用户在颜色下拉中手动覆盖。 

### Description
- 在 `components/sidebar/Sidebar.tsx` 中将分类颜色数据替换为 `CALENDAR_COLOR_OPTIONS`（7 个深色项）并生成 `CALENDAR_COLOR_MAP` 用于渲染复选框颜色。 
- 在 `components/sidebar/Sidebar.tsx` 的“创建分类”弹窗中复用 `CALENDAR_COLOR_OPTIONS`，并改为使用 `option.value`（如 `bg-blue-500`）作为颜色值，移除额外的 indigo/orange 选项。 
- 在 `components/event/EventDialog.tsx` 中为事件颜色增加与日历分类颜色的映射 `calendarColorToEventColor`，并新增 `getEventColorByCalendarId` 帮助函数用于根据分类 id 获取默认事件颜色。 
- 新建日程（非编辑）场景下如果存在日历分类，会将默认事件颜色设置为首个分类对应的事件颜色；选择/切换日历分类时会自动将事件颜色更新为该分类的映射颜色，但用户仍可通过颜色下拉修改。 

### Testing
- 尝试运行 `npm run build` 以构建项目，但失败，错误为 `next: not found`，当前环境缺少构建依赖。 
- 尝试运行 `npm install` 以安装依赖但失败，npm registry 返回 403 导致无法安装依赖并完成构建验证。 
- 由于依赖安装/构建受限，未能在运行时进一步验证 UI 行为，代码变更已保存到上述文件以便在有正常 dev 环境下进行完整验证。

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69893e304f788332a68f2f39c2dfe532)