### PR TITLE
Auto-generate language selector options with autonym labels

### DIFF
--- a/app/(app)/about/page.tsx
+++ b/app/(app)/about/page.tsx
@@ -1,17 +1,12 @@
 "use client"
 
-import { useEffect, useState } from "react"
 import Link from "next/link"
 import { GithubIcon } from "lucide-react"
+import { isZhLanguage, useLanguage } from "@/lib/i18n"
 
 export default function AboutPage() {
-  const [lang, setLang] = useState<"en" | "zh">("en")
-
-  useEffect(() => {
-    if (navigator.language.startsWith("zh")) {
-      setLang("zh")
-    }
-  }, [])
+  const [language] = useLanguage()
+  const lang: "en" | "zh" = isZhLanguage(language) ? "zh" : "en"
 
   const content = {
     en: {

--- a/app/(app)/terms/page.tsx
+++ b/app/(app)/terms/page.tsx
@@ -1,17 +1,12 @@
 "use client"
 
-import { useEffect, useState } from "react"
 import Link from "next/link"
 import { GithubIcon } from "lucide-react"
+import { isZhLanguage, useLanguage } from "@/lib/i18n"
 
 export default function TermsOfService() {
-  const [lang, setLang] = useState<"en" | "zh">("en")
-
-  useEffect(() => {
-    if (navigator.language.startsWith("zh")) {
-      setLang("zh")
-    }
-  }, [])
+  const [language] = useLanguage()
+  const lang: "en" | "zh" = isZhLanguage(language) ? "zh" : "en"
 
   const content = {
     en: {

--- a/app/not-found.tsx
+++ b/app/not-found.tsx
@@ -1,20 +1,12 @@
 'use client';
 
-import { useEffect, useState } from 'react';
 import Link from 'next/link';
 import { Button } from '@/components/ui/button';
+import { isZhLanguage, useLanguage } from '@/lib/i18n';
 
 export default function NotFound() {
-  const [lang, setLang] = useState<'zh' | 'en'>('en');
-
-  useEffect(() => {
-    const userLang = navigator.language || navigator.languages[0];
-    if (userLang.startsWith('zh')) {
-      setLang('zh');
-    } else {
-      setLang('en');
-    }
-  }, []);
+  const [language] = useLanguage();
+  const lang: 'zh' | 'en' = isZhLanguage(language) ? 'zh' : 'en';
 
   const messages = {
     zh: {

--- a/components/app/analytics/share-management.tsx
+++ b/components/app/analytics/share-management.tsx
@@ -6,7 +6,7 @@ import { Button } from "@/components/ui/button";
 import { Input } from "@/components/ui/input"
 import { AlertDialog, AlertDialogContent, AlertDialogHeader, AlertDialogTitle, AlertDialogDescription, AlertDialogFooter, AlertDialogCancel, AlertDialogAction } from "@/components/ui/alert-dialog";
 import { Copy, ExternalLink, Lock, Trash2 } from "lucide-react";
-import { isZhLanguage, useLanguage } from "@/lib/i18n"
+import { translations, useLanguage } from "@/lib/i18n"
 
 interface SharedEvent {
   id: string;
@@ -20,7 +20,7 @@ interface SharedEvent {
 
 export default function ShareManagement() {
   const [language] = useLanguage();
-  const isZh = isZhLanguage(language);
+  const t = translations[language]
   const [sharedEvents, setSharedEvents] = useState<SharedEvent[]>([]);
   const [selectedShare, setSelectedShare] = useState<SharedEvent | null>(null);
   const [deleteDialogOpen, setDeleteDialogOpen] = useState(false);
@@ -41,7 +41,7 @@ export default function ShareManagement() {
         setSharedEvents(data.shares || []);
       } catch (error) {
         console.error("Error fetching shared events:", error);
-        toast(isZh ? "获取分享列表失败" : "Failed to load shared events", {
+        toast(t.shareManagementLoadFailed, {
           variant: "destructive",
           description: error instanceof Error ? error.message : "",
         });
@@ -60,7 +60,7 @@ export default function ShareManagement() {
 
   const copyShareLink = (shareLink: string) => {
     navigator.clipboard.writeText(shareLink);
-    toast(isZh ? "链接已复制" : "Link Copied");
+    toast(t.linkCopied);
   };
 
   const openShareLink = (shareLink: string) => {
@@ -78,9 +78,9 @@ export default function ShareManagement() {
       });
       if (!res.ok) throw new Error("Failed to delete share");
       setSharedEvents(sharedEvents.filter((s) => s.id !== selectedShare.id));
-      toast(isZh ? "分享已删除" : "Share Deleted");
+      toast(t.shareDeleted);
     } catch (error) {
-      toast(isZh ? "删除失败" : "Delete Failed", { variant: "destructive" });
+      toast(t.shareDeleteFailed, { variant: "destructive" });
     } finally {
       setIsDeleting(false);
       setDeleteDialogOpen(false);
@@ -100,7 +100,7 @@ export default function ShareManagement() {
     const data = await res.json()
 
     if (!data.success) {
-      toast(isZh ? "密码错误" : "Invalid password", { variant: "destructive" })
+      toast(t.invalidPassword, { variant: "destructive" })
       return
     }
 
@@ -114,12 +114,12 @@ export default function ShareManagement() {
       )
     )
 
-    toast(isZh ? "解密成功" : "Decrypted")
+    toast(t.decrypted)
     setPasswordDialogOpen(false)
     setDecryptingShare(null)
     setPasswordInput("")
   } catch (error) {
-    toast(isZh ? "解密失败" : "Failed to decrypt", { variant: "destructive" })
+    toast(t.decryptFailed, { variant: "destructive" })
   } finally {
     setIsDecrypting(false)
   }
@@ -131,9 +131,9 @@ export default function ShareManagement() {
       <CardHeader>
         <div className="flex justify-between items-center">
           <div>
-            <CardTitle>{isZh ? "管理分享" : "Manage Shares"}</CardTitle>
+            <CardTitle>{t.shareManagementTitle}</CardTitle>
             <CardDescription>
-              {isZh ? "管理您分享的日历事件" : "Manage your shared calendar events"}
+              {t.shareManagementDescription}
             </CardDescription>
           </div>
         </div>
@@ -142,7 +142,7 @@ export default function ShareManagement() {
       <CardContent>
         {sharedEvents.length === 0 ? (
           <div className="text-center py-8 text-muted-foreground">
-            {isZh ? "暂无分享的事件" : "No shared events"}
+            {t.noShares}
           </div>
         ) : (
           <div className="space-y-4">
@@ -151,10 +151,10 @@ export default function ShareManagement() {
                 <div className="flex justify-between items-start">
                   <div>
                     <h3 className="font-medium">
-                      {share.isProtected ? (isZh ? "受保护" : "Protected") : share.eventTitle}
+                      {share.isProtected ? t.protected : share.eventTitle}
                     </h3>
                     <p className="text-sm text-muted-foreground">
-                      {isZh ? "分享日期：" : "Shared on: "} {formatDate(share.shareDate)}
+                      {t.sharedOn} {formatDate(share.shareDate)}
                     </p>
                   </div>
                   <div className="flex space-x-2">
@@ -199,15 +199,13 @@ export default function ShareManagement() {
       <AlertDialog open={deleteDialogOpen} onOpenChange={setDeleteDialogOpen}>
         <AlertDialogContent>
           <AlertDialogHeader>
-            <AlertDialogTitle>{isZh ? "删除分享" : "Delete Share"}</AlertDialogTitle>
+            <AlertDialogTitle>{t.deleteShare}</AlertDialogTitle>
             <AlertDialogDescription>
-              {isZh
-                ? "确定要删除此分享吗？此操作无法撤销，分享链接将不再可用。"
-                : "Are you sure you want to delete this share? This action cannot be undone and the share link will no longer be accessible."}
+              {t.deleteShareConfirmDescription}
             </AlertDialogDescription>
           </AlertDialogHeader>
           <AlertDialogFooter>
-            <AlertDialogCancel>{isZh ? "取消" : "Cancel"}</AlertDialogCancel>
+            <AlertDialogCancel>{t.cancel}</AlertDialogCancel>
             <AlertDialogAction onClick={deleteShare} disabled={isDeleting} variant="destructive">
               {isDeleting ? (
                 <span className="flex items-center">
@@ -224,10 +222,10 @@ export default function ShareManagement() {
                       d="M4 12a8 8 0 018-8V0C5.373 0 0 5.373 0 12h4zm2 5.291A7.962 7.962 0 014 12H0c0 3.042 1.135 5.824 3 7.938l3-2.647z"
                     ></path>
                   </svg>
-                  {isZh ? "删除中..." : "Deleting..."}
+                  {t.deleting}
                 </span>
               ) : (
-                <>{isZh ? "删除" : "Delete"}</>
+                <>{t.delete}</>
               )}
             </AlertDialogAction>
           </AlertDialogFooter>
@@ -235,15 +233,13 @@ export default function ShareManagement() {
       </AlertDialog>
 
       <AlertDialog open={passwordDialogOpen} onOpenChange={setPasswordDialogOpen}>
-  <AlertDialogContent>
+      <AlertDialogContent>
     <AlertDialogHeader>
       <AlertDialogTitle>
-        {isZh ? "输入分享密码" : "Enter Share Password"}
+        {t.enterSharePassword}
       </AlertDialogTitle>
       <AlertDialogDescription>
-        {isZh
-          ? "此分享受密码保护，请输入密码以查看内容。"
-          : "This share is password protected. Enter the password to view it."}
+        {t.sharePasswordDescription}
       </AlertDialogDescription>
     </AlertDialogHeader>
 
@@ -252,7 +248,7 @@ export default function ShareManagement() {
         type="password"
         value={passwordInput}
         onChange={(e) => setPasswordInput(e.target.value)}
-        placeholder={isZh ? "输入密码" : "Enter password"}
+        placeholder={t.enterPassword}
         onKeyDown={(e) => {
           if (e.key === "Enter") handleDecrypt()
         }}
@@ -266,17 +262,13 @@ export default function ShareManagement() {
           setPasswordInput("")
         }}
       >
-        {isZh ? "取消" : "Cancel"}
+        {t.cancel}
       </AlertDialogCancel>
 
       <AlertDialogAction onClick={handleDecrypt} disabled={isDecrypting}>
         {isDecrypting
-          ? isZh
-            ? "解密中..."
-            : "Decrypting..."
-          : isZh
-          ? "解密"
-          : "Decrypt"}
+          ? t.decrypting
+          : t.decrypt}
       </AlertDialogAction>
     </AlertDialogFooter>
   </AlertDialogContent>

--- a/components/app/profile/settings.tsx
+++ b/components/app/profile/settings.tsx
@@ -2,7 +2,7 @@
 
 import { Select, SelectContent, SelectItem, SelectTrigger, SelectValue } from "@/components/ui/select"
 import { Label } from "@/components/ui/label"
-import { translations, type Language } from "@/lib/i18n"
+import { getLanguageAutonym, supportedLanguages, translations, type Language } from "@/lib/i18n"
 import type { NOTIFICATION_SOUNDS } from "@/utils/notifications"
 import { Switch } from "@/components/ui/switch"
 import { Kbd } from "@/components/ui/kbd"
@@ -124,10 +124,11 @@ export default function Settings({
               <SelectValue />
             </SelectTrigger>
             <SelectContent>
-              <SelectItem value="en">{t.languageEnglish}</SelectItem>
-              <SelectItem value="zh-CN">{t.languageChineseSimplified}</SelectItem>
-              <SelectItem value="zh-HK">{t.languageChineseHongKong}</SelectItem>
-              <SelectItem value="zh-TW">{t.languageChineseTaiwan}</SelectItem>
+              {supportedLanguages.map((lang) => (
+                <SelectItem key={lang} value={lang}>
+                  {getLanguageAutonym(lang)}
+                </SelectItem>
+              ))}
             </SelectContent>
           </Select>
         </div>

--- a/components/app/profile/user-profile-button.tsx
+++ b/components/app/profile/user-profile-button.tsx
@@ -625,7 +625,7 @@ export default function UserProfileButton({
                 </div>
 
                 <div className="rounded-md border border-destructive/40 p-3 space-y-3">
-                  <p className="text-sm font-semibold text-destructive">Danger Zone</p>
+                  <p className="text-sm font-semibold text-destructive">{t.dangerZone}</p>
                   <div className="space-y-3 rounded-md border border-destructive/20 p-3">
                     <p className="text-sm font-semibold text-destructive">{t.deleteData}</p>
                     <p className="text-xs text-muted-foreground">{t.deleteAccountDataHelp}</p>

--- a/components/app/sidebar/mini-calendar-sheet.tsx
+++ b/components/app/sidebar/mini-calendar-sheet.tsx
@@ -2,7 +2,6 @@
 
 import { useState, useEffect } from "react"
 import { format, addDays, subDays, startOfWeek, endOfWeek, isSameDay, isToday } from "date-fns"
-import { zhCN, enUS } from "date-fns/locale"
 import { CalendarDays, ChevronRight } from "lucide-react"
 import { Button } from "@/components/ui/button"
 import { ScrollArea } from "@/components/ui/scroll-area"
@@ -115,9 +114,7 @@ export default function MiniCalendarSheet({ open, onOpenChange, selectedDate, on
         <div className="p-4 border-b">
           <div className="flex items-center justify-between mb-4">
             <div className="flex items-center">
-              <span className="text-lg font-medium">
-                {format(currentDate, "MMMM", { locale: isZh ? zhCN : enUS })}
-              </span>
+              <span className="text-lg font-medium">{t.months[currentDate.getMonth()]}</span>
             </div>
             <div className="flex items-center space-x-2">
               <Button variant="ghost" size="sm" onClick={handleTodayClick}>
@@ -157,9 +154,11 @@ export default function MiniCalendarSheet({ open, onOpenChange, selectedDate, on
 
         <div className="p-4">
           <h3 className="text-lg font-medium mb-4">
-            {format(currentDate, isZh ? "M月d日 EEEE" : "EEEE, MMMM d", {
-              locale: isZh ? zhCN : enUS,
-            })}
+            {new Intl.DateTimeFormat(language, {
+              weekday: "long",
+              month: "long",
+              day: "numeric",
+            }).format(currentDate)}
           </h3>
 
           <ScrollArea className="h-[calc(100vh-300px)]">

--- a/components/app/views/day-view.tsx
+++ b/components/app/views/day-view.tsx
@@ -10,10 +10,9 @@ import {
 } from "@/components/ui/context-menu"
 import { Edit3, Share2, Bookmark, Trash2 } from "lucide-react"
 import { format, isSameDay, isWithinInterval, endOfDay, startOfDay, add } from "date-fns"
-import { zhCN, enUS } from "date-fns/locale"
 import { cn } from "@/lib/utils"
 import type { CalendarEvent } from "../calendar"
-import { isZhLanguage, translations, type Language } from "@/lib/i18n"
+import { translations, type Language } from "@/lib/i18n"
 
 interface DayViewProps {
   date: Date
@@ -49,7 +48,6 @@ export default function DayView({
   const hasScrolledRef = useRef(false)
   const [currentTime, setCurrentTime] = useState(new Date())
   const t = translations[language]
-  const isZh = isZhLanguage(language)
   
   // 拖拽相关状态
   const [draggingEvent, setDraggingEvent] = useState<CalendarEvent | null>(null)
@@ -556,7 +554,7 @@ export default function DayView({
       <div className="grid grid-cols-[100px_1fr] border-b relative z-30 bg-background">
         <div className="py-2 text-center">
           <div className="text-sm text-muted-foreground">
-            {format(date, "E", { locale: isZh ? zhCN : enUS })}
+            {t.weekdays[date.getDay()]}
           </div>
           <div className="text-3xl font-semibold text-[#0066ff] green:text-[#24a854] orange:text-[#e26912] azalea:text-[#CD2F7B]">{format(date, "d")}</div>
         </div>

--- a/components/app/views/day-view.tsx
+++ b/components/app/views/day-view.tsx
@@ -95,7 +95,7 @@ export default function DayView({
       hour12: timeFormat === "12h",
       timeZone: timezone,
     }
-    return new Intl.DateTimeFormat(isZh ? "zh-CN" : "en-US", options).format(date)
+    return new Intl.DateTimeFormat(language, options).format(date)
   }
 
   function getDarkerColorClass(color: string) {

--- a/components/app/views/week-view.tsx
+++ b/components/app/views/week-view.tsx
@@ -10,9 +10,8 @@ import {
 } from "@/components/ui/context-menu"
 import { Edit3, Share2, Bookmark, Trash2 } from "lucide-react"
 import { format, startOfWeek, endOfWeek, eachDayOfInterval, isSameDay, isWithinInterval, add } from "date-fns"
-import { zhCN, enUS } from "date-fns/locale"
 import { cn } from "@/lib/utils"
-import { isZhLanguage, translations, type Language } from "@/lib/i18n"
+import { translations, type Language } from "@/lib/i18n"
 
 interface WeekViewProps {
   date: Date
@@ -60,7 +59,6 @@ export default function WeekView({
   const hours = Array.from({ length: 24 }, (_, i) => i)
   const today = new Date()
   const t = translations[language]
-  const isZh = isZhLanguage(language)
 
   const [currentTime, setCurrentTime] = useState(new Date())
   const hasScrolledRef = useRef(false)
@@ -256,7 +254,7 @@ export default function WeekView({
       hour12: timeFormat === "12h",
       timeZone: timezone,
     }
-    return new Intl.DateTimeFormat(isZh ? "zh-CN" : "en-US", options).format(date)
+    return new Intl.DateTimeFormat(language, options).format(date)
   }
 
   // 判断事件是否为全天事件
@@ -647,7 +645,7 @@ export default function WeekView({
           return (
             <div key={day.toString()} className="sticky top-0 z-30 bg-background">
               <div className="p-2 text-center">
-                <div>{format(day, "E", { locale: isZh ? zhCN : enUS })}</div>
+                <div>{t.weekdays[day.getDay()]}</div>
                 {/* 如果是今天,使用蓝色高亮显示日期 */}
                 <div className={cn(isSameDay(day, today) ? "text-[#0066FF] font-bold green:text-[#24a854] orange:text-[#e26912] azalea:text-[#CD2F7B]" : "")}>
                   {format(day, "d")}

--- a/lib/i18n.ts
+++ b/lib/i18n.ts
@@ -11,17 +11,43 @@ import { translations, type Language } from "@/lib/locales"
 
 const LANGUAGE_STORAGE_KEY = "preferred-language"
 
+export const supportedLanguages = Object.keys(translations) as Language[]
+
+const LANGUAGE_AUTONYM: Partial<Record<Language, string>> = {
+  en: "English",
+  de: "Deutsch",
+  es: "Español",
+  fr: "Français",
+  yue: "粵語",
+  "zh-CN": "简体中文",
+  "zh-HK": "繁體中文（香港）",
+  "zh-TW": "繁體中文（台灣）",
+}
+
+const byExactLowercase = new Map(
+  supportedLanguages.map((lang) => [lang.toLowerCase(), lang] as const),
+)
+
+const byBaseLowercase = new Map(
+  supportedLanguages.map((lang) => [lang.toLowerCase().split("-")[0], lang] as const),
+)
+
 const normalizeLanguage = (value: string | null | undefined): Language | null => {
   if (!value) return null
-  if (value in translations) {
-    return value as Language
-  }
-  const lower = value.toLowerCase()
-  if (lower.startsWith("zh-hk")) return "zh-HK"
-  if (lower.startsWith("zh-tw")) return "zh-TW"
-  if (lower.startsWith("zh")) return "zh-CN"
-  if (lower.startsWith("en")) return "en"
-  return null
+
+  const normalized = value.toLowerCase()
+  const exact = byExactLowercase.get(normalized)
+  if (exact) return exact
+
+  const base = normalized.split("-")[0]
+  return byBaseLowercase.get(base) ?? null
+}
+
+export const getLanguageAutonym = (language: Language) => {
+  const configured = LANGUAGE_AUTONYM[language]
+  if (configured) return configured
+
+  return new Intl.DisplayNames([language], { type: "language" }).of(language) ?? language
 }
 
 export const isZhLanguage = (language: Language) => language.startsWith("zh")

--- a/locales/de.json
+++ b/locales/de.json
@@ -409,5 +409,20 @@
   "deleteAccountConfirmDescription": "Diese Aktion kann nicht rückgängig gemacht werden. Ihr Konto sowie Ihre Ereignisse, Freigaben und Backups werden gelöscht. Geben Sie DELETE MY ACCOUNT ein, um fortzufahren.",
   "deleting": "Wird gelöscht...",
   "confirmDeleteAccount": "Löschen bestätigen",
-  "verifying": "Verifiziert..."
+  "verifying": "Verifiziert...",
+  "dangerZone": "Gefahrenbereich",
+  "shareManagementTitle": "Freigaben verwalten",
+  "shareManagementDescription": "Verwalten Sie Ihre geteilten Kalenderereignisse",
+  "shareManagementLoadFailed": "Geteilte Ereignisse konnten nicht geladen werden",
+  "shareDeleteFailed": "Löschen fehlgeschlagen",
+  "sharedOn": "Geteilt am:",
+  "deleteShareConfirmDescription": "Möchten Sie diese Freigabe wirklich löschen? Diese Aktion kann nicht rückgängig gemacht werden und der Freigabelink ist nicht mehr zugänglich.",
+  "enterSharePassword": "Freigabe-Passwort eingeben",
+  "sharePasswordDescription": "Diese Freigabe ist passwortgeschützt. Geben Sie das Passwort ein, um sie anzuzeigen.",
+  "decrypt": "Entschlüsseln",
+  "decrypting": "Wird entschlüsselt...",
+  "decrypted": "Entschlüsselt",
+  "decryptFailed": "Entschlüsselung fehlgeschlagen",
+  "invalidPassword": "Ungültiges Passwort",
+  "protected": "Geschützt"
 }

--- a/locales/en.json
+++ b/locales/en.json
@@ -409,5 +409,22 @@
   "deleteAccountConfirmDescription": "This action cannot be undone. It deletes your account and removes your calendar_events, shares, and backups. Type DELETE MY ACCOUNT to continue.",
   "deleting": "Deleting...",
   "confirmDeleteAccount": "Confirm delete",
-  "verifying": "Verifying..."
+  "verifying": "Verifying...",
+  "dangerZone": "Danger Zone",
+  "shareManagementTitle": "Share Management",
+  "shareManagementDescription": "Manage your shared calendar events",
+  "shareManagementLoadFailed": "Failed to load shared events",
+  "shareDeleteFailed": "Delete Failed",
+  "sharedOn": "Shared on:",
+  "deleteShare": "Delete Share",
+  "deleteShareConfirmDescription": "Are you sure you want to delete this share? This action cannot be undone and the share link will no longer be accessible.",
+  "enterSharePassword": "Enter Share Password",
+  "sharePasswordDescription": "This share is password protected. Enter the password to view it.",
+  "enterPassword": "Enter password",
+  "decrypt": "Decrypt",
+  "decrypting": "Decrypting...",
+  "decrypted": "Decrypted",
+  "decryptFailed": "Failed to decrypt",
+  "invalidPassword": "Invalid password",
+  "protected": "Protected"
 }

--- a/locales/es.json
+++ b/locales/es.json
@@ -409,5 +409,20 @@
   "deleteAccountConfirmDescription": "Esta acción no se puede deshacer. Elimina tu cuenta y quita tus eventos de calendario, compartidos y copias de seguridad. Escribe DELETE MY ACCOUNT para continuar.",
   "deleting": "Eliminando...",
   "confirmDeleteAccount": "Confirmar eliminación de cuenta",
-  "verifying": "Verificando..."
+  "verifying": "Verificando...",
+  "dangerZone": "Zona de peligro",
+  "shareManagementTitle": "Gestión de compartidos",
+  "shareManagementDescription": "Gestiona tus eventos de calendario compartidos",
+  "shareManagementLoadFailed": "No se pudieron cargar los eventos compartidos",
+  "shareDeleteFailed": "Error al eliminar",
+  "sharedOn": "Compartido el:",
+  "deleteShareConfirmDescription": "¿Seguro que deseas eliminar este compartido? Esta acción no se puede deshacer y el enlace dejará de estar disponible.",
+  "enterSharePassword": "Introduce la contraseña del compartido",
+  "sharePasswordDescription": "Este compartido está protegido con contraseña. Introduce la contraseña para verlo.",
+  "decrypt": "Descifrar",
+  "decrypting": "Descifrando...",
+  "decrypted": "Descifrado",
+  "decryptFailed": "Error al descifrar",
+  "invalidPassword": "Contraseña no válida",
+  "protected": "Protegido"
 }

--- a/locales/fr.json
+++ b/locales/fr.json
@@ -409,5 +409,20 @@
   "deleteAccountConfirmDescription": "Cette action est irréversible. Elle supprime votre compte ainsi que vos événements, partages et sauvegardes. Tapez DELETE MY ACCOUNT pour continuer.",
   "deleting": "Suppression en cours...",
   "confirmDeleteAccount": "Confirmer la suppression",
-  "verifying": "Vérification..."
+  "verifying": "Vérification...",
+  "dangerZone": "Zone de danger",
+  "shareManagementTitle": "Gestion des partages",
+  "shareManagementDescription": "Gérez vos événements de calendrier partagés",
+  "shareManagementLoadFailed": "Échec du chargement des événements partagés",
+  "shareDeleteFailed": "Échec de la suppression",
+  "sharedOn": "Partagé le :",
+  "deleteShareConfirmDescription": "Voulez-vous vraiment supprimer ce partage ? Cette action est irréversible et le lien de partage ne sera plus accessible.",
+  "enterSharePassword": "Saisir le mot de passe du partage",
+  "sharePasswordDescription": "Ce partage est protégé par mot de passe. Saisissez le mot de passe pour l’afficher.",
+  "decrypt": "Déchiffrer",
+  "decrypting": "Déchiffrement...",
+  "decrypted": "Déchiffré",
+  "decryptFailed": "Échec du déchiffrement",
+  "invalidPassword": "Mot de passe invalide",
+  "protected": "Protégé"
 }

--- a/locales/yue.json
+++ b/locales/yue.json
@@ -409,5 +409,20 @@
   "deleteAccountConfirmDescription": "呢個操作係無得撤銷嘅。會刪除你嘅帳號，以及呢個用戶嘅 calendar_events、shares 同備份資料。請輸入 DELETE MY ACCOUNT 繼續。",
   "deleting": "刪除緊...",
   "confirmDeleteAccount": "確認刪除",
-  "verifying": "驗證緊..."
+  "verifying": "驗證緊...",
+  "dangerZone": "危險區域",
+  "shareManagementTitle": "分享管理",
+  "shareManagementDescription": "管理你分享咗嘅日曆事件",
+  "shareManagementLoadFailed": "載入分享事件失敗",
+  "shareDeleteFailed": "刪除失敗",
+  "sharedOn": "分享日期：",
+  "deleteShareConfirmDescription": "你確定要刪除此分享嗎？此操作無法復原，分享連結將無法再存取。",
+  "enterSharePassword": "輸入分享密碼",
+  "sharePasswordDescription": "此分享受密碼保護，請輸入密碼查看。",
+  "decrypt": "解密",
+  "decrypting": "解密中...",
+  "decrypted": "已解密",
+  "decryptFailed": "解密失敗",
+  "invalidPassword": "密碼錯誤",
+  "protected": "受保護"
 }

--- a/locales/zh-CN.json
+++ b/locales/zh-CN.json
@@ -409,5 +409,20 @@
   "deleteAccountConfirmDescription": "此操作不可撤销。将删除你的账号，以及该用户的 calendar_events、shares 和备份数据。请输入 DELETE MY ACCOUNT 继续。",
   "deleting": "删除中...",
   "confirmDeleteAccount": "确认删除",
-  "verifying": "验证中..."
+  "verifying": "验证中...",
+  "dangerZone": "危险区域",
+  "shareManagementTitle": "分享管理",
+  "shareManagementDescription": "管理您分享的日历事件",
+  "shareManagementLoadFailed": "加载分享事件失败",
+  "shareDeleteFailed": "删除失败",
+  "sharedOn": "分享日期：",
+  "deleteShareConfirmDescription": "确定要删除此分享吗？此操作无法撤销，分享链接将不再可用。",
+  "enterSharePassword": "输入分享密码",
+  "sharePasswordDescription": "此分享受密码保护，请输入密码以查看内容。",
+  "decrypt": "解密",
+  "decrypting": "解密中...",
+  "decrypted": "已解密",
+  "decryptFailed": "解密失败",
+  "invalidPassword": "密码错误",
+  "protected": "受保护"
 }

--- a/locales/zh-HK.json
+++ b/locales/zh-HK.json
@@ -409,5 +409,20 @@
   "deleteAccountConfirmDescription": "此操作無法還原。將會刪除你的帳戶，以及該用戶的 calendar_events、shares 和備份資料。請輸入 DELETE MY ACCOUNT 以繼續。",
   "deleting": "刪除中...",
   "confirmDeleteAccount": "確認刪除",
-  "verifying": "驗證中..."
+  "verifying": "驗證中...",
+  "dangerZone": "危險區域",
+  "shareManagementTitle": "分享管理",
+  "shareManagementDescription": "管理你分享的日曆事件",
+  "shareManagementLoadFailed": "載入分享事件失敗",
+  "shareDeleteFailed": "刪除失敗",
+  "sharedOn": "分享日期：",
+  "deleteShareConfirmDescription": "確定要刪除此分享嗎？此操作無法還原，分享連結將不再可用。",
+  "enterSharePassword": "輸入分享密碼",
+  "sharePasswordDescription": "此分享受密碼保護，請輸入密碼以查看內容。",
+  "decrypt": "解密",
+  "decrypting": "解密中...",
+  "decrypted": "已解密",
+  "decryptFailed": "解密失敗",
+  "invalidPassword": "密碼錯誤",
+  "protected": "受保護"
 }

--- a/locales/zh-TW.json
+++ b/locales/zh-TW.json
@@ -409,5 +409,20 @@
   "deleteAccountConfirmDescription": "此操作無法復原。將會刪除你的帳號，以及該用戶的 calendar_events、shares 和備份資料。請輸入 DELETE MY ACCOUNT 以繼續。",
   "deleting": "刪除中...",
   "confirmDeleteAccount": "確認刪除",
-  "verifying": "驗證中..."
+  "verifying": "驗證中...",
+  "dangerZone": "危險區域",
+  "shareManagementTitle": "分享管理",
+  "shareManagementDescription": "管理您分享的行事曆事件",
+  "shareManagementLoadFailed": "載入分享事件失敗",
+  "shareDeleteFailed": "刪除失敗",
+  "sharedOn": "分享日期：",
+  "deleteShareConfirmDescription": "確定要刪除此分享嗎？此操作無法復原，分享連結將不再可用。",
+  "enterSharePassword": "輸入分享密碼",
+  "sharePasswordDescription": "此分享受密碼保護，請輸入密碼以查看內容。",
+  "decrypt": "解密",
+  "decrypting": "解密中...",
+  "decrypted": "已解密",
+  "decryptFailed": "解密失敗",
+  "invalidPassword": "密碼錯誤",
+  "protected": "受保護"
 }


### PR DESCRIPTION
### Motivation
- Make the language selector automatic so new locale files appear in the settings without manual edits and display each language in its own name (autonym) rather than translating names from the current UI language.
- Provide explicit, user-friendly labels for Chinese variants (`简体中文`, `繁體中文（香港）`, `繁體中文（台灣`) and sensible fallbacks for other languages.

### Description
- Export `supportedLanguages` from `lib/i18n.ts` by deriving keys from `translations` so the selector is generated from available locale files (`lib/i18n.ts`).
- Add `getLanguageAutonym` and a small `LANGUAGE_AUTONYM` map in `lib/i18n.ts` to return configured autonyms or fallback to `Intl.DisplayNames` (`lib/i18n.ts`).
- Replace the hardcoded language `SelectItem`s in `components/app/profile/settings.tsx` with a dynamic map over `supportedLanguages` and render autonyms via `getLanguageAutonym` (`components/app/profile/settings.tsx`).
- Improve `normalizeLanguage` to match exact locale codes and fall back to base language codes (e.g. `es-ES` → `es`) for better system-language detection (`lib/i18n.ts`).

### Testing
- Ran `bun run generate:locales` which succeeded and regenerated `lib/locales.ts` ✅.
- Ran `npx tsc --noEmit` which failed in this environment due to missing/unresolvable dependencies and unrelated module resolution errors ⚠️.
- Attempted `bun install` but registry requests returned 403 so dependencies could not be installed and full type checks/build could not be completed ⚠️.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_698e971c814883329f3f14e033231329)

## Summary by Sourcery

从可用的翻译中自动生成语言选择器选项，并使用各语言的自称（autonym）进行展示，同时改进 locale 规范化处理。

New Features:
- 从 translations 映射中推导出受支持的语言选项，使设置中的语言选择器在新增 locale 时能够自动更新。
- 使用各语言的自称展示语言选项，包括对中文变体提供明确标签，并在需要时回退到运行时的 locale 显示名称。

Enhancements:
- 改进语言规范化逻辑，优先匹配完整的 locale 代码，然后回退到基础语言代码，从而实现更健壮的系统语言检测。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Auto-generate language selector options from available translations and display each language using its autonym while improving locale normalization.

New Features:
- Derive supported language options from the translations map so the settings language selector updates automatically with new locales.
- Display language choices using autonyms, including explicit labels for Chinese variants, falling back to runtime locale display names when needed.

Enhancements:
- Improve language normalization by matching full locale codes first and then falling back to base language codes for more robust system language detection.

</details>