### PR TITLE
Remove pink/crimson themes and make sidebar logo black in light mode

### DIFF
--- a/app/globals.css
+++ b/app/globals.css
@@ -200,124 +200,42 @@ body {
     --sidebar-ring: 331 63% 49%;
 }
 
-.pink,
-.pink .app-theme-scope {
-    --background: 7 60% 95%;
-    --foreground: 7 25% 18%;
-    --card: 7 50% 90%;
-    --card-foreground: 7 25% 18%;
-    --popover: 7 50% 90%;
-    --popover-foreground: 7 25% 18%;
-    --primary: 7 100% 82%;
-    --primary-foreground: 0 0% 100%;
-    --secondary: 5 30% 85%;
-    --secondary-foreground: 7 25% 18%;
-    --muted: 5 30% 88%;
-    --muted-foreground: 7 20% 42%;
-    --accent: 7 60% 87%;
-    --accent-foreground: 7 100% 82%;
-    --destructive: 0 84% 60%;
-    --destructive-foreground: 0 0% 100%;
-    --border: 7 50% 75%;
-    --input: 7 40% 85%;
-    --ring: 7 100% 82%;
-    --chart-1: 7 100% 82%;
-    --chart-2: 217 91% 60%;
-    --chart-3: 38 92% 50%;
-    --chart-4: 270 95% 75%;
-    --chart-5: 340 82% 52%;
-    --sidebar-background: 7 50% 90%;
-    --sidebar-foreground: 7 25% 18%;
-    --sidebar-primary: 7 100% 82%;
-    --sidebar-primary-foreground: 0 0% 100%;
-    --sidebar-accent: 5 30% 85%;
-    --sidebar-accent-foreground: 7 25% 18%;
-    --sidebar-border: 7 50% 75%;
-    --sidebar-ring: 7 100% 82%;
-}
 
-.crimson,
-.crimson .app-theme-scope {
-    --background: 341 25% 95%;
-    --foreground: 341 15% 18%;
-    --card: 341 20% 90%;
-    --card-foreground: 341 15% 18%;
-    --popover: 341 20% 90%;
-    --popover-foreground: 341 15% 18%;
-    --primary: 341 100% 30%;
-    --primary-foreground: 0 0% 100%;
-    --secondary: 338 15% 85%;
-    --secondary-foreground: 341 15% 18%;
-    --muted: 338 15% 88%;
-    --muted-foreground: 341 12% 42%;
-    --accent: 341 25% 87%;
-    --accent-foreground: 341 100% 30%;
-    --destructive: 0 84% 60%;
-    --destructive-foreground: 0 0% 100%;
-    --border: 341 20% 75%;
-    --input: 341 18% 85%;
-    --ring: 341 100% 30%;
-    --chart-1: 341 100% 30%;
-    --chart-2: 217 91% 60%;
-    --chart-3: 38 92% 50%;
-    --chart-4: 270 95% 75%;
-    --chart-5: 340 82% 52%;
-    --sidebar-background: 341 20% 90%;
-    --sidebar-foreground: 341 15% 18%;
-    --sidebar-primary: 341 100% 30%;
-    --sidebar-primary-foreground: 0 0% 100%;
-    --sidebar-accent: 338 15% 85%;
-    --sidebar-accent-foreground: 341 15% 18%;
-    --sidebar-border: 341 20% 75%;
-    --sidebar-ring: 341 100% 30%;
-}
 
 .green,
 .green .app-theme-scope,
 .orange,
 .orange .app-theme-scope,
 .azalea,
