### PR TITLE
fix: prevent long EventPreview title/description overflow

### DIFF
--- a/components/event/EventPreview.tsx
+++ b/components/event/EventPreview.tsx
@@ -429,7 +429,16 @@ export default function EventPreview({
 />
 
           <div className="flex-1">
-            <h2 className="text-2xl font-bold mb-1">{event.title}</h2>
+            <h2
+              className="mb-1 text-2xl font-bold break-words overflow-hidden"
+              style={{
+                display: "-webkit-box",
+                WebkitLineClamp: 2,
+                WebkitBoxOrient: "vertical",
+              }}
+            >
+              {event.title}
+            </h2>
             <p className="text-muted-foreground">{formatDateRange()}</p>
           </div>
         </div>
@@ -498,7 +507,16 @@ export default function EventPreview({
             <div className="flex items-start">
               <AlignLeft className="h-5 w-5 mr-3 mt-0.5 text-muted-foreground" />
               <div className="flex-1">
-                <p className="whitespace-pre-wrap">{event.description}</p>
+                <p
+                  className="whitespace-pre-wrap break-words overflow-hidden"
+                  style={{
+                    display: "-webkit-box",
+                    WebkitLineClamp: 4,
+                    WebkitBoxOrient: "vertical",
+                  }}
+                >
+                  {event.description}
+                </p>
               </div>
             </div>
           )}

--- a/components/event/EventPreview.tsx
+++ b/components/event/EventPreview.tsx
@@ -430,7 +430,7 @@ export default function EventPreview({
 
           <div className="flex-1">
             <h2
-              className="mb-1 text-2xl font-bold break-words overflow-hidden"
+              className="mb-1 text-2xl font-bold break-words break-all overflow-hidden [overflow-wrap:anywhere]"
               style={{
                 display: "-webkit-box",
                 WebkitLineClamp: 2,
@@ -508,7 +508,7 @@ export default function EventPreview({
               <AlignLeft className="h-5 w-5 mr-3 mt-0.5 text-muted-foreground" />
               <div className="flex-1">
                 <p
-                  className="whitespace-pre-wrap break-words overflow-hidden"
+                  className="whitespace-pre-wrap break-words break-all overflow-hidden [overflow-wrap:anywhere]"
                   style={{
                     display: "-webkit-box",
                     WebkitLineClamp: 4,


### PR DESCRIPTION
### Motivation
- Prevent the EventPreview modal from being stretched or overflowing when event `title` or `description` contain very long words or many lines while keeping existing multiline semantics for descriptions.

### Description
- Modify `components/event/EventPreview.tsx` so the title uses `break-words overflow-hidden` and a CSS line-clamp (`-webkit-line-clamp: 2`) to wrap and limit to 2 lines, and the description keeps `whitespace-pre-wrap` while adding `break-words overflow-hidden` and a `-webkit-line-clamp: 4` to limit to 4 lines.

### Testing
- Attempted automated checks: `bun install` failed due to npm registry 403 responses so dependencies could not be installed, `bun run build` failed because the `next` binary/dependencies are not available in this environment, and a Playwright screenshot attempt failed because the local dev server was not reachable, therefore no build/site verification completed here.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_698942aaf0a0833282d01b62ba7c6e49)

## Summary by Sourcery

在 EventPreview 模态框中约束过长的事件标题和描述，防止布局溢出和垂直方向过度拉伸。

Bug 修复：
- 防止过长或不可断行的事件标题导致溢出并拉伸 EventPreview 布局。
- 防止过长或多行事件描述在保持换行的同时发生溢出。

增强：
- 在 EventPreview 模态框中，将事件标题限制为最多两行可见文本，将事件描述限制为最多四行可见文本，超出部分进行截断显示。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Constrain long event titles and descriptions in the EventPreview modal to prevent layout overflow and excessive vertical stretching.

Bug Fixes:
- Prevent long or unbroken event titles from overflowing and stretching the EventPreview layout.
- Prevent long or highly multiline event descriptions from overflowing while preserving line breaks.

Enhancements:
- Limit event titles to two visible lines and descriptions to four lines with truncation in the EventPreview modal.

</details>