### PR TITLE
feat(settings): add build info card (version, commit, deploy age)

### DIFF
--- a/components/analytics/BuildInfoCard.tsx
+++ b/components/analytics/BuildInfoCard.tsx
@@ -1,0 +1,73 @@
+"use client"
+
+import { useEffect, useMemo, useState } from "react"
+import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card"
+import type { Language } from "@/lib/i18n"
+
+const APP_VERSION = process.env.NEXT_PUBLIC_APP_VERSION ?? "unknown"
+const COMMIT_HASH = process.env.NEXT_PUBLIC_GIT_COMMIT ?? "unknown"
+const DEPLOYED_AT = process.env.NEXT_PUBLIC_BUILD_TIME ?? ""
+
+const formatTimeAgo = (language: Language, deployedAt: string) => {
+  const deployedDate = new Date(deployedAt)
+  if (Number.isNaN(deployedDate.getTime())) {
+    return language === "zh-CN" ? "未知" : "Unknown"
+  }
+
+  const diffMs = Date.now() - deployedDate.getTime()
+  const diffMinutes = Math.max(1, Math.floor(diffMs / 60000))
+
+  if (diffMinutes < 60) {
+    return language === "zh-CN" ? `${diffMinutes} 分钟` : `${diffMinutes} minutes`
+  }
+
+  const diffHours = Math.floor(diffMinutes / 60)
+  if (diffHours < 24) {
+    return language === "zh-CN" ? `${diffHours} 小时` : `${diffHours} hours`
+  }
+
+  const diffDays = Math.floor(diffHours / 24)
+  return language === "zh-CN" ? `${diffDays} 天` : `${diffDays} days`
+}
+
+interface BuildInfoCardProps {
+  language: Language
+}
+
+export default function BuildInfoCard({ language }: BuildInfoCardProps) {
+  const [tick, setTick] = useState(0)
+
+  useEffect(() => {
+    const timer = window.setInterval(() => {
+      setTick((value) => value + 1)
+    }, 60000)
+
+    return () => {
+      window.clearInterval(timer)
+    }
+  }, [])
+
+  const deployedAgo = useMemo(() => formatTimeAgo(language, DEPLOYED_AT), [language, tick])
+
+  return (
+    <Card>
+      <CardHeader>
+        <CardTitle>{language === "zh-CN" ? "版本信息" : "Build Information"}</CardTitle>
+      </CardHeader>
+      <CardContent className="space-y-3 text-sm">
+        <div className="flex items-center justify-between gap-4">
+          <span className="text-muted-foreground">{language === "zh-CN" ? "版本号" : "Version"}</span>
+          <span className="font-mono">{APP_VERSION}</span>
+        </div>
+        <div className="flex items-center justify-between gap-4">
+          <span className="text-muted-foreground">{language === "zh-CN" ? "提交号" : "Commit"}</span>
+          <span className="font-mono">{COMMIT_HASH}</span>
+        </div>
+        <div className="flex items-center justify-between gap-4">
+          <span className="text-muted-foreground">{language === "zh-CN" ? "部署时间" : "Deployment"}</span>
+          <span>{language === "zh-CN" ? `${deployedAgo}前部署` : `Deployed ${deployedAgo} ago`}</span>
+        </div>
+      </CardContent>
+    </Card>
+  )
+}

--- a/components/home/Settings.tsx
+++ b/components/home/Settings.tsx
@@ -9,6 +9,7 @@ import { Switch } from "@/components/ui/switch"
 import { Kbd } from "@/components/ui/kbd"
 import ImportExport from "@/components/analytics/ImportExport"
 import ShareManagement from "@/components/analytics/ShareManagement"
+import BuildInfoCard from "@/components/analytics/BuildInfoCard"
 import type { CalendarEvent } from "@/components/Calendar"
 import { useTheme } from "next-themes"
 import UserProfileButton, { type UserProfileSection } from "@/components/home/UserProfileButton"
@@ -220,6 +221,7 @@ export default function Settings({
 
       <ShareManagement />
       <ImportExport events={events} onImportEvents={onImportEvents} />
+      <BuildInfoCard language={language} />
     </div>
   )
 }

--- a/next.config.mjs
+++ b/next.config.mjs
@@ -1,8 +1,21 @@
+import { execSync } from "node:child_process"
+import { readFileSync } from "node:fs"
+
 let userConfig = undefined
 try {
-  userConfig = await import('./next.config')
+  userConfig = await import("./next.config")
 } catch (e) {
 
+}
+
+const packageJson = JSON.parse(readFileSync(new URL("./package.json", import.meta.url), "utf8"))
+
+const getGitCommit = () => {
+  try {
+    return execSync("git rev-parse --short HEAD", { encoding: "utf8" }).trim()
+  } catch {
+    return "unknown"
+  }
 }
 
 /** @type {import('next').NextConfig} */
@@ -12,7 +25,12 @@ const nextConfig = {
   },
   images: {
     unoptimized: true,
-  }
+  },
+  env: {
+    NEXT_PUBLIC_APP_VERSION: packageJson.version,
+    NEXT_PUBLIC_GIT_COMMIT: getGitCommit(),
+    NEXT_PUBLIC_BUILD_TIME: new Date().toISOString(),
+  },
  /* experimental: {
     webpackBuildWorker: true,
     parallelServerBuildTraces: true,
@@ -30,7 +48,7 @@ function mergeConfig(nextConfig, userConfig) {
 
   for (const key in userConfig) {
     if (
-      typeof nextConfig[key] === 'object' &&
+      typeof nextConfig[key] === "object" &&
       !Array.isArray(nextConfig[key])
     ) {
       nextConfig[key] = {


### PR DESCRIPTION
### Motivation
- Provide obvious build metadata in Settings so users can see the app `version`, the deployed `commit` short hash and how long ago the site was deployed.
- Surface this data under the existing Import & Export card to assist debugging and release identification from the UI.

### Description
- Add a new component `components/analytics/BuildInfoCard.tsx` that reads `NEXT_PUBLIC_APP_VERSION`, `NEXT_PUBLIC_GIT_COMMIT` and `NEXT_PUBLIC_BUILD_TIME` and renders version, commit and a relative deploy-age string that refreshes every minute.
- Import and render `BuildInfoCard` in `components/home/Settings.tsx` below the `ImportExport` card so it appears in the Settings page.
- Update `next.config.mjs` to expose build-time env vars by reading `package.json` and attempting to run `git rev-parse --short HEAD`, and set `NEXT_PUBLIC_APP_VERSION`, `NEXT_PUBLIC_GIT_COMMIT`, and `NEXT_PUBLIC_BUILD_TIME` for frontend consumption.

### Testing
- Attempted `npm run build`, which failed with `next: not found` because dependencies were not installed in the environment.
- Attempted `bun run build`, which also failed with `next: not found` for the same reason.
- Attempted `npm install`, which failed with a `403 Forbidden` error from the npm registry when fetching `@clerk/localizations`, preventing a full build in this environment.
- Attempted a Playwright screenshot to validate the running app, which failed with `ERR_EMPTY_RESPONSE` because the app server was not running; no UI screenshot could be captured.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_698963df4f048332bcc2a7be4f63c18b)