### PR TITLE
refactor: remove "forgot encryption key" restore-from-backup flow from profile dialog

### DIFF
--- a/components/app/profile/user-profile-button.tsx
+++ b/components/app/profile/user-profile-button.tsx
@@ -44,7 +44,7 @@ import { ScrollArea } from "@/components/ui/scroll-area"
 import { toast } from "sonner"
 import { useCalendar } from "@/components/providers/calendar-context"
 import { translations, useLanguage } from "@/lib/i18n"
-import { useReverification, useUser, SignOutButton } from "@clerk/nextjs"
+import { useUser, SignOutButton } from "@clerk/nextjs"
 import { useRouter } from "next/navigation"
 import Image from "next/image"
 import { decryptPayload, encryptPayload, isEncryptedPayload } from "@/lib/crypto"
@@ -56,7 +56,6 @@ import {
   readEncryptedLocalStorage,
   setEncryptionPassword,
 } from "@/hooks/useLocalStorage"
-import type { CalendarEvent } from "@/components/providers/calendar-context"
 
 const AUTO_KEY = "auto-backup-enabled"
 const BACKUP_VERSION = 1
@@ -186,7 +185,6 @@ export default function UserProfileButton({
   const t = translations[language]
   const { events, calendars, setEvents, setCalendars } = useCalendar()
   const { user, isSignedIn } = useUser()
-  const { startReverification } = useReverification()
   const router = useRouter()
 
   const [enabled, setEnabled] = useState(false)
@@ -198,12 +196,6 @@ export default function UserProfileButton({
   const [deleteAccountOpen, setDeleteAccountOpen] = useState(false)
   const [isDeletingAccount, setIsDeletingAccount] = useState(false)
   const [isUnlocking, setIsUnlocking] = useState(false)
-  const [forgotOpen, setForgotOpen] = useState(false)
-  const [restoreStep, setRestoreStep] = useState<"verify" | "upload">("verify")
-  const [isReverifying, setIsReverifying] = useState(false)
-  const [isRestoring, setIsRestoring] = useState(false)
-  const [restoreFile, setRestoreFile] = useState<File | null>(null)
-  const [restoreJsonPassword, setRestoreJsonPassword] = useState("")
   const [deleteAccountConfirmText, setDeleteAccountConfirmText] = useState("")
   const [profileSection, setProfileSection] = useState<"basic" | "emails" | "oauth">("basic")
 
@@ -344,202 +336,6 @@ export default function UserProfileButton({
   }
 
   const isZh = useMemo(() => language.startsWith("zh"), [language])
-
-  const hydrateEvent = (raw: any): CalendarEvent => {
-    const startDate = raw?.startDate ? new Date(raw.startDate) : new Date()
-    const endDate = raw?.endDate ? new Date(raw.endDate) : new Date(startDate.getTime() + 60 * 60 * 1000)
-
-    return {
-      id: raw?.id || `${Date.now()}-${Math.random().toString(36).slice(2, 8)}`,
-      title: raw?.title || (isZh ? "未命名日程" : "Unnamed Event"),
-      startDate,
-      endDate: endDate < startDate ? new Date(startDate.getTime() + 60 * 60 * 1000) : endDate,
-      isAllDay: Boolean(raw?.isAllDay),
-      recurrence: ["none", "daily", "weekly", "monthly", "yearly"].includes(raw?.recurrence)
-        ? raw.recurrence
-        : "none",
-      location: raw?.location,
-      participants: Array.isArray(raw?.participants) ? raw.participants : [],
-      notification: typeof raw?.notification === "number" ? raw.notification : 0,
-      description: raw?.description,
-      color: raw?.color || "bg-blue-500",
-      calendarId: raw?.calendarId || "1",
-    }
-  }
-
-  const parseICSBackup = (icsContent: string): CalendarEvent[] => {
-    const events: CalendarEvent[] = []
-    const lines = icsContent.split(/\r\n|\n|\r/)
-    let inEvent = false
-    let current: any = {}
-
-    for (const line of lines) {
-      if (line.startsWith("BEGIN:VEVENT")) {
-        inEvent = true
-        current = {}
-        continue
-      }
-      if (line.startsWith("END:VEVENT")) {
-        if (inEvent) events.push(hydrateEvent(current))
-        inEvent = false
-        current = {}
-        continue
-      }
-      if (!inEvent) continue
-
-      const i = line.indexOf(":")
-      if (i < 0) continue
-      const key = line.slice(0, i).split(";")[0]
-      const value = line.slice(i + 1)
-
-      if (key === "SUMMARY") current.title = value
-      if (key === "DESCRIPTION") current.description = value.replace(/\\n/g, "\n")
-      if (key === "LOCATION") current.location = value
-      if (key === "UID") current.id = value
-      if (key === "DTSTART") current.startDate = value.endsWith("Z") ? new Date(value.replace(/(\d{4})(\d{2})(\d{2})T(\d{2})(\d{2})(\d{2})Z/, "$1-$2-$3T$4:$5:$6Z")) : new Date(value)
-      if (key === "DTEND") current.endDate = value.endsWith("Z") ? new Date(value.replace(/(\d{4})(\d{2})(\d{2})T(\d{2})(\d{2})(\d{2})Z/, "$1-$2-$3T$4:$5:$6Z")) : new Date(value)
-    }
-
-    return events
-  }
-
-  const parseCSVLine = (line: string): string[] => {
-    const result: string[] = []
-    let insideQuotes = false
-    let currentValue = ""
-
-    for (let i = 0; i < line.length; i++) {
-      const char = line[i]
-      if (char === '"') {
-        if (i < line.length - 1 && line[i + 1] === '"') {
-          currentValue += '"'
-          i++
-        } else {
-          insideQuotes = !insideQuotes
-        }
-      } else if (char === "," && !insideQuotes) {
-        result.push(currentValue.trim())
-        currentValue = ""
-      } else {
-        currentValue += char
-      }
-    }
-
-    result.push(currentValue.trim())
-    return result
-  }
-
-  const parseCSVBackup = (csvContent: string): CalendarEvent[] => {
-    const lines = csvContent.split("\n").filter((l) => l.trim())
-    if (lines.length < 2) return []
-    const headers = parseCSVLine(lines[0]).map((h) => h.toLowerCase())
-
-    return lines.slice(1).map((line) => {
-      const values = parseCSVLine(line)
-      const map: Record<string, string> = {}
-      headers.forEach((h, i) => {
-        map[h] = values[i] || ""
-      })
-      return hydrateEvent({
-        title: map["title"],
-        startDate: map["start date"] || map["start"],
-        endDate: map["end date"] || map["end"],
-        location: map["location"],
-        description: map["description"],
-        color: map["color"],
-      })
-    })
-  }
-
-  const parseJSONBackup = async (raw: string) => {
-    const parsed = JSON.parse(raw)
-
-    if (isEncryptedPayload(parsed) || parsed?.encrypted) {
-      if (!restoreJsonPassword.trim()) {
-        throw new Error(isZh ? "请输入 JSON 备份密码" : "Please enter the JSON backup password")
-      }
-      if (!isEncryptedPayload(parsed)) {
-        throw new Error(isZh ? "JSON 备份格式无效" : "Invalid JSON backup format")
-      }
-      const plain = await decryptPayload(restoreJsonPassword, parsed.ciphertext, parsed.iv)
-      const decrypted = JSON.parse(plain)
-      if (!Array.isArray(decrypted)) {
-        throw new Error(isZh ? "JSON 备份格式无效" : "Invalid JSON backup format")
-      }
-      return decrypted.map(hydrateEvent)
-    }
-
-    if (Array.isArray(parsed)) {
-      return parsed.map(hydrateEvent)
-    }
-
-    throw new Error(isZh ? "JSON 备份格式无效" : "Invalid JSON backup format")
-  }
-
-  const restoreFromBackupFile = async () => {
-    if (!restoreFile) {
-      toast(isZh ? "请先选择备份文件" : "Please choose a backup file first", { variant: "destructive" })
-      return
-    }
-
-    try {
-      setIsRestoring(true)
-      const ext = restoreFile.name.split(".").pop()?.toLowerCase()
-      const content = await restoreFile.text()
-
-      let restoredEvents: CalendarEvent[] = []
-      if (ext === "ics") {
-        restoredEvents = parseICSBackup(content)
-      } else if (ext === "json") {
-        restoredEvents = await parseJSONBackup(content)
-      } else if (ext === "csv") {
-        restoredEvents = parseCSVBackup(content)
-      } else {
-        throw new Error(isZh ? "不支持的备份格式" : "Unsupported backup format")
-      }
-
-      if (restoredEvents.length === 0) {
-        throw new Error(isZh ? "备份中未解析到事件" : "No events found in backup file")
-      }
-
-      setEvents(restoredEvents)
-      localStorage.setItem("calendar-events", JSON.stringify(restoredEvents))
-      clearEncryptionPassword()
-      keyRef.current = null
-      restoredRef.current = false
-      setEnabled(false)
-      localStorage.removeItem(AUTO_KEY)
-
-      setForgotOpen(false)
-      setUnlockOpen(false)
-      setRestoreFile(null)
-      setRestoreJsonPassword("")
-      setPassword("")
-      toast(isZh ? "已从备份恢复数据" : "Data restored from backup")
-    } catch (e: any) {
-      toast(isZh ? "恢复失败" : "Restore failed", {
-        description: e?.message || "",
-        variant: "destructive",
-      })
-    } finally {
-      setIsRestoring(false)
-    }
-  }
-
-  const startForgotRecovery = async () => {
-    try {
-      setIsReverifying(true)
-      await startReverification({ strategy: "password" })
-      setRestoreStep("upload")
-    } catch (e: any) {
-      toast(isZh ? "验证失败" : "Reverification failed", {
-        description: e?.errors?.[0]?.longMessage || e?.message || "",
-        variant: "destructive",
-      })
-    } finally {
-      setIsReverifying(false)
-    }
-  }
 
   async function unlock() {
     if (!password) return
@@ -1053,17 +849,6 @@ export default function UserProfileButton({
             <DialogDescription>{t.enterPasswordDescription}</DialogDescription>
           </DialogHeader>
           <Input type="password" value={password} onChange={(e) => setPassword(e.target.value)} />
-          <button
-            type="button"
-            className="text-left text-xs text-blue-600 hover:underline"
-            onClick={() => {
-              setUnlockOpen(false)
-              setRestoreStep("verify")
-              setForgotOpen(true)
-            }}
-          >
-            {isZh ? "忘记加密密钥？从备份恢复" : "Forgot encryption key? Restore from backup"}
-          </button>
           <DialogFooter>
             <Button onClick={unlock} disabled={isUnlocking}>
               {isUnlocking ? (
@@ -1088,71 +873,6 @@ export default function UserProfileButton({
               )}
             </Button>
           </DialogFooter>
-        </DialogContent>
-      </Dialog>
-
-
-      <Dialog open={forgotOpen} onOpenChange={setForgotOpen}>
-        <DialogContent>
-          <DialogHeader>
-            <DialogTitle>{isZh ? "从备份恢复数据" : "Restore from backup"}</DialogTitle>
-            <DialogDescription>
-              {restoreStep === "verify"
-                ? (isZh ? "请先完成 Clerk 二次验证（输入登录密码）后继续。" : "Complete Clerk reverification (enter your account password) before continuing.")
-                : (isZh ? "上传 .ics、.json 或 .csv 备份文件恢复数据。" : "Upload a .ics, .json, or .csv backup file to restore your data.")}
-            </DialogDescription>
-          </DialogHeader>
-
-          {restoreStep === "verify" ? (
-            <div className="space-y-3">
-              <p className="text-sm text-muted-foreground">
-                {isZh ? "验证通过后，您可以上传备份文件恢复日历数据。" : "After successful reverification, you can upload a backup file to restore calendar data."}
-              </p>
-              <DialogFooter>
-                <Button variant="outline" onClick={() => { setForgotOpen(false); setUnlockOpen(true) }}>
-                  {t.cancel}
-                </Button>
-                <Button onClick={startForgotRecovery} disabled={isReverifying}>
-                  {isReverifying ? (isZh ? "验证中..." : "Verifying...") : (isZh ? "开始验证" : "Start reverification")}
-                </Button>
-              </DialogFooter>
-            </div>
-          ) : (
-            <div className="space-y-3">
-              <div className="space-y-2">
-                <Label htmlFor="restore-file">{isZh ? "备份文件" : "Backup file"}</Label>
-                <Input
-                  id="restore-file"
-                  type="file"
-                  accept=".ics,.json,.csv"
-                  onChange={(e) => setRestoreFile(e.target.files?.[0] || null)}
-                />
-                <p className="text-xs text-muted-foreground">{isZh ? "支持 .ics、.json、.csv" : "Supported: .ics, .json, .csv"}</p>
-              </div>
-
-              {restoreFile?.name.toLowerCase().endsWith(".json") && (
-                <div className="space-y-2">
-                  <Label htmlFor="restore-json-password">{isZh ? "JSON 备份密码（如有）" : "JSON backup password (if encrypted)"}</Label>
-                  <Input
-                    id="restore-json-password"
-                    type="password"
-                    value={restoreJsonPassword}
-                    onChange={(e) => setRestoreJsonPassword(e.target.value)}
-                    placeholder={isZh ? "如果 JSON 已加密，请输入密码" : "Enter password if JSON backup is encrypted"}
-                  />
-                </div>
-              )}
-
-              <DialogFooter>
-                <Button variant="outline" onClick={() => { setForgotOpen(false); setUnlockOpen(true) }}>
-                  {t.cancel}
-                </Button>
-                <Button onClick={restoreFromBackupFile} disabled={isRestoring}>
-                  {isRestoring ? (isZh ? "恢复中..." : "Restoring...") : (isZh ? "恢复数据" : "Restore data")}
-                </Button>
-              </DialogFooter>
-            </div>
-          )}
         </DialogContent>
       </Dialog>
 


### PR DESCRIPTION
### Motivation
- Remove the fragile "forgot encryption key → restore from backup" path that caused runtime crashes and confusion, and simplify the unlock behavior to only accept an existing encryption password.
- Reduce surface area and maintenance burden by deleting the offline restore UI and its parsing/restore logic.

### Description
- Deleted all restore-related state and UI from `UserProfileButton`, including the unlock dialog link and the separate restore dialog.
- Removed restore handlers and helpers for parsing and applying backups: `.ics`, `.json`, and `.csv` parsers, `hydrateEvent`, `restoreFromBackupFile`, `parseJSONBackup`, `parseICSBackup`, `parseCSVBackup`, and related flow control functions.
- Removed Clerk reverification usage and the `useReverification`/`startReverification` call site, and removed the now-unused `CalendarEvent` type import.
- Kept unlock, rotate, backup, and profile functionality intact while clearing references to the deleted restore flow.

### Testing
- Ran a source search to verify removal of restore/reverification symbols (`rg` for restore-related identifiers), which confirmed no remaining matches in the modified file.
- Attempted a Playwright smoke capture to validate the UI, but the local dev server at `http://127.0.0.1:3000` did not respond (`ERR_EMPTY_RESPONSE`), so end-to-end UI verification could not complete.
- No typecheck or unit tests were executed in this environment due to missing dev server and dependencies.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_698d91cc629083329c67971e7ef5afd5)

## Summary by Sourcery

从个人资料解锁流程中移除基于备份的恢复路径，将加密解锁简化为只接受现有密码，并移除相关的恢复逻辑。

增强内容：
- 从用户头像按钮中删除离线“从备份恢复”的对话框和状态，包括“忘记加密密钥”的入口。
- 移除仅用于已废弃恢复流程的日历备份解析和恢复辅助工具，包括对 ICS、JSON 和 CSV 格式的支持。
- 移除不再使用的 Clerk 重新验证集成及相关状态，因为在个人资料解锁或恢复中已不再需要重新验证。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Remove the backup-based recovery path from the profile unlock flow, simplifying encryption unlock to only accept the existing password and dropping associated restore logic.

Enhancements:
- Delete the offline restore-from-backup dialogs and state from the user profile button, including the "forgot encryption key" entry point.
- Remove calendar backup parsing and restore helpers for ICS, JSON, and CSV formats that were only used by the deprecated restore flow.
- Drop unused Clerk reverification integration and related state now that reverification is no longer required for profile unlock or recovery.

</details>