### PR TITLE
small change

### DIFF
--- a/app/api/share/auth/route.ts
+++ b/app/api/share/auth/route.ts
@@ -1,0 +1,64 @@
+import { NextRequest, NextResponse } from "next/server";
+import {
+  createShareAccessToken,
+  decryptWithKey,
+  initializeShareDatabase,
+  isValidSha256Hex,
+  keyV3Password,
+  withShareClient,
+} from "@/lib/server/share-security";
+
+export async function POST(request: NextRequest) {
+  try {
+    const body = await request.json();
+    const { id, passwordHash } = body as { id?: string; passwordHash?: string };
+
+    if (!id || !passwordHash) {
+      return NextResponse.json({ error: "Missing required fields" }, { status: 400 });
+    }
+
+    if (!isValidSha256Hex(passwordHash)) {
+      return NextResponse.json({ error: "Invalid hash format" }, { status: 400 });
+    }
+
+    await initializeShareDatabase();
+
+    return await withShareClient(async (client) => {
+      const result = await client.query(
+        "SELECT encrypted_data, iv, auth_tag, is_protected FROM shares WHERE share_id = $1",
+        [id],
+      );
+
+      if (!result.rows.length) {
+        return NextResponse.json({ error: "Share not found" }, { status: 404 });
+      }
+
+      const row = result.rows[0] as {
+        encrypted_data: string;
+        iv: string;
+        auth_tag: string;
+        is_protected: boolean;
+      };
+
+      if (!row.is_protected) {
+        return NextResponse.json({ error: "Share is not password protected" }, { status: 400 });
+      }
+
+      try {
+        decryptWithKey(row.encrypted_data, row.iv, row.auth_tag, keyV3Password(passwordHash, id));
+      } catch {
+        return NextResponse.json({ error: "Invalid key hash" }, { status: 403 });
+      }
+
+      const token = createShareAccessToken(id, passwordHash);
+      return NextResponse.json({ success: true, token, expiresIn: 60 * 60 * 24 });
+    });
+  } catch (error) {
+    return NextResponse.json(
+      {
+        error: error instanceof Error ? error.message : "Unknown error occurred",
+      },
+      { status: 500 },
+    );
+  }
+}

--- a/app/api/share/content/route.ts
+++ b/app/api/share/content/route.ts
@@ -1,0 +1,98 @@
+import { NextRequest, NextResponse } from "next/server";
+import {
+  decryptWithKey,
+  initializeShareDatabase,
+  keyV3Password,
+  verifyShareAccessToken,
+  withShareClient,
+} from "@/lib/server/share-security";
+
+function getBearerToken(request: NextRequest) {
+  const auth = request.headers.get("authorization");
+  if (!auth?.startsWith("Bearer ")) return null;
+  return auth.slice(7).trim();
+}
+
+export async function GET(request: NextRequest) {
+  const id = request.nextUrl.searchParams.get("id");
+  const token = getBearerToken(request);
+
+  if (!id) {
+    return NextResponse.json({ error: "Missing share ID" }, { status: 400 });
+  }
+
+  if (!token) {
+    return NextResponse.json({ error: "Missing token" }, { status: 401 });
+  }
+
+  try {
+    const payload = verifyShareAccessToken(token);
+    if (!payload || payload.sid !== id) {
+      return NextResponse.json({ error: "Invalid or expired token" }, { status: 401 });
+    }
+
+    await initializeShareDatabase();
+
+    return await withShareClient(async (client) => {
+      await client.query("BEGIN");
+
+      try {
+        const result = await client.query(
+          "SELECT encrypted_data, iv, auth_tag, timestamp, is_protected, is_burn FROM shares WHERE share_id = $1 FOR UPDATE",
+          [id],
+        );
+
+        if (!result.rows.length) {
+          await client.query("ROLLBACK");
+          return NextResponse.json({ error: "Share not found" }, { status: 404 });
+        }
+
+        const row = result.rows[0] as {
+          encrypted_data: string;
+          iv: string;
+          auth_tag: string;
+          timestamp: Date;
+          is_protected: boolean;
+          is_burn: boolean;
+        };
+
+        if (!row.is_protected) {
+          await client.query("ROLLBACK");
+          return NextResponse.json({ error: "Share is not password protected" }, { status: 400 });
+        }
+
+        let decryptedData: string;
+        try {
+          decryptedData = decryptWithKey(row.encrypted_data, row.iv, row.auth_tag, keyV3Password(payload.ph, id));
+        } catch {
+          await client.query("ROLLBACK");
+          return NextResponse.json({ error: "Token no longer valid for share" }, { status: 401 });
+        }
+
+        if (row.is_burn) {
+          await client.query("DELETE FROM shares WHERE share_id = $1", [id]);
+        }
+
+        await client.query("COMMIT");
+
+        return NextResponse.json({
+          success: true,
+          data: decryptedData,
+          timestamp: row.timestamp.toISOString(),
+          protected: true,
+          burnAfterRead: row.is_burn,
+        });
+      } catch (e) {
+        await client.query("ROLLBACK");
+        throw e;
+      }
+    });
+  } catch (error) {
+    return NextResponse.json(
+      {
+        error: error instanceof Error ? error.message : "Unknown error occurred",
+      },
+      { status: 500 },
+    );
+  }
+}

