### PR TITLE
small change

### DIFF
--- a/app/api/blob/session/route.ts
+++ b/app/api/blob/session/route.ts
@@ -1,0 +1,93 @@
+import { NextRequest, NextResponse } from "next/server"
+import { currentUser } from "@clerk/nextjs/server"
+import { Pool } from "pg"
+import { createSessionToken } from "@/lib/session-jwt"
+import { timingSafeEqual } from "crypto"
+
+export const runtime = "nodejs"
+
+const pool = new Pool({
+  connectionString: process.env.POSTGRES_URL,
+  ssl: { rejectUnauthorized: false },
+})
+
+let inited = false
+
+async function initDB() {
+  if (inited) return
+  const client = await pool.connect()
+  try {
+    await client.query(`
+      CREATE TABLE IF NOT EXISTS calendar_backup_keys (
+        user_id TEXT PRIMARY KEY,
+        key_hash TEXT NOT NULL,
+        updated_at TIMESTAMP NOT NULL
+      )
+    `)
+    inited = true
+  } finally {
+    client.release()
+  }
+}
+
+function isValidHash(keyHash: unknown): keyHash is string {
+  return typeof keyHash === "string" && /^[a-f0-9]{64}$/i.test(keyHash)
+}
+
+function tokenFor(userId: string, keyHash: string) {
+  const secret = process.env.BACKUP_JWT_SECRET
+  if (!secret) throw new Error("BACKUP_JWT_SECRET is not configured")
+  const exp = Math.floor(Date.now() / 1000) + 24 * 60 * 60
+  return createSessionToken({ sub: userId, keyHash, exp }, secret)
+}
+
+export async function POST(req: NextRequest) {
+  try {
+    const user = await currentUser()
+    if (!user) return NextResponse.json({ error: "Unauthorized" }, { status: 401 })
+
+    const body = await req.json()
+    const action = body?.action
+    const keyHash = body?.keyHash
+
+    if (!isValidHash(keyHash)) {
+      return NextResponse.json({ error: "Invalid key hash" }, { status: 400 })
+    }
+
+    await initDB()
+
+    const client = await pool.connect()
+    try {
+      if (action === "register") {
+        await client.query(
+          `
+            INSERT INTO calendar_backup_keys (user_id, key_hash, updated_at)
+            VALUES ($1, $2, $3)
+            ON CONFLICT (user_id)
+            DO UPDATE SET key_hash = EXCLUDED.key_hash, updated_at = EXCLUDED.updated_at
+          `,
+          [user.id, keyHash, new Date().toISOString()],
+        )
+        return NextResponse.json({ token: tokenFor(user.id, keyHash) })
+      }
+
+      const result = await client.query(`SELECT key_hash FROM calendar_backup_keys WHERE user_id = $1`, [user.id])
+      if (result.rowCount === 0) {
+        return NextResponse.json({ error: "Encryption key not configured" }, { status: 404 })
+      }
+
+      const stored = result.rows[0].key_hash as string
+      const storedBuffer = Buffer.from(stored)
+      const inputBuffer = Buffer.from(keyHash)
+      if (storedBuffer.length !== inputBuffer.length || !timingSafeEqual(storedBuffer, inputBuffer)) {
+        return NextResponse.json({ error: "Invalid encryption key" }, { status: 403 })
+      }
+
+      return NextResponse.json({ token: tokenFor(user.id, keyHash) })
+    } finally {
+      client.release()
+    }
+  } catch (e: any) {
+    return NextResponse.json({ error: e?.message || "Internal error" }, { status: 500 })
+  }
+}

