### PR TITLE
fix: stabilize forgot-key recovery and prevent reverification crash

### DIFF
--- a/components/app/profile/user-profile-button.tsx
+++ b/components/app/profile/user-profile-button.tsx
@@ -476,6 +476,18 @@ export default function UserProfileButton({
     throw new Error(isZh ? "JSON 备份格式无效" : "Invalid JSON backup format")
   }
 
+  const resetRestoreFlow = () => {
+    setRestoreStep("verify")
+    setRestoreFile(null)
+    setRestoreJsonPassword("")
+  }
+
+  const goBackToUnlock = () => {
+    setForgotOpen(false)
+    resetRestoreFlow()
+    setUnlockOpen(true)
+  }
+
   const restoreFromBackupFile = async () => {
     if (!restoreFile) {
       toast(isZh ? "请先选择备份文件" : "Please choose a backup file first", { variant: "destructive" })
@@ -512,8 +524,7 @@ export default function UserProfileButton({
 
       setForgotOpen(false)
       setUnlockOpen(false)
-      setRestoreFile(null)
-      setRestoreJsonPassword("")
+      resetRestoreFlow()
       setPassword("")
       toast(isZh ? "已从备份恢复数据" : "Data restored from backup")
     } catch (e: any) {
@@ -529,7 +540,7 @@ export default function UserProfileButton({
   const startForgotRecovery = async () => {
     try {
       setIsReverifying(true)
-      await startReverification({ strategy: "password" })
+      await startReverification()
       setRestoreStep("upload")
     } catch (e: any) {
       toast(isZh ? "验证失败" : "Reverification failed", {
@@ -1092,7 +1103,13 @@ export default function UserProfileButton({
       </Dialog>
 
 
-      <Dialog open={forgotOpen} onOpenChange={setForgotOpen}>
+      <Dialog
+        open={forgotOpen}
+        onOpenChange={(open) => {
+          setForgotOpen(open)
+          if (!open) resetRestoreFlow()
+        }}
+      >
         <DialogContent>
           <DialogHeader>
             <DialogTitle>{isZh ? "从备份恢复数据" : "Restore from backup"}</DialogTitle>
@@ -1109,7 +1126,7 @@ export default function UserProfileButton({
                 {isZh ? "验证通过后，您可以上传备份文件恢复日历数据。" : "After successful reverification, you can upload a backup file to restore calendar data."}
               </p>
               <DialogFooter>
-                <Button variant="outline" onClick={() => { setForgotOpen(false); setUnlockOpen(true) }}>
+                <Button variant="outline" onClick={goBackToUnlock}>
                   {t.cancel}
                 </Button>
                 <Button onClick={startForgotRecovery} disabled={isReverifying}>
@@ -1144,10 +1161,10 @@ export default function UserProfileButton({
               )}
 
               <DialogFooter>
-                <Button variant="outline" onClick={() => { setForgotOpen(false); setUnlockOpen(true) }}>
+                <Button variant="outline" onClick={goBackToUnlock}>
                   {t.cancel}
                 </Button>
-                <Button onClick={restoreFromBackupFile} disabled={isRestoring}>
+                <Button onClick={restoreFromBackupFile} disabled={isRestoring || !restoreFile}>
                   {isRestoring ? (isZh ? "恢复中..." : "Restoring...") : (isZh ? "恢复数据" : "Restore data")}
                 </Button>
               </DialogFooter>


### PR DESCRIPTION
### Motivation
- Prevent a runtime crash (`p is not a function`) triggered during the "forgot encryption key" reverification path by calling the Clerk reverification helper with an unsupported signature. 
- Make the restore-from-backup UI flow more robust and easier to reason about by centralizing reset/navigation behavior. 

### Description
- Replace `startReverification({ strategy: "password" })` with `startReverification()` to match the supported usage and avoid the crash in the reverification flow. 
- Add `resetRestoreFlow()` to centralize clearing of `restoreStep`, `restoreFile`, and `restoreJsonPassword`. 
- Add `goBackToUnlock()` to centralize the cancel/back behavior that closes the forgot-key dialog and re-opens the unlock dialog. 
- Use `resetRestoreFlow()` after a successful restore and when the forgot-key dialog closes, and disable the restore confirm button unless a backup file is selected to prevent invalid submissions. 
- Changes are localized to `components/app/profile/user-profile-button.tsx` and adjust dialog handlers and restore logic accordingly. 

### Testing
- Ran type-checking with `bunx tsc --noEmit`, which produced errors in this environment due to missing project dependencies and type declarations and is therefore inconclusive for this localized change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_698d91cc629083329c67971e7ef5afd5)

## Summary by Sourcery

稳定“忘记加密密钥”恢复流程，以及用户资料解锁界面中的重新验证对话框行为。

Bug 修复：
- 通过使用受支持的重新验证助手函数签名，避免在“忘记密钥”重新验证流程中发生运行时崩溃。
- 当未选择备份文件时禁用恢复操作，防止提交无效的恢复请求。

增强：
- 将恢复流程中的状态重置以及“忘记密钥”与解锁对话框之间的返回导航逻辑集中管理，使整个流程更加稳健且行为一致。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Stabilize the forgot-encryption-key recovery flow and reverification dialog behavior in the user profile unlock UI.

Bug Fixes:
- Avoid a runtime crash in the forgot-key reverification flow by using the supported reverification helper signature.
- Prevent invalid restore submissions by disabling the restore action when no backup file is selected.

Enhancements:
- Centralize restore-flow state resets and back-navigation between forgot-key and unlock dialogs to make the flow more robust and consistent.

</details>