--- a/app/api/share/route.ts
+++ b/app/api/share/route.ts
@@ -1,87 +1,27 @@
 import { type NextRequest, NextResponse } from "next/server";
 import { currentUser } from "@clerk/nextjs/server";
-import { Pool } from "pg";
-import crypto from "crypto";
-
-const pool = new Pool({
-  connectionString: process.env.POSTGRES_URL,
-  ssl: { rejectUnauthorized: false },
-});
-
-async function initializeDatabase() {
-  const client = await pool.connect();
-  try {
-    await client.query(`
-      CREATE TABLE IF NOT EXISTS shares (
-        id SERIAL PRIMARY KEY,
-        user_id TEXT NOT NULL,
-        share_id VARCHAR(255) NOT NULL,
-        encrypted_data TEXT NOT NULL,
-        iv TEXT NOT NULL,
-        auth_tag TEXT NOT NULL,
-        timestamp TIMESTAMP NOT NULL,
-        is_protected BOOLEAN DEFAULT FALSE,
-        is_burn BOOLEAN DEFAULT FALSE,
-        enc_version INTEGER,
-        UNIQUE(share_id)
-      )
-    `);
-    await client.query(`ALTER TABLE shares ADD COLUMN IF NOT EXISTS user_id TEXT`);
-    await client.query(`ALTER TABLE shares ADD COLUMN IF NOT EXISTS is_protected BOOLEAN DEFAULT FALSE`);
-    await client.query(`ALTER TABLE shares ADD COLUMN IF NOT EXISTS is_burn BOOLEAN DEFAULT FALSE`);
-    await client.query(`ALTER TABLE shares ADD COLUMN IF NOT EXISTS enc_version INTEGER`);
-    await client.query(`UPDATE shares SET enc_version = 1 WHERE enc_version IS NULL`);
-    await client.query(`CREATE INDEX IF NOT EXISTS idx_shares_user_id ON shares(user_id)`);
-  } finally {
-    client.release();
-  }
-}
-
-const ALGORITHM = "aes-256-gcm";
-
-function keyV2Unprotected(shareId: string) {
-  return crypto.createHash("sha256").update(shareId, "utf8").digest();
-}
-
-function keyV3Password(password: string, shareId: string) {
-  return crypto.scryptSync(password, shareId, 32);
-}
-
-function keyV1Legacy(shareId: string) {
-  const salt = process.env.SALT;
-  if (!salt) throw new Error("SALT environment variable is not set");
-  return crypto.scryptSync(shareId, salt, 32);
-}
-
-function encryptWithKey(data: string, key: Buffer): { encryptedData: string; iv: string; authTag: string } {
-  const iv = crypto.randomBytes(16);
-  const cipher = crypto.createCipheriv(ALGORITHM, key, iv);
-  let encrypted = cipher.update(data, "utf8", "hex");
-  encrypted += cipher.final("hex");
-  const authTag = cipher.getAuthTag();
-  return { encryptedData: encrypted, iv: iv.toString("hex"), authTag: authTag.toString("hex") };
-}
-
-function decryptWithKey(encryptedData: string, iv: string, authTag: string, key: Buffer): string {
-  const ivBuffer = Buffer.from(iv, "hex");
-  const authTagBuffer = Buffer.from(authTag, "hex");
-  const decipher = crypto.createDecipheriv(ALGORITHM, key, ivBuffer);
-  decipher.setAuthTag(authTagBuffer);
-  let decrypted = decipher.update(encryptedData, "hex", "utf8");
-  decrypted += decipher.final("utf8");
-  return decrypted;
-}
+import {
+  decryptWithKey,
+  encryptWithKey,
+  initializeShareDatabase,
+  isValidSha256Hex,
+  keyV1Legacy,
+  keyV2Unprotected,
+  keyV3Password,
+  withShareClient,
+} from "@/lib/server/share-security";
 
 export async function POST(request: NextRequest) {
   try {
-    const user = await currentUser()
+    const user = await currentUser();
     if (!user) {
       return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
     }
+
     const body = await request.json();
     const { id, data, password, burnAfterRead } = body as {
       id?: string;
-      data?: any;
+      data?: unknown;
       password?: string;
       burnAfterRead?: boolean;
     };
@@ -93,22 +33,24 @@ export async function POST(request: NextRequest) {
     const hasPassword = typeof password === "string" && password.length > 0;
     const burn = !!burnAfterRead;
 
+    if (hasPassword && !isValidSha256Hex(password)) {
+      return NextResponse.json({ error: "Password must be SHA-256 hash" }, { status: 400 });
+    }
+
     if (burn && !hasPassword) {
       return NextResponse.json({ error: "burnAfterRead requires password protection" }, { status: 400 });
     }
 
-    const POSTGRES_URL = process.env.POSTGRES_URL;
-    if (!POSTGRES_URL) throw new Error("POSTGRES_URL is not set");
+    if (!process.env.POSTGRES_URL) throw new Error("POSTGRES_URL is not set");
 
-    await initializeDatabase();
+    await initializeShareDatabase();
 
     const dataString = typeof data === "string" ? data : JSON.stringify(data);
     const encVersion = hasPassword ? 3 : 2;
     const key = hasPassword ? keyV3Password(password as string, id) : keyV2Unprotected(id);
     const { encryptedData, iv, authTag } = encryptWithKey(dataString, key);
 
-    const client = await pool.connect();
-    try {
+    await withShareClient(async (client) => {
       await client.query(
         `
         INSERT INTO shares (user_id, share_id, encrypted_data, iv, auth_tag, timestamp, is_protected, is_burn, enc_version)
@@ -124,134 +66,119 @@ export async function POST(request: NextRequest) {
           enc_version = EXCLUDED.enc_version,
           user_id = EXCLUDED.user_id
         `,
-        [user.id, id, encryptedData, iv, authTag, new Date().toISOString(), hasPassword, burn, encVersion]
+        [user.id, id, encryptedData, iv, authTag, new Date().toISOString(), hasPassword, burn, encVersion],
       );
+    });
 
-      return NextResponse.json({
-        success: true,
-        path: `shares/${id}/data.json`,
-        id,
-        message: "Share created successfully.",
-        protected: hasPassword,
-        burnAfterRead: burn,
-      });
-    } finally {
-      client.release();
-    }
+    return NextResponse.json({
+      success: true,
+      path: `shares/${id}/data.json`,
+      id,
+      message: "Share created successfully.",
+      protected: hasPassword,
+      burnAfterRead: burn,
+    });
   } catch (error) {
     return NextResponse.json(
       {
         error: error instanceof Error ? error.message : "Unknown error occurred",
-        stack: error instanceof Error ? error.stack : undefined,
       },
-      { status: 500 }
+      { status: 500 },
     );
   }
 }
 
 export async function GET(request: NextRequest) {
   const id = request.nextUrl.searchParams.get("id");
-  const password = request.nextUrl.searchParams.get("password") ?? "";
 
   if (!id) {
     return NextResponse.json({ error: "Missing share ID" }, { status: 400 });
   }
 
   try {
-    const POSTGRES_URL = process.env.POSTGRES_URL;
-    if (!POSTGRES_URL) throw new Error("POSTGRES_URL is not set");
+    if (!process.env.POSTGRES_URL) throw new Error("POSTGRES_URL is not set");
 
-    await initializeDatabase();
+    await initializeShareDatabase();
 
-    const client = await pool.connect();
-    try {
+    return await withShareClient(async (client) => {
       await client.query("BEGIN");
 
-      const result = await client.query(
-        "SELECT encrypted_data, iv, auth_tag, timestamp, is_protected, is_burn, enc_version FROM shares WHERE share_id = $1 FOR UPDATE",
-        [id]
-      );
-
-      if (result.rows.length === 0) {
-        await client.query("ROLLBACK");
-        return NextResponse.json({ error: "Share not found" }, { status: 404 });
-      }
-
-      const row = result.rows[0] as {
-        encrypted_data: string;
-        iv: string;
-        auth_tag: string;
-        timestamp: Date;
-        is_protected: boolean;
-        is_burn: boolean;
-        enc_version: number | null;
-      };
-
-      if (row.is_protected && !password) {
-        await client.query("COMMIT");
-        return NextResponse.json(
-          { error: "Password required", requiresPassword: true, burnAfterRead: row.is_burn },
-          { status: 401 }
+      try {
+        const result = await client.query(
+          "SELECT encrypted_data, iv, auth_tag, timestamp, is_protected, is_burn, enc_version FROM shares WHERE share_id = $1 FOR UPDATE",
+          [id],
         );
-      }
 
-      const encVersion = row.enc_version ?? 1;
+        if (result.rows.length === 0) {
+          await client.query("ROLLBACK");
+          return NextResponse.json({ error: "Share not found" }, { status: 404 });
+        }
 
-      let key: Buffer;
-      if (row.is_protected) {
-        key = keyV3Password(password, id);
-      } else {
-        key = encVersion === 1 ? keyV1Legacy(id) : keyV2Unprotected(id);
-      }
+        const row = result.rows[0] as {
+          encrypted_data: string;
+          iv: string;
+          auth_tag: string;
+          timestamp: Date;
+          is_protected: boolean;
+          is_burn: boolean;
+          enc_version: number | null;
+        };
 
-      let decryptedData: string;
-      try {
-        decryptedData = decryptWithKey(row.encrypted_data, row.iv, row.auth_tag, key);
-      } catch {
+        if (row.is_protected) {
+          await client.query("COMMIT");
+          return NextResponse.json(
+            { error: "Password required", requiresPassword: true, burnAfterRead: row.is_burn },
+            { status: 401 },
+          );
+        }
+
+        const encVersion = row.enc_version ?? 1;
+        const key = encVersion === 1 ? keyV1Legacy(id) : keyV2Unprotected(id);
+
+        let decryptedData: string;
+        try {
+          decryptedData = decryptWithKey(row.encrypted_data, row.iv, row.auth_tag, key);
+        } catch {
+          await client.query("COMMIT");
+          if (row.is_protected) return NextResponse.json({ error: "Invalid password" }, { status: 403 });
+          return NextResponse.json({ error: "Failed to decrypt share data." }, { status: 403 });
+        }
+
+        if (row.is_burn) {
+          await client.query("DELETE FROM shares WHERE share_id = $1", [id]);
+        }
+
         await client.query("COMMIT");
-        if (row.is_protected) return NextResponse.json({ error: "Invalid password" }, { status: 403 });
-        return NextResponse.json({ error: "Failed to decrypt share data." }, { status: 403 });
-      }
 
-      if (row.is_burn) {
-        await client.query("DELETE FROM shares WHERE share_id = $1", [id]);
-      }
-
-      await client.query("COMMIT");
-
-      return NextResponse.json({
-        success: true,
-        data: decryptedData,
-        timestamp: row.timestamp.toISOString(),
-        protected: row.is_protected,
-        burnAfterRead: row.is_burn,
-      });
-    } catch (e) {
-      try {
+        return NextResponse.json({
+          success: true,
+          data: decryptedData,
+          timestamp: row.timestamp.toISOString(),
+          protected: row.is_protected,
+          burnAfterRead: row.is_burn,
+        });
+      } catch (e) {
         await client.query("ROLLBACK");
-      } catch {}
-      throw e;
-    } finally {
-      client.release();
-    }
+        throw e;
+      }
+    });
   } catch (error) {
     return NextResponse.json(
       {
         error: error instanceof Error ? error.message : "Unknown error occurred",
-        stack: error instanceof Error ? error.stack : undefined,
       },
-      { status: 500 }
+      { status: 500 },
     );
   }
 }
 
 export async function DELETE(request: NextRequest) {
   try {
-    const user = await currentUser()
+    const user = await currentUser();
     if (!user) {
       return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
     }
-    
+
     const body = await request.json();
     const { id } = body as { id?: string };
 
@@ -259,13 +186,11 @@ export async function DELETE(request: NextRequest) {
       return NextResponse.json({ error: "Missing share ID" }, { status: 400 });
     }
 
-    const POSTGRES_URL = process.env.POSTGRES_URL;
-    if (!POSTGRES_URL) throw new Error("POSTGRES_URL is not set");
+    if (!process.env.POSTGRES_URL) throw new Error("POSTGRES_URL is not set");
 
-    await initializeDatabase();
+    await initializeShareDatabase();
 
-    const client = await pool.connect();
-    try {
+    return await withShareClient(async (client) => {
       const result = await client.query("DELETE FROM shares WHERE share_id = $1 AND user_id = $2 RETURNING *", [id, user.id]);
 
       if (result.rowCount === 0) {
@@ -279,16 +204,13 @@ export async function DELETE(request: NextRequest) {
         success: true,
         message: `Successfully deleted share with ID: ${id}`,
       });
-    } finally {
-      client.release();
-    }
+    });
   } catch (error) {
     return NextResponse.json(
       {
         error: error instanceof Error ? error.message : "Unknown error occurred",
-        stack: error instanceof Error ? error.stack : undefined,
       },
-      { status: 500 }
+      { status: 500 },
     );
   }
 }

--- a/components/app/event/event-preview.tsx
+++ b/components/app/event/event-preview.tsx
@@ -36,6 +36,7 @@ import { Label } from "@/components/ui/label";
 import { toast } from "sonner";
 import QRCodeStyling from "qr-code-styling";
 import { useUser } from "@clerk/nextjs";
+import { sha256Hex } from "@/lib/hash";
 
 interface EventPreviewProps {
   event: CalendarEvent | null;
@@ -269,7 +270,7 @@ export default function EventPreview({
       const sharedEvent = { ...event, sharedBy: clerkUsername };
 
       const payload: any = { id: shareId, data: sharedEvent };
-      if (passwordEnabled) payload.password = sharePassword;
+      if (passwordEnabled) payload.password = await sha256Hex(sharePassword);
       if (passwordEnabled) payload.burnAfterRead = !!burnAfterRead;
 
       const response = await fetch("/api/share", {

--- a/lib/hash.ts
+++ b/lib/hash.ts
@@ -1,0 +1,7 @@
+export async function sha256Hex(input: string) {
+  const encoded = new TextEncoder().encode(input);
+  const digest = await crypto.subtle.digest("SHA-256", encoded);
+  return Array.from(new Uint8Array(digest))
+    .map((b) => b.toString(16).padStart(2, "0"))
+    .join("");
+}

--- a/lib/server/share-security.ts
+++ b/lib/server/share-security.ts
@@ -1,0 +1,164 @@
+import crypto from "crypto";
+import { Pool } from "pg";
+
+const ALGORITHM = "aes-256-gcm";
+const ONE_DAY_SECONDS = 60 * 60 * 24;
+
+const pool = new Pool({
+  connectionString: process.env.POSTGRES_URL,
+  ssl: { rejectUnauthorized: false },
+});
+
+export type ShareRow = {
+  encrypted_data: string;
+  iv: string;
+  auth_tag: string;
+  timestamp: Date;
+  is_protected: boolean;
+  is_burn: boolean;
+  enc_version: number | null;
+};
+
+function toBase64Url(value: Buffer | string) {
+  return Buffer.from(value)
+    .toString("base64")
+    .replace(/=/g, "")
+    .replace(/\+/g, "-")
+    .replace(/\//g, "_");
+}
+
+function fromBase64Url(value: string) {
+  const normalized = value.replace(/-/g, "+").replace(/_/g, "/");
+  const padded = normalized + "=".repeat((4 - (normalized.length % 4)) % 4);
+  return Buffer.from(padded, "base64");
+}
+
+export function keyV2Unprotected(shareId: string) {
+  return crypto.createHash("sha256").update(shareId, "utf8").digest();
+}
+
+export function keyV3Password(passwordHash: string, shareId: string) {
+  return crypto.scryptSync(passwordHash, shareId, 32);
+}
+
+export function keyV1Legacy(shareId: string) {
+  const salt = process.env.SALT;
+  if (!salt) throw new Error("SALT environment variable is not set");
+  return crypto.scryptSync(shareId, salt, 32);
+}
+
+export function encryptWithKey(data: string, key: Buffer): { encryptedData: string; iv: string; authTag: string } {
+  const iv = crypto.randomBytes(16);
+  const cipher = crypto.createCipheriv(ALGORITHM, key, iv);
+  let encrypted = cipher.update(data, "utf8", "hex");
+  encrypted += cipher.final("hex");
+  const authTag = cipher.getAuthTag();
+  return { encryptedData: encrypted, iv: iv.toString("hex"), authTag: authTag.toString("hex") };
+}
+
+export function decryptWithKey(encryptedData: string, iv: string, authTag: string, key: Buffer): string {
+  const ivBuffer = Buffer.from(iv, "hex");
+  const authTagBuffer = Buffer.from(authTag, "hex");
+  const decipher = crypto.createDecipheriv(ALGORITHM, key, ivBuffer);
+  decipher.setAuthTag(authTagBuffer);
+  let decrypted = decipher.update(encryptedData, "hex", "utf8");
+  decrypted += decipher.final("utf8");
+  return decrypted;
+}
+
+export async function initializeShareDatabase() {
+  const client = await pool.connect();
+  try {
+    await client.query(`
+      CREATE TABLE IF NOT EXISTS shares (
+        id SERIAL PRIMARY KEY,
+        user_id TEXT NOT NULL,
+        share_id VARCHAR(255) NOT NULL,
+        encrypted_data TEXT NOT NULL,
+        iv TEXT NOT NULL,
+        auth_tag TEXT NOT NULL,
+        timestamp TIMESTAMP NOT NULL,
+        is_protected BOOLEAN DEFAULT FALSE,
+        is_burn BOOLEAN DEFAULT FALSE,
+        enc_version INTEGER,
+        UNIQUE(share_id)
+      )
+    `);
+    await client.query(`ALTER TABLE shares ADD COLUMN IF NOT EXISTS user_id TEXT`);
+    await client.query(`ALTER TABLE shares ADD COLUMN IF NOT EXISTS is_protected BOOLEAN DEFAULT FALSE`);
+    await client.query(`ALTER TABLE shares ADD COLUMN IF NOT EXISTS is_burn BOOLEAN DEFAULT FALSE`);
+    await client.query(`ALTER TABLE shares ADD COLUMN IF NOT EXISTS enc_version INTEGER`);
+    await client.query(`UPDATE shares SET enc_version = 1 WHERE enc_version IS NULL`);
+    await client.query(`CREATE INDEX IF NOT EXISTS idx_shares_user_id ON shares(user_id)`);
+  } finally {
+    client.release();
+  }
+}
+
+export function isValidSha256Hex(value: unknown): value is string {
+  return typeof value === "string" && /^[a-f0-9]{64}$/i.test(value);
+}
+
+type ShareTokenPayload = {
+  sid: string;
+  ph: string;
+  exp: number;
+  iat: number;
+};
+
+function getJwtSecret() {
+  const secret = process.env.SHARE_JWT_SECRET;
+  if (!secret || secret.length < 32) {
+    throw new Error("SHARE_JWT_SECRET must be set and at least 32 characters long");
+  }
+  return secret;
+}
+
+export function createShareAccessToken(shareId: string, passwordHash: string, ttlSeconds = ONE_DAY_SECONDS) {
+  const now = Math.floor(Date.now() / 1000);
+  const payload: ShareTokenPayload = {
+    sid: shareId,
+    ph: passwordHash,
+    iat: now,
+    exp: now + ttlSeconds,
+  };
+  const header = { alg: "HS256", typ: "JWT" };
+  const encodedHeader = toBase64Url(JSON.stringify(header));
+  const encodedPayload = toBase64Url(JSON.stringify(payload));
+  const signature = crypto
+    .createHmac("sha256", getJwtSecret())
+    .update(`${encodedHeader}.${encodedPayload}`)
+    .digest();
+  return `${encodedHeader}.${encodedPayload}.${toBase64Url(signature)}`;
+}
+
+export function verifyShareAccessToken(token: string): ShareTokenPayload | null {
+  const [encodedHeader, encodedPayload, encodedSignature] = token.split(".");
+  if (!encodedHeader || !encodedPayload || !encodedSignature) return null;
+
+  const expectedSignature = crypto
+    .createHmac("sha256", getJwtSecret())
+    .update(`${encodedHeader}.${encodedPayload}`)
+    .digest();
+  const actualSignature = fromBase64Url(encodedSignature);
+
+  if (actualSignature.length !== expectedSignature.length) return null;
+  if (!crypto.timingSafeEqual(actualSignature, expectedSignature)) return null;
+
+  const payload = JSON.parse(fromBase64Url(encodedPayload).toString("utf8")) as ShareTokenPayload;
+  const now = Math.floor(Date.now() / 1000);
+
+  if (!payload?.sid || !isValidSha256Hex(payload?.ph) || typeof payload.exp !== "number") return null;
+  if (payload.exp <= now) return null;
+
+  return payload;
+}
+
+export async function withShareClient<T>(handler: (client: Awaited<ReturnType<typeof pool.connect>>) => Promise<T>) {
+  const client = await pool.connect();
+  try {
+    return await handler(client);
+  } finally {
+    client.release();
+  }
+}


### PR DESCRIPTION
Codex generated this pull request, but encountered an unexpected error after generation. This is a placeholder PR message.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69928167911c833281c5cb05e7218c21)

## Summary by Sourcery

安全分享流程重构：使用哈希密码、类 JWT 访问令牌，以及用于分享记录的共享数据库工具。

New Features:
- 引入 `share-security` 服务器模块，用于集中管理分享的加密、数据库初始化、令牌处理以及密码哈希验证。
- 新增专用的 `/api/share/auth` 和 `/api/share/content` 端点，用于对受密码保护的分享进行身份验证，并通过 Bearer Token 获取其内容。

Bug Fixes:
- 确保分享删除与查询始终通过共享的辅助方法使用连接池中的数据库客户端，降低连接泄漏风险。
- 改进分享相关 API 的错误处理响应，从 JSON 响应中移除堆栈跟踪信息，并统一状态码。

Enhancements:
- 修改分享创建逻辑，要求使用预先哈希的 SHA-256 密码，并在加密前验证其格式，从而收紧客户端与服务器之间的安全边界。
- 重构分享的 GET/DELETE API 路由，复用共享的数据库与加密辅助方法，替代内联的连接池管理和加密逻辑。
- 更新共享事件、分享管理和事件预览的 UI 流程，在客户端对密码进行哈希处理，本地持久化访问令牌，并对受密码保护的分享使用新的 auth/content 端点。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Secure sharing flow refactor to use hashed passwords, JWT-like access tokens, and shared DB utilities for share records.

New Features:
- Introduce share-security server module to centralize encryption, database initialization, token handling, and password-hash validation for shares.
- Add dedicated /api/share/auth and /api/share/content endpoints to authenticate password-protected shares and retrieve their content via bearer tokens.

Bug Fixes:
- Ensure share deletion and retrieval always use pooled DB clients via a shared helper, reducing the risk of connection leaks.
- Improve error handling responses for share APIs by omitting stack traces from JSON responses and standardizing status codes.

Enhancements:
- Change share creation to require pre-hashed SHA-256 passwords and validate their format before encryption, tightening client-server security boundaries.
- Refactor share GET/DELETE API routes to reuse shared DB and crypto helpers instead of inline pool management and crypto logic.
- Update UI flows for shared events, share management, and event preview to hash passwords client-side, persist access tokens locally, and use the new auth/content endpoints for password-protected shares.

</details>