--- a/app/api/verify/route.ts
+++ b/app/api/verify/route.ts
@@ -5,18 +5,13 @@ export async function POST(request: NextRequest) {
     const { token, action } = await request.json();
     const secretKey = process.env.TURNSTILE_SECRET_KEY;
 
-    console.log("Request body:", { token: token ? token.slice(0, 10) + "..." : null, action });
-    console.log("TURNSTILE_SECRET_KEY:", secretKey ? "Set" : "Missing");
-
     if (!token) {
-      console.error("Missing token in request body");
       return new Response(JSON.stringify({ error: "Missing CAPTCHA token" }), {
         status: 400,
         headers: { "Content-Type": "application/json" },
       });
     }
     if (!secretKey) {
-      console.error("Missing TURNSTILE_SECRET_KEY in environment");
       return new Response(JSON.stringify({ error: "Server configuration error: Missing secret key" }), {
         status: 400,
         headers: { "Content-Type": "application/json" },
@@ -36,7 +31,6 @@ export async function POST(request: NextRequest) {
     );
 
     if (!response.ok) {
-      console.error("Cloudflare API error:", response.status, response.statusText);
       return new Response(JSON.stringify({ error: "Failed to verify with Cloudflare", status: response.status }), {
         status: 500,
         headers: { "Content-Type": "application/json" },
@@ -44,16 +38,12 @@ export async function POST(request: NextRequest) {
     }
 
     const data = await response.json();
-    console.log("Cloudflare response:", JSON.stringify(data, null, 2));
-
     if (data.success) {
-      console.log("Verification successful for action:", action);
       return new Response(JSON.stringify({ success: true }), {
         status: 200,
         headers: { "Content-Type": "application/json" },
       });
     } else {
-      console.error("Turnstile verification failed:", data["error-codes"]);
       return new Response(
         JSON.stringify({
           error: "Turnstile verification failed",
@@ -67,11 +57,11 @@ export async function POST(request: NextRequest) {
       );
     }
   } catch (error) {
-    console.error("Server error during verification:", error.message, error.stack);
+    const message = error instanceof Error ? error.message : "Unknown error"
     return new Response(
       JSON.stringify({
         error: "Server error during verification",
-        details: error.message,
+        details: message,
       }),
       {
         status: 500,

--- a/lib/crypto.ts
+++ b/lib/crypto.ts
@@ -58,3 +58,10 @@ export function isEncryptedPayload(value: unknown): value is EncryptedPayload {
   if (!value || typeof value !== "object") return false
   return "ciphertext" in value && "iv" in value
 }
+
+export async function sha256Hex(input: string) {
+  const digest = await crypto.subtle.digest("SHA-256", new TextEncoder().encode(input))
+  return Array.from(new Uint8Array(digest))
+    .map((byte) => byte.toString(16).padStart(2, "0"))
+    .join("")
+}

--- a/lib/session-jwt.ts
+++ b/lib/session-jwt.ts
@@ -1,0 +1,57 @@
+import { createHmac, timingSafeEqual } from "crypto"
+
+const encoder = new TextEncoder()
+
+function base64UrlEncode(input: Buffer | string) {
+  return Buffer.from(input)
+    .toString("base64")
+    .replace(/=/g, "")
+    .replace(/\+/g, "-")
+    .replace(/\//g, "_")
+}
+
+function base64UrlDecode(input: string) {
+  const padded = input.replace(/-/g, "+").replace(/_/g, "/") + "===".slice((input.length + 3) % 4)
+  return Buffer.from(padded, "base64")
+}
+
+function sign(data: string, secret: string) {
+  return base64UrlEncode(createHmac("sha256", secret).update(data).digest())
+}
+
+export type SessionPayload = {
+  sub: string
+  keyHash: string
+  exp: number
+}
+
+export function createSessionToken(payload: SessionPayload, secret: string) {
+  const header = base64UrlEncode(JSON.stringify({ alg: "HS256", typ: "JWT" }))
+  const body = base64UrlEncode(JSON.stringify(payload))
+  const message = `${header}.${body}`
+  const signature = sign(message, secret)
+  return `${message}.${signature}`
+}
+
+export function verifySessionToken(token: string, secret: string): SessionPayload | null {
+  const parts = token.split(".")
+  if (parts.length !== 3) return null
+
+  const [header, body, signature] = parts
+  const message = `${header}.${body}`
+  const expectedSig = sign(message, secret)
+
+  const sigBuf = encoder.encode(signature)
+  const expectedBuf = encoder.encode(expectedSig)
+
+  if (sigBuf.length !== expectedBuf.length || !timingSafeEqual(sigBuf, expectedBuf)) return null
+
+  try {
+    const payload = JSON.parse(base64UrlDecode(body).toString("utf8")) as SessionPayload
+    if (!payload?.sub || !payload?.keyHash || typeof payload.exp !== "number") return null
+    if (payload.exp <= Math.floor(Date.now() / 1000)) return null
+    return payload
+  } catch {
+    return null
+  }
+}


### PR DESCRIPTION
Codex generated this pull request, but encountered an unexpected error after generation. This is a placeholder PR message.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_699285b90a6883329fc5ae34589fe486)

## 由 Sourcery 提供的总结

引入基于「已哈希密码」的备份会话，用于用户日历备份，使其能够通过令牌自动恢复和解密，而无需在每次访问时重新输入密码。

新功能：
- 添加会话令牌 API 和 JWT 辅助工具，用于创建和验证与用户密码哈希绑定的用户级备份会话。
- 允许客户端重用已保存的备份会话令牌，在登录时自动解密并恢复云备份数据。

增强点：
- 重构备份加密逻辑，使用 SHA-256 派生并存储密码哈希，而非原始密码，并相应更新注册、解锁和轮换（rotation）流程。
- 增强 blob API，当提供有效的备份会话令牌时，可选择性地解密并返回备份数据。
- 在禁用自动备份或删除云数据时清除备份会话令牌，以避免陈旧会话。

杂项维护：
- 从 Turnstile 校验 API 中移除冗长日志，并简化错误报告。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Introduce hashed-password–based backup sessions for user calendar backups, enabling token-based automatic restore and decryption without re-entering the password on each visit.

New Features:
- Add session token API and JWT helper utilities to create and verify per-user backup sessions tied to a password hash.
- Allow the client to reuse a stored backup session token to automatically decrypt and restore cloud backup data on sign-in.

Enhancements:
- Refactor backup encryption to derive and store SHA-256 password hashes instead of raw passwords, updating registration, unlock, and rotation flows accordingly.
- Enhance the blob API to optionally decrypt and return backup data when presented with a valid backup session token.
- Clear backup session tokens when disabling auto backup or deleting cloud data to avoid stale sessions.

Chores:
- Remove verbose logging from the Turnstile verification API and simplify error reporting.

</details>