### PR TITLE
feat: 增加 12/24 小时制切换并同步日/周视图时间线

### DIFF
--- a/components/Calendar.tsx
+++ b/components/Calendar.tsx
@@ -117,6 +117,7 @@ export default function Calendar({ className, ...props }: CalendarProps) {
   // Add the new state variables for default view and keyboard shortcuts
   const [defaultView, setDefaultView] = useLocalStorage<ViewType>("default-view", "week")
   const [enableShortcuts, setEnableShortcuts] = useLocalStorage<boolean>("enable-shortcuts", true)
+  const [timeFormat, setTimeFormat] = useLocalStorage<"24h" | "12h">("time-format", "24h")
 
   // Add a useEffect to set the initial view based on the default view setting
   useEffect(() => {
@@ -584,6 +585,7 @@ export default function Calendar({ className, ...props }: CalendarProps) {
               onTimeSlotClick={handleTimeSlotClick}
               language={language}
               timezone={timezone}
+              timeFormat={timeFormat}
               onEditEvent={handleEventEdit}
               onDeleteEvent={(event) => handleEventDelete(event.id)}
               onShareEvent={(event) => {
@@ -611,6 +613,7 @@ export default function Calendar({ className, ...props }: CalendarProps) {
               language={language}
               firstDayOfWeek={firstDayOfWeek}
               timezone={timezone}
+              timeFormat={timeFormat}
               onEditEvent={handleEventEdit}
               onDeleteEvent={(event) => handleEventDelete(event.id)}
               onShareEvent={(event) => {
@@ -663,6 +666,8 @@ export default function Calendar({ className, ...props }: CalendarProps) {
               setDefaultView={setDefaultView}
               enableShortcuts={enableShortcuts}
               setEnableShortcuts={setEnableShortcuts}
+              timeFormat={timeFormat}
+              setTimeFormat={setTimeFormat}
               events={events}
               onImportEvents={handleImportEvents}
               focusUserProfileSection={focusUserProfileSection}

--- a/components/home/Settings.tsx
+++ b/components/home/Settings.tsx
@@ -27,6 +27,8 @@ interface SettingsProps {
   setDefaultView: (view: string) => void
   enableShortcuts: boolean
   setEnableShortcuts: (enable: boolean) => void
+  timeFormat: "24h" | "12h"
+  setTimeFormat: (format: "24h" | "12h") => void
   events: CalendarEvent[]
   onImportEvents: (events: CalendarEvent[]) => void
   focusUserProfileSection?: UserProfileSection | null
@@ -45,6 +47,8 @@ export default function Settings({
   setDefaultView,
   enableShortcuts,
   setEnableShortcuts,
+  timeFormat,
+  setTimeFormat,
   events,
   onImportEvents,
   focusUserProfileSection = null,
@@ -188,6 +192,19 @@ export default function Settings({
                   {tz.label}
                 </SelectItem>
               ))}
+            </SelectContent>
+          </Select>
+        </div>
+
+        <div className="space-y-2">
+          <Label htmlFor="time-format">{t.timeFormat}</Label>
+          <Select value={timeFormat} onValueChange={(value: "24h" | "12h") => setTimeFormat(value)}>
+            <SelectTrigger id="time-format">
+              <SelectValue />
+            </SelectTrigger>
+            <SelectContent>
+              <SelectItem value="24h">{t.timeFormat24h}</SelectItem>
+              <SelectItem value="12h">{language.startsWith("zh") ? "12 小时制（下午 1 点）" : t.timeFormat12h}</SelectItem>
             </SelectContent>
           </Select>
         </div>

--- a/components/view/WeekView.tsx
+++ b/components/view/WeekView.tsx
@@ -22,6 +22,7 @@ interface WeekViewProps {
   language: Language
   firstDayOfWeek: number
   timezone: string
+  timeFormat: "24h" | "12h"
   onEditEvent?: (event: CalendarEvent) => void
   onDeleteEvent?: (event: CalendarEvent) => void
   onShareEvent?: (event: CalendarEvent) => void
@@ -46,6 +47,7 @@ export default function WeekView({
   language,
   firstDayOfWeek,
   timezone,
+  timeFormat,
   onEditEvent,
   onDeleteEvent,
   onShareEvent,
@@ -230,15 +232,28 @@ export default function WeekView({
   }, [draggingEvent, dragStartPosition, dragPreview, onEventDrop, weekDays, dragEventDuration]);
 
   const formatTime = (hour: number) => {
-    // 使用24小时制格式化时间
+    if (timeFormat === "12h") {
+      const period = hour >= 12 ? "PM" : "AM"
+      const twelveHour = hour % 12 || 12
+      return `${twelveHour} ${period}`
+    }
     return `${hour.toString().padStart(2, "0")}:00`
+  }
+
+  const formatHourMinute = (hour: number, minute: number) => {
+    if (timeFormat === "12h") {
+      const period = hour >= 12 ? "PM" : "AM"
+      const twelveHour = hour % 12 || 12
+      return `${twelveHour}:${minute.toString().padStart(2, "0")} ${period}`
+    }
+    return `${hour.toString().padStart(2, "0")}:${minute.toString().padStart(2, "0")}`
   }
 
   const formatDateWithTimezone = (date: Date) => {
     const options: Intl.DateTimeFormatOptions = {
       hour: "2-digit",
       minute: "2-digit",
-      hour12: false, // 使用24小时制
+      hour12: timeFormat === "12h",
       timeZone: timezone,
     }
     return new Intl.DateTimeFormat(isZh ? "zh-CN" : "en-US", options).format(date)
@@ -605,7 +620,7 @@ export default function WeekView({
           <div className="font-medium truncate" style={{ color: getDarkerColorClass(draggingEvent.color) }}>{draggingEvent.title}</div>
           {dragEventDuration >= 40 && (
             <div className="text-xs text-white/90 truncate">
-              {formatTime(dragPreview.hour)}:{dragPreview.minute.toString().padStart(2, '0')} - {formatTime(Math.floor(endMinutes / 60))}:{(endMinutes % 60).toString().padStart(2, '0')}
+              {formatHourMinute(dragPreview.hour, dragPreview.minute)} - {formatHourMinute(Math.floor(endMinutes / 60), endMinutes % 60)}
             </div>
           )}
         </div>
@@ -768,19 +783,9 @@ export default function WeekView({
 
               {isSameDay(day, today) &&
                 (() => {
-                  // 获取当前时区的时间
-                  const timeOptions: Intl.DateTimeFormatOptions = {
-                    hour: "2-digit",
-                    minute: "2-digit",
-                    hour12: false,
-                    timeZone: timezone,
-                  }
-
-                  // 获取小时和分钟
-                  const timeString = new Intl.DateTimeFormat("en-US", timeOptions).format(currentTime)
-                  const [hoursStr, minutesStr] = timeString.split(":")
-                  const currentHours = Number.parseInt(hoursStr, 10)
-                  const currentMinutes = Number.parseInt(minutesStr, 10)
+                  const currentTimeInTimezone = new Date(currentTime.toLocaleString("en-US", { timeZone: timezone }))
+                  const currentHours = currentTimeInTimezone.getHours()
+                  const currentMinutes = currentTimeInTimezone.getMinutes()
 
                   // 计算像素位置
                   const topPosition = currentHours * 60 + currentMinutes

--- a/locales/en.json
+++ b/locales/en.json
@@ -334,5 +334,8 @@
   "categoryAdded": "Category added",
   "categoryAddedDesc": "Successfully added",
   "category": "category",
-  "untitledInParentheses": "(Untitled)"
+  "untitledInParentheses": "(Untitled)",
+  "timeFormat": "Time Format",
+  "timeFormat24h": "24-hour (13:00)",
+  "timeFormat12h": "12-hour (1 PM)"
 }

--- a/locales/zh-CN.json
+++ b/locales/zh-CN.json
@@ -334,5 +334,8 @@
   "categoryAdded": "分类已添加",
   "categoryAddedDesc": "已成功添加",
   "category": "分类",
-  "untitledInParentheses": "（无标题）"
+  "untitledInParentheses": "（无标题）",
+  "timeFormat": "时间制",
+  "timeFormat24h": "24 小时制（13:00）",
+  "timeFormat12h": "12 小时制（1 PM）"
 }


### PR DESCRIPTION
### Motivation
- 提供设置项让用户在 24 小时制与 12 小时制之间切换，并使周视图/日视图左侧时间线及事件时间文本随之切换。
- 避免在 12 小时制下通过字符串格式解析当前时间导致的时间线定位偏移问题。

### Description
- 在 `Settings` 中新增 `timeFormat` 下拉（`24h` / `12h`），并在 `Calendar` 中将 `time-format` 持久化到本地存储后透传给 `DayView` 与 `WeekView`（修改文件：`components/home/Settings.tsx`、`components/Calendar.tsx`）。
- 在 `DayView` 与 `WeekView` 中新增基于配置的格式化函数（`formatTime`、`formatHourMinute`），并将事件时间、拖拽预览时间和左侧时间标签改为支持 12h/24h 显示（修改文件：`components/view/DayView.tsx`、`components/view/WeekView.tsx`）。
- 修正当前时间指示器的时区处理逻辑，改为用 `new Date(currentTime.toLocaleString("en-US", { timeZone }))` 直接读取目标时区的小时和分钟来计算位置，避免格式化字符串解析带来的偏差（修改文件：`components/view/DayView.tsx`、`components/view/WeekView.tsx`）。
- 添加中英文文案键 `timeFormat`、`timeFormat24h`、`timeFormat12h` 到 `locales/en.json` 与 `locales/zh-CN.json`，并在设置中显示本地化文本（修改文件：`locales/en.json`、`locales/zh-CN.json`）。

### Testing
- Executed `npm run build` which failed because the `next` executable is not available in the environment (build did not run). 
- Executed `bun run build` which also failed because `next` is not available in the environment (build did not run). 
- Executed `npm install` which failed due to a 403 when fetching `@clerk/localizations` from the npm registry, preventing full dependency installation. 
- Attempted an automated Playwright screenshot against `http://127.0.0.1:3000` but the local dev server was not running and returned `ERR_EMPTY_RESPONSE`, so UI verification could not be completed.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69897b8988dc8332aef8bdc1473accfe)