-.azalea .app-theme-scope,
-.pink,
-.pink .app-theme-scope,
-.crimson,
-.crimson .app-theme-scope {
+.azalea .app-theme-scope {
     --card: var(--background);
     --popover: var(--background);
 }
 
 .green .app-theme-scope button[variant="outline"],
 .orange .app-theme-scope button[variant="outline"],
-.azalea .app-theme-scope button[variant="outline"],
-.pink .app-theme-scope button[variant="outline"],
-.crimson .app-theme-scope button[variant="outline"] {
+.azalea .app-theme-scope button[variant="outline"] {
     border: 1px solid hsl(var(--border));
     background: transparent;
 }
 
 .green .app-theme-scope button[variant="ghost"],
 .orange .app-theme-scope button[variant="ghost"],
-.azalea .app-theme-scope button[variant="ghost"],
-.pink .app-theme-scope button[variant="ghost"],
-.crimson .app-theme-scope button[variant="ghost"] {
+.azalea .app-theme-scope button[variant="ghost"] {
     border: none;
     background: transparent;
 }
 
 .green .app-theme-scope hr, .green .app-theme-scope .divider,
 .orange .app-theme-scope hr, .orange .app-theme-scope .divider,
-.azalea .app-theme-scope hr, .azalea .app-theme-scope .divider,
-.pink .app-theme-scope hr, .pink .app-theme-scope .divider,
-.crimson .app-theme-scope hr, .crimson .app-theme-scope .divider {
+.azalea .app-theme-scope hr, .azalea .app-theme-scope .divider {
     border-color: hsl(var(--border));
     opacity: 0.8;
 }
 
 .green .app-theme-scope .separator,
 .orange .app-theme-scope .separator,
-.azalea .app-theme-scope .separator,
-.pink .app-theme-scope .separator,
-.crimson .app-theme-scope .separator {
+.azalea .app-theme-scope .separator {
     height: 1px;
     background: hsl(var(--border));
     opacity: 0.6;

--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -58,7 +58,7 @@ export default function RootLayout({
         signUpUrl="/sign-up"
       >
         <ThemeProvider
-            themes={['light', 'dark', 'green', 'orange', 'azalea', 'pink', 'crimson']}
+            themes={['light', 'dark', 'green', 'orange', 'azalea']}
             attribute="class"
             defaultTheme="system"
             enableSystem

--- a/components/app/profile/settings.tsx
+++ b/components/app/profile/settings.tsx
@@ -112,8 +112,6 @@ export default function Settings({
               <SelectItem value="green">{t.themeGreen}</SelectItem>
               <SelectItem value="orange">{t.themeOrange}</SelectItem>
               <SelectItem value="azalea">{t.themeAzalea}</SelectItem>
-              <SelectItem value="pink">{t.themePink}</SelectItem>
-              <SelectItem value="crimson">{t.themeCrimson}</SelectItem>
               <SelectItem value="system">{t.themeSystem}</SelectItem>
             </SelectContent>
           </Select>

--- a/components/app/sidebar/countdown.tsx
+++ b/components/app/sidebar/countdown.tsx
@@ -217,7 +217,7 @@ export function CountdownTool({ open, onOpenChange }: CountdownToolProps) {
           variant="outline"
           size="sm"
           onClick={startAddCountdown}
-          className="w-full mb-4 bg-[#0066ff] text-white hover:bg-[#0052CC] border-[#0066ff] green:bg-[#24a854] green:border-[#24a854] orange:bg-[#e26912] orange:border-[#e26912] azalea:bg-[#CD2F7B] azalea:border-[#CD2F7B] pink:bg-[#FFAFA5] pink:border-[#FFAFA5] crimson:bg-[#9B0032] crimson:border-[#9B0032]"
+          className="w-full mb-4 bg-[#0066ff] text-white hover:bg-[#0052CC] border-[#0066ff] green:bg-[#24a854] green:border-[#24a854] orange:bg-[#e26912] orange:border-[#e26912] azalea:bg-[#CD2F7B] azalea:border-[#CD2F7B]"
         >
           <Plus className="mr-2 h-4 w-4" />
           {t.countdownAdd}

--- a/components/app/sidebar/sidebar.tsx
+++ b/components/app/sidebar/sidebar.tsx
@@ -1,6 +1,7 @@
 "use client"
 
 import { useState } from "react"
+import { useTheme } from "next-themes"
 import { Button } from "@/components/ui/button"
 import { Calendar } from "@/components/ui/calendar"
 import { Input } from "@/components/ui/input"
@@ -68,6 +69,7 @@ export default function Sidebar({
   const [manageCategoriesOpen, setManageCategoriesOpen] = useState(false)
   const [deleteDialogOpen, setDeleteDialogOpen] = useState(false)
   const [categoryToDelete, setCategoryToDelete] = useState<string | null>(null)
+  const { resolvedTheme } = useTheme()
   const t = translations[language || "zh"]
 
   const deleteText = {
@@ -131,12 +133,19 @@ export default function Sidebar({
     >
       <div className="p-4">
         <div className="mb-4 flex items-center">
-          <Image src="/icon.svg" alt="One Calendar" width={24} height={24} className="mr-2" />
+          <Image
+            src="/icon.svg"
+            alt="One Calendar"
+            width={24}
+            height={24}
+            className="mr-2"
+            style={{ filter: resolvedTheme === "dark" ? "brightness(0) invert(1)" : "brightness(0)" }}
+          />
           <h1 className="text-lg font-semibold">{t.oneCalendar}</h1>
         </div>
 
         <Button
-          className="w-full justify-center bg-[#0066FF] text-white hover:bg-[#0052CC] mb-4 h-10 green:bg-[#24a854] orange:bg-[#e26912] azalea:bg-[#CD2F7B] pink:bg-[#FFAFA5] crimson:bg-[#9B0032]"
+          className="w-full justify-center bg-[#0066FF] text-white hover:bg-[#0052CC] mb-4 h-10 green:bg-[#24a854] orange:bg-[#e26912] azalea:bg-[#CD2F7B]"
           onClick={onCreateEvent}
         >
           {t.createEvent}

--- a/components/app/views/day-view.tsx
+++ b/components/app/views/day-view.tsx
@@ -558,7 +558,7 @@ export default function DayView({
           <div className="text-sm text-muted-foreground">
             {format(date, "E", { locale: isZh ? zhCN : enUS })}
           </div>
-          <div className="text-3xl font-semibold text-[#0066ff] green:text-[#24a854] orange:text-[#e26912] azalea:text-[#CD2F7B] pink:text-[#FFAFA5]">{format(date, "d")}</div>
+          <div className="text-3xl font-semibold text-[#0066ff] green:text-[#24a854] orange:text-[#e26912] azalea:text-[#CD2F7B]">{format(date, "d")}</div>
         </div>
         <div className="p-2">
           {/* 全天事件区域 */}
@@ -700,7 +700,7 @@ export default function DayView({
 
             return (
               <div
-                className="absolute left-0 right-0 border-t-2 border-[#0066FF] z-0 green:border-[#24a854] orange:border-[#e26912] azalea:border-[#CD2F7B] pink:border-[#FFAFA5]"
+                className="absolute left-0 right-0 border-t-2 border-[#0066FF] z-0 green:border-[#24a854] orange:border-[#e26912] azalea:border-[#CD2F7B]"
                 style={{
                   top: `${topPosition}px`,
                 }}

--- a/components/app/views/month-view.tsx
+++ b/components/app/views/month-view.tsx
@@ -91,7 +91,7 @@ export default function MonthView({ date, events, onEventClick, language, firstD
                 "font-medium text-sm",
                 isSameMonth(day, date) ? "" : "text-gray-400",
                 isSameDay(day, today)
-                  ? "text-[#0066FF] font-bold green:text-[#24a854] orange:text-[#e26912] azalea:text-[#CD2F7B] pink:text-[#FFAFA5]"
+                  ? "text-[#0066FF] font-bold green:text-[#24a854] orange:text-[#e26912] azalea:text-[#CD2F7B]"
                   : "",
               )}
             >

--- a/components/app/views/week-view.tsx
+++ b/components/app/views/week-view.tsx
@@ -649,7 +649,7 @@ export default function WeekView({
               <div className="p-2 text-center">
                 <div>{format(day, "E", { locale: isZh ? zhCN : enUS })}</div>
                 {/* 如果是今天,使用蓝色高亮显示日期 */}
-                <div className={cn(isSameDay(day, today) ? "text-[#0066FF] font-bold green:text-[#24a854] orange:text-[#e26912] azalea:text-[#CD2F7B] pink:text-[#FFAFA5]" : "")}>
+                <div className={cn(isSameDay(day, today) ? "text-[#0066FF] font-bold green:text-[#24a854] orange:text-[#e26912] azalea:text-[#CD2F7B]" : "")}>
                   {format(day, "d")}
                 </div>
               </div>
@@ -792,7 +792,7 @@ export default function WeekView({
 
                   return (
                     <div
-                      className="absolute left-0 right-0 border-t-2 border-[#0066FF] z-0 green:border-[#24a854] orange:border-[#e26912] azalea:border-[#CD2F7B] pink:border-[#FFAFA5]"
+                      className="absolute left-0 right-0 border-t-2 border-[#0066FF] z-0 green:border-[#24a854] orange:border-[#e26912] azalea:border-[#CD2F7B]"
                       style={{
                         top: `${topPosition}px`,
                       }}

--- a/components/app/views/year-view.tsx
+++ b/components/app/views/year-view.tsx
@@ -141,7 +141,7 @@ export default function YearView({
                           !isCurrentMonth && "text-muted-foreground",
                           dayEvents.length > 0 && "font-semibold",
                           isToday &&
-                            "bg-[#0066FF] text-white green:bg-[#24a854] orange:bg-[#e26912] azalea:bg-[#CD2F7B] pink:bg-[#FFAFA5] crimson:bg-[#9B0032]",
+                            "bg-[#0066FF] text-white green:bg-[#24a854] orange:bg-[#e26912] azalea:bg-[#CD2F7B]",
                         )}
                       >
                         {format(day, "d")}

--- a/components/providers/theme-provider.tsx
+++ b/components/providers/theme-provider.tsx
@@ -5,7 +5,7 @@ import { ThemeProvider as NextThemesProvider } from 'next-themes';
 
 export function ThemeProvider({
   children,
-  themes = ['light', 'dark', 'green', "orange", "azalea", "pink", "crimson"],
+  themes = ['light', 'dark', 'green', 'orange', 'azalea'],
   ...props
 }: React.ComponentProps<typeof NextThemesProvider> & {
   themes?: string[];

--- a/locales/en.json
+++ b/locales/en.json
@@ -231,8 +231,6 @@
   "themeGreen": "Green",
   "themeOrange": "Orange",
   "themeAzalea": "Azalea",
-  "themePink": "Pink",
-  "themeCrimson": "Crimson",
   "languageEnglish": "English",
   "languageChinese": "Chinese",
   "noEventsToday": "No events today",

--- a/locales/zh-CN.json
+++ b/locales/zh-CN.json
@@ -231,8 +231,6 @@
   "themeGreen": "绿色",
   "themeOrange": "橙色",
   "themeAzalea": "映山红",
-  "themePink": "粉色",
-  "themeCrimson": "深红色",
   "languageEnglish": "英语",
   "languageChinese": "中文",
   "noEventsToday": "今天没有日程",


### PR DESCRIPTION
### Motivation
- Remove the `pink` and `crimson` color themes from the multi-theme system so they are no longer selectable or applied.
- Ensure the sidebar logo appears black in light mode (and white in dark mode) so it remains visible across themes.

### Description
- Removed `pink` and `crimson` from the registered theme lists in `components/providers/theme-provider.tsx` and the root `app/layout.tsx` by updating the `themes` arrays to `['light','dark','green','orange','azalea']`.
- Deleted the `themePink`/`themeCrimson` locale entries and removed their options from the theme selector in `components/app/profile/settings.tsx` and the locale files `locales/en.json` and `locales/zh-CN.json`.
- Removed the `pink` and `crimson` CSS theme blocks and cleaned grouped selectors in `app/globals.css` so only supported theme CSS remains (`green`, `orange`, `azalea`).
- Cleared uses of `pink`/`crimson` theme utility classes across UI components (sidebar, countdown tool, and day/week/month/year views) so no UI references remain to the removed themes.
- Updated sidebar logo rendering in `components/app/sidebar/sidebar.tsx` to use `next-themes`' `resolvedTheme` and apply `style={{ filter: resolvedTheme === "dark" ? "brightness(0) invert(1)" : "brightness(0)" }}` to force black in light mode and white in dark mode.

### Testing
- Ran a JSON parse check on `locales/en.json` and `locales/zh-CN.json` using a small Python script (`json.load(...)`) which succeeded and validated JSON syntax.
- Searched the codebase with `rg` for `\bpink\b|\bcrimson\b` to verify theme registration/UI/CSS references were removed; remaining hits are only event color names and not theme registrations, confirming removal of the themes.
- Attempted `npm run build` to validate a production build, but it failed in this environment with `next: not found` because dependencies/binaries are not installed, so a full build could not be completed here.
- Attempted an automated browser screenshot via Playwright but the local dev server was not running (`ERR_EMPTY_RESPONSE`), so visual verification was not captured in this environment.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_698c25e321b083329b7147456481445e)

## Summary by Sourcery

移除已弃用的配色主题并更新侧边栏品牌标识的行为。

Bug 修复：
- 确保侧边栏 Logo 在浅色模式下自动渲染为黑色，在深色模式下自动渲染为白色，以在不同主题中保持更好的可见性。

增强改进：
- 从主题配置、样式和 UI 主题选择器中移除粉色（pink）和深红色（crimson）主题，只保留浅色（light）、深色（dark）、绿色（green）、橙色（orange）和杜鹃花色（azalea）。
- 清理 CSS 选择器和组件主题工具类，仅引用受支持的主题。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Remove deprecated color themes and update sidebar branding behavior.

Bug Fixes:
- Ensure the sidebar logo automatically renders black in light mode and white in dark mode for better visibility across themes.

Enhancements:
- Remove the pink and crimson themes from theme configuration, styles, and UI theme selectors, leaving only light, dark, green, orange, and azalea.
- Clean up CSS selectors and component theme utility classes to reference only the supported themes.

</details>