### PR TITLE
test

### DIFF
--- a/app/api/blob/route.ts
+++ b/app/api/blob/route.ts
@@ -2,8 +2,6 @@
 import { NextRequest, NextResponse } from "next/server"
 import { currentUser } from "@clerk/nextjs/server"
 import { Pool } from "pg"
-import { decryptPayload } from "@/lib/crypto"
-import { verifySessionToken } from "@/lib/session-jwt"
 
 export const runtime = "nodejs"
 
@@ -30,16 +28,6 @@ async function initDB() {
   } finally {
     client.release()
   }
-}
-
-function getSessionSecret() {
-  return process.env.BACKUP_JWT_SECRET
-}
-
-function getBearerToken(req: NextRequest) {
-  const auth = req.headers.get("authorization")
-  if (!auth?.startsWith("Bearer ")) return null
-  return auth.slice(7).trim()
 }
 
 export async function POST(req: NextRequest) {
@@ -81,7 +69,7 @@ export async function POST(req: NextRequest) {
   }
 }
 
-export async function GET(req: NextRequest) {
+export async function GET() {
   const user = await currentUser()
   if (!user) return NextResponse.json({ error: "Unauthorized" }, { status: 401 })
 
@@ -96,32 +84,11 @@ export async function GET(req: NextRequest) {
     if (result.rowCount === 0) return NextResponse.json({ error: "Not found" }, { status: 404 })
 
     const row = result.rows[0]
-    const token = getBearerToken(req)
-    if (!token) {
-      return NextResponse.json({
-        ciphertext: row.encrypted_data,
-        iv: row.iv,
-        timestamp: row.timestamp,
-      })
-    }
-
-    const secret = getSessionSecret()
-    if (!secret) {
-      return NextResponse.json({ error: "Server misconfigured" }, { status: 500 })
-    }
-
-    const payload = verifySessionToken(token, secret)
-    if (!payload || payload.sub !== user.id) {
-      return NextResponse.json({ error: "Invalid or expired token" }, { status: 401 })
-    }
-
-    try {
-      const plain = await decryptPayload(payload.keyHash, row.encrypted_data, row.iv)
-      const data = JSON.parse(plain)
-      return NextResponse.json({ data, timestamp: row.timestamp })
-    } catch {
-      return NextResponse.json({ error: "Unable to decrypt data with current token" }, { status: 403 })
-    }
+    return NextResponse.json({
+      ciphertext: row.encrypted_data,
+      iv: row.iv,
+      timestamp: row.timestamp,
+    })
   } finally {
     client.release()
   }


### PR DESCRIPTION
Codex generated this pull request, but encountered an unexpected error after generation. This is a placeholder PR message.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69928f1ff3b88332bb619e74d1401402)

## Summary by Sourcery

通过始终返回加密后的数据块（encrypted blobs）来简化备份 API，并将所有解密和会话处理逻辑移至客户端；在本地持久化备份密码，并基于过期时间（expiration-based）管理会话。

New Features:
- 引入客户端备份会话机制，在本地存储中以固定 TTL（存活时间）保存备份密码和可选的会话 token。

Bug Fixes:
- 在尝试自动恢复之前，确保清理已过期或无效的备份会话，防止失败的恢复操作继续使用过期的凭据。
- 在解锁或轮换备份密码时，如果缺少云备份，则通过通知用户来优雅地处理，而不是静默失败。

Enhancements:
- 重构客户端备份流程，使用原始备份密码作为本地和云端数据的加密密钥，而不是使用哈希后的密钥。
- 将备份会话管理集中到辅助函数中，以统一处理会话状态的保存、读取和清理。
- 精简服务器的 `GET /api/blob` 行为，使其仅返回加密数据和元数据，将所有解密和 token 校验逻辑委托给其他端点处理。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Simplify the backup API by always returning encrypted blobs and move all decryption and session handling to the client, persisting the backup password locally with an expiration-based session.

New Features:
- Introduce client-side backup sessions that store the backup password and optional session token with a fixed TTL in local storage.

Bug Fixes:
- Ensure expired or invalid backup sessions are cleared before attempting automatic restore, preventing failed restores from using stale credentials.
- Handle missing cloud backups gracefully when unlocking or rotating backup passwords by notifying the user instead of failing silently.

Enhancements:
- Refactor client backup flow to use the raw backup password as the encryption key instead of a hashed key for local and cloud data.
- Centralize backup session management into helper functions for saving, reading, and clearing session state.
- Streamline server GET /api/blob to return only encrypted data and metadata, delegating all decryption and token validation to other endpoints.

</details>