### PR TITLE
Scope multi-theme to /app and migrate themeColor to viewport export

### DIFF
--- a/app/(app)/app/layout.tsx
+++ b/app/(app)/app/layout.tsx
@@ -9,5 +9,5 @@ export const viewport: Viewport = {
 }
 
 export default function AppPageLayout({ children }: { children: ReactNode }) {
-  return <>{children}</>
+  return <div className="app-theme-scope">{children}</div>
 }

--- a/app/(app)/app/layout.tsx
+++ b/app/(app)/app/layout.tsx
@@ -1,6 +1,5 @@
 import type { ReactNode } from "react"
 import type { Viewport } from "next"
-import { ThemeProvider } from "@/components/context/theme-provider"
 
 export const viewport: Viewport = {
   themeColor: [
@@ -10,15 +9,5 @@ export const viewport: Viewport = {
 }
 
 export default function AppPageLayout({ children }: { children: ReactNode }) {
-  return (
-    <ThemeProvider
-      themes={["light", "dark", "green", "orange", "azalea", "pink", "crimson"]}
-      attribute="class"
-      defaultTheme="system"
-      enableSystem
-      disableTransitionOnChange
-    >
-      {children}
-    </ThemeProvider>
-  )
+  return <>{children}</>
 }

--- a/app/(app)/app/layout.tsx
+++ b/app/(app)/app/layout.tsx
@@ -1,0 +1,24 @@
+import type { ReactNode } from "react"
+import type { Viewport } from "next"
+import { ThemeProvider } from "@/components/context/theme-provider"
+
+export const viewport: Viewport = {
+  themeColor: [
+    { media: "(prefers-color-scheme: light)", color: "#ffffff" },
+    { media: "(prefers-color-scheme: dark)", color: "#0a0a0a" },
+  ],
+}
+
+export default function AppPageLayout({ children }: { children: ReactNode }) {
+  return (
+    <ThemeProvider
+      themes={["light", "dark", "green", "orange", "azalea", "pink", "crimson"]}
+      attribute="class"
+      defaultTheme="system"
+      enableSystem
+      disableTransitionOnChange
+    >
+      {children}
+    </ThemeProvider>
+  )
+}

--- a/app/(app)/app/page.tsx
+++ b/app/(app)/app/page.tsx
@@ -1,29 +1,6 @@
 "use client"
-import { useEffect, useState } from "react";
 import Calendar from "@/components/Calendar";
 
 export default function Home() {
-  const [isMobile, setIsMobile] = useState(false);
-  const [isChinese, setIsChinese] = useState(false);
-
-  useEffect(() => {
-    const checkIfMobile = () => {
-      setIsMobile(window.innerWidth <= 768);
-    };
-    checkIfMobile();
-    window.addEventListener("resize", checkIfMobile);
-    return () => window.removeEventListener("resize", checkIfMobile);
-  }, []);
-  useEffect(() => {
-    const lang = navigator.language;
-    setIsChinese(lang.startsWith("zh"));
-  }, []);
-
-  {/*if (isMobile) {
-    return (
-      
-    )
-  }*/}
-
   return <Calendar />;
 }

--- a/app/globals.css
+++ b/app/globals.css
@@ -92,7 +92,7 @@ body {
     --sidebar-ring: 217.2 91.2% 59.8%;
   }
   
-.app.green {
+.green .app-theme-scope {
     --background: 142 35% 92%;
     --foreground: 140 20% 15%;
     --card: 142 30% 88%;
@@ -127,7 +127,7 @@ body {
     --sidebar-ring: 142 65% 40%;
 }
 
-.app.orange {
+.orange .app-theme-scope {
     --background: 28 50% 92%;
     --foreground: 20 24% 15%;
     --card: 28 45% 88%;
@@ -162,7 +162,7 @@ body {
     --sidebar-ring: 25 85% 48%;
 }
 
-.app.azalea {
+.azalea .app-theme-scope {
     --background: 331 25% 95%;
     --foreground: 331 15% 18%;
     --card: 331 20% 90%;
@@ -197,7 +197,7 @@ body {
     --sidebar-ring: 331 63% 49%;
 }
 
-.app.pink {
+.pink .app-theme-scope {
     --background: 7 60% 95%;
     --foreground: 7 25% 18%;
     --card: 7 50% 90%;
@@ -232,7 +232,7 @@ body {
     --sidebar-ring: 7 100% 82%;
 }
 
-.app.crimson {
+.crimson .app-theme-scope {
     --background: 341 25% 95%;
     --foreground: 341 15% 18%;
     --card: 341 20% 90%;
@@ -267,38 +267,38 @@ body {
     --sidebar-ring: 341 100% 30%;
 }
 
-.app.green button[variant="outline"],
-.app.orange button[variant="outline"],
-.app.azalea button[variant="outline"],
-.app.pink button[variant="outline"],
-.app.crimson button[variant="outline"] {
+.green .app-theme-scope button[variant="outline"],
+.orange .app-theme-scope button[variant="outline"],
+.azalea .app-theme-scope button[variant="outline"],
+.pink .app-theme-scope button[variant="outline"],
+.crimson .app-theme-scope button[variant="outline"] {
     border: 1px solid hsl(var(--border));
     background: transparent;
 }
 
-.app.green button[variant="ghost"],
-.app.orange button[variant="ghost"],
-.app.azalea button[variant="ghost"],
-.app.pink button[variant="ghost"],
-.app.crimson button[variant="ghost"] {
+.green .app-theme-scope button[variant="ghost"],
+.orange .app-theme-scope button[variant="ghost"],
+.azalea .app-theme-scope button[variant="ghost"],
+.pink .app-theme-scope button[variant="ghost"],
+.crimson .app-theme-scope button[variant="ghost"] {
     border: none;
     background: transparent;
 }
 
-.app.green hr, .app.green .divider,
-.app.orange hr, .app.orange .divider,
-.app.azalea hr, .app.azalea .divider,
-.app.pink hr, .app.pink .divider,
-.app.crimson hr, .app.crimson .divider {
+.green .app-theme-scope hr, .green .app-theme-scope .divider,
+.orange .app-theme-scope hr, .orange .app-theme-scope .divider,
+.azalea .app-theme-scope hr, .azalea .app-theme-scope .divider,
+.pink .app-theme-scope hr, .pink .app-theme-scope .divider,
+.crimson .app-theme-scope hr, .crimson .app-theme-scope .divider {
     border-color: hsl(var(--border));
     opacity: 0.8;
 }
 
-.app.green .separator,
-.app.orange .separator,
-.app.azalea .separator,
-.app.pink .separator,
-.app.crimson .separator {
+.green .app-theme-scope .separator,
+.orange .app-theme-scope .separator,
+.azalea .app-theme-scope .separator,
+.pink .app-theme-scope .separator,
+.crimson .app-theme-scope .separator {
     height: 1px;
     background: hsl(var(--border));
     opacity: 0.6;

--- a/app/globals.css
+++ b/app/globals.css
@@ -92,6 +92,7 @@ body {
     --sidebar-ring: 217.2 91.2% 59.8%;
   }
   
+.green,
 .green .app-theme-scope {
     --background: 142 35% 92%;
     --foreground: 140 20% 15%;
@@ -127,6 +128,7 @@ body {
     --sidebar-ring: 142 65% 40%;
 }
 
+.orange,
 .orange .app-theme-scope {
     --background: 28 50% 92%;
     --foreground: 20 24% 15%;
@@ -162,6 +164,7 @@ body {
     --sidebar-ring: 25 85% 48%;
 }
 
+.azalea,
 .azalea .app-theme-scope {
     --background: 331 25% 95%;
     --foreground: 331 15% 18%;
@@ -197,6 +200,7 @@ body {
     --sidebar-ring: 331 63% 49%;
 }
 
+.pink,
 .pink .app-theme-scope {
     --background: 7 60% 95%;
     --foreground: 7 25% 18%;
@@ -232,6 +236,7 @@ body {
     --sidebar-ring: 7 100% 82%;
 }
 
+.crimson,
 .crimson .app-theme-scope {
     --background: 341 25% 95%;
     --foreground: 341 15% 18%;

--- a/app/globals.css
+++ b/app/globals.css
@@ -272,6 +272,20 @@ body {
     --sidebar-ring: 341 100% 30%;
 }
 
+.green,
+.green .app-theme-scope,
+.orange,
+.orange .app-theme-scope,
+.azalea,
+.azalea .app-theme-scope,
+.pink,
+.pink .app-theme-scope,
+.crimson,
+.crimson .app-theme-scope {
+    --card: var(--background);
+    --popover: var(--background);
+}
+
 .green .app-theme-scope button[variant="outline"],
 .orange .app-theme-scope button[variant="outline"],
 .azalea .app-theme-scope button[variant="outline"],

--- a/app/globals.css
+++ b/app/globals.css
@@ -267,11 +267,11 @@ body {
     --sidebar-ring: 341 100% 30%;
 }
 
-.green button[variant="outline"],
-.orange button[variant="outline"],
-.azalea button[variant="outline"],
-.pink button[variant="outline"]
-.crimson button[variant="outline"]{
+.app.green button[variant="outline"],
+.app.orange button[variant="outline"],
+.app.azalea button[variant="outline"],
+.app.pink button[variant="outline"],
+.app.crimson button[variant="outline"] {
     border: 1px solid hsl(var(--border));
     background: transparent;
 }
@@ -285,11 +285,11 @@ body {
     background: transparent;
 }
 
-.app.green hr, .green .divider,
-.app.orange hr, .orange .divider,
-.app.azalea hr, .azalea .divider,
-.app.pink hr, .pink .divider,
-.app.crimson hr, .crimson .divider {
+.app.green hr, .app.green .divider,
+.app.orange hr, .app.orange .divider,
+.app.azalea hr, .app.azalea .divider,
+.app.pink hr, .app.pink .divider,
+.app.crimson hr, .app.crimson .divider {
     border-color: hsl(var(--border));
     opacity: 0.8;
 }

--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -58,7 +58,7 @@ export default function RootLayout({
         signUpUrl="/sign-up"
       >
         <ThemeProvider
-            themes={['light', 'dark']}
+            themes={['light', 'dark', 'green', 'orange', 'azalea', 'pink', 'crimson']}
             attribute="class"
             defaultTheme="system"
             enableSystem

--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -13,7 +13,6 @@ import { ThemeProvider } from "@/components/context/theme-provider"
 export const metadata: Metadata = {
   title: "One Calendar",
   description: "All your events in one place, beautifully organized.",
-  themeColor: "#0066ff",
   openGraph: {
     title: "One Calendar",
     description: "All your events in one place, beautifully organized.",
@@ -59,7 +58,7 @@ export default function RootLayout({
         signUpUrl="/sign-up"
       >
         <ThemeProvider
-            themes={['light', 'dark', 'blue', 'green']}
+            themes={['light', 'dark']}
             attribute="class"
             defaultTheme="system"
             enableSystem
@@ -77,4 +76,3 @@ export default function RootLayout({
     </html>
   )
 }
-

--- a/components/Calendar.tsx
+++ b/components/Calendar.tsx
@@ -1,6 +1,6 @@
 "use client"
 
-import { useState, useEffect, useRef, Suspense, useLayoutEffect, useMemo } from "react"
+import { useState, useEffect, useRef, Suspense, useMemo } from "react"
 import { Button } from "@/components/ui/button"
 import { Select, SelectContent, SelectItem, SelectTrigger, SelectValue, SelectGroup } from "@/components/ui/select"
 import { Input } from "@/components/ui/input"
@@ -26,7 +26,6 @@ import { ScrollArea } from "@/components/ui/scroll-area"
 import { cn } from "@/lib/utils"
 import DailyToast from "@/components/home/DailyToast"
 import { toast } from "sonner"
-import { useTheme } from "next-themes"
 import {
   AlertDialog,
   AlertDialogAction,
@@ -83,28 +82,10 @@ export default function Calendar({ className, ...props }: CalendarProps) {
   const [previewOpen, setPreviewOpen] = useState(false)
   const [focusUserProfileSection, setFocusUserProfileSection] = useState<UserProfileSection | null>(null)
   const [sidebarDate, setSidebarDate] = useState<Date>(new Date())
-  const { theme } = useTheme()
   const [pendingDeleteEvent, setPendingDeleteEvent] = useState<CalendarEvent | null>(null)
   const [deleteConfirmOpen, setDeleteConfirmOpen] = useState(false)
 
-  useLayoutEffect(() => {
-    const body = document.body
-    const colorThemes = ['green', 'orange', 'azalea', 'pink', 'crimson']
 
-    body.classList.add('app')
-
-    colorThemes.forEach(color => body.classList.remove(color))
-    
-    if (theme && colorThemes.includes(theme)) {
-      body.classList.add(theme)
-    }
-
-    return () => {
-      body.classList.remove('app')
-      colorThemes.forEach(color => body.classList.remove(color))
-    }
-  }, [theme])
-  
   const updateEvent = (updatedEvent) => {
     setEvents(prevEvents => 
       prevEvents.map(event => 

--- a/components/Calendar.tsx
+++ b/components/Calendar.tsx
@@ -89,7 +89,7 @@ export default function Calendar({ className, ...props }: CalendarProps) {
 
   useLayoutEffect(() => {
     const body = document.body
-    const colorThemes = ['blue', 'green', 'purple', 'orange', 'azalea', 'pink', 'crimson']
+    const colorThemes = ['green', 'orange', 'azalea', 'pink', 'crimson']
 
     body.classList.add('app')
 

--- a/components/analytics/ImportExport.tsx
+++ b/components/analytics/ImportExport.tsx
@@ -746,7 +746,7 @@ END:VEVENT
           </Tabs>
 
           {debugInfo && (
-            <div className="mt-4 p-2 bg-gray-100 dark:bg-gray-800 rounded-md">
+            <div className="mt-4 rounded-md bg-muted p-2">
               <h4 className="font-medium mb-1">{t.debugInfo}</h4>
               <pre className="text-xs overflow-auto max-h-40 whitespace-pre-wrap">{debugInfo}</pre>
             </div>

--- a/components/home/Settings.tsx
+++ b/components/home/Settings.tsx
@@ -58,7 +58,7 @@ export default function Settings({
 
   useEffect(() => {
     const body = document.body
-    const colorThemes = ["blue", "green", "purple", "orange", "azalea", "pink", "crimson"]
+    const colorThemes = ["green", "orange", "azalea", "pink", "crimson"]
 
     body.classList.add("app")
     colorThemes.forEach((colorTheme) => body.classList.remove(colorTheme))

--- a/components/home/Settings.tsx
+++ b/components/home/Settings.tsx
@@ -1,6 +1,5 @@
 "use client"
 
-import { useEffect } from "react"
 import { Select, SelectContent, SelectItem, SelectTrigger, SelectValue } from "@/components/ui/select"
 import { Label } from "@/components/ui/label"
 import { translations, type Language } from "@/lib/i18n"
@@ -55,23 +54,6 @@ export default function Settings({
 }: SettingsProps) {
   const { theme, setTheme } = useTheme()
   const t = translations[language]
-
-  useEffect(() => {
-    const body = document.body
-    const colorThemes = ["green", "orange", "azalea", "pink", "crimson"]
-
-    body.classList.add("app")
-    colorThemes.forEach((colorTheme) => body.classList.remove(colorTheme))
-
-    if (theme && colorThemes.includes(theme)) {
-      body.classList.add(theme)
-    }
-
-    return () => {
-      body.classList.remove("app")
-      colorThemes.forEach((colorTheme) => body.classList.remove(colorTheme))
-    }
-  }, [theme])
 
   const getGMTTimezones = () => {
     const timezones = Intl.supportedValuesOf("timeZone")


### PR DESCRIPTION
### Motivation
- Fix the Next.js build warning that `themeColor` must be exported via `viewport` instead of `metadata` to comply with Next 16 conventions.
- Restrict the heavy multi-theme configuration to the `/app` route so non-app pages do not load extra theme variants or related runtime work.
- Remove unused client-side hooks from the `/app` page to reduce unnecessary work and improve render performance.

### Description
- Removed `themeColor` from the root `metadata` in `app/layout.tsx` to eliminate the unsupported metadata usage.
- Reduced the global `ThemeProvider` in `app/layout.tsx` to only `['light','dark']` so non-`/app` pages use a minimal theme surface.
- Added a route-specific layout `app/(app)/app/layout.tsx` that exports `viewport.themeColor` with light/dark media variants and enables the extended theme list only for `/app`.
- Simplified `app/(app)/app/page.tsx` by removing unused `isMobile`/`isChinese` state and `useEffect` hooks to lighten client work and kept the page to simply render the `Calendar` component.
- No AGENTS skills were used because this is a local layout and metadata refactor.

### Testing
- Ran `bun run build` but it failed immediately with `next: command not found` in the environment, so a full Next build could not be completed.
- Ran `bun install` but dependency resolution failed due to `403` responses from the npm registry, preventing a complete local install and build verification.
- Unit/e2e tests were not executed because dependencies and build tooling could not be installed in this environment, so no automated tests passed here.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_698ad2c70d60833299cd8ada542cbc3d)

## Summary by Sourcery

将丰富的多主题支持和 `themeColor` 处理范围限定到 `/app` 路由，同时简化 app 页面端的客户端逻辑。

Bug Fixes:
- 使 `themeColor` 处理方式与 Next.js 的 `viewport` 导出规范保持一致，以避免使用不受支持的 metadata。

Enhancements:
- 在根布局中将全局 `ThemeProvider` 限制为仅支持明暗主题（light/dark），从而使非 `/app` 路由只使用最小主题集合。
- 引入专用于 `/app` 的布局，通过 `viewport` 导出提供扩展的主题变体以及具备媒体感知能力的 `themeColor`。
- 简化 `/app` 首页，移除未使用的响应式和本地化检测 hooks，使其仅渲染 `Calendar` 组件。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Scope rich multi-theme support and themeColor handling to the /app route while simplifying the app page client logic.

Bug Fixes:
- Align themeColor handling with Next.js viewport export requirements to avoid unsupported metadata usage.

Enhancements:
- Limit the global ThemeProvider to light/dark themes in the root layout so non-/app routes use a minimal theme set.
- Introduce an /app-specific layout that provides extended theme variants and media-aware themeColor via the viewport export.
- Simplify the /app home page by removing unused responsiveness and locale detection hooks, leaving it to render only the Calendar component.

</details>