### PR TITLE
fix: resolve Turbopack parse error in analytics import/export component

### DIFF
--- a/components/app/analytics/import-export.tsx
+++ b/components/app/analytics/import-export.tsx
@@ -101,8 +101,9 @@ export default function ImportExport({ events, onImportEvents }: ImportExportPro
             throw new Error(t.passwordsDoNotMatch || "Passwords do not match")
           }
 
-        const encrypted = await encryptPayload(jsonPassword, jsonContent)
-        jsonContent = JSON.stringify({ ...encrypted, encrypted: true, format: "one-calendar-json-v1" }, null, 2)
+          const encrypted = await encryptPayload(jsonPassword, jsonContent)
+          jsonContent = JSON.stringify({ ...encrypted, encrypted: true, format: "one-calendar-json-v1" }, null, 2)
+        }
 
         downloadFile(jsonContent, "calendar-export.json", "application/json")
       } else if (exportFormat === "csv") {


### PR DESCRIPTION
### Motivation
- Fix a Turbopack/Next build parse error caused by a missing closing brace in the JSON export branch of the analytics import/export component so the file parses correctly during production builds.

### Description
- Closed the conditional block in `components/app/analytics/import-export.tsx` so the JSON export password-encryption logic remains inside `if (hasAnyPasswordInput)` and the following code is parsed correctly.

### Testing
- Ran `bun run build` which failed locally because the `next` binary was not available in this environment (build could not complete).
- Ran `bun install` which failed due to npm registry `403` responses in this environment, so a full dependency install and build could not be performed.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_698d9018a58c833280caba91969c460e)

## Summary by Sourcery

错误修复：
- 通过在分析导入/导出组件中，正确关闭围绕 JSON 密码加密逻辑的条件代码块，解决 Turbopack/Next 构建时的解析错误。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Bug Fixes:
- Resolve a Turbopack/Next build parse error by correctly closing the conditional block around JSON password-encryption logic in the analytics import/export component.

</details>