### PR TITLE
feat: add New Year theme and switch share icon to icon.svg

### DIFF
--- a/app/(app)/share/[id]/layout.tsx
+++ b/app/(app)/share/[id]/layout.tsx
@@ -21,11 +21,17 @@ export async function generateMetadata(
 
     return {
       title: `${eventTitle} | One Calendar`,
+      icons: {
+        icon: "/icon.svg",
+      },
     }
   } catch (err) {
     console.error("[generateMetadata error]", err)
     return {
       title: "One Calendar",
+      icons: {
+        icon: "/icon.svg",
+      },
     }
   }
 }

--- a/app/globals.css
+++ b/app/globals.css
@@ -202,40 +202,83 @@ body {
 
 
 
+.newyear,
+.newyear .app-theme-scope {
+    --background: 0 0% 100%;
+    --foreground: 0 0% 3.9%;
+    --card: 0 0% 100%;
+    --card-foreground: 0 0% 3.9%;
+    --popover: 0 0% 100%;
+    --popover-foreground: 0 0% 3.9%;
+    --primary: 0 84.7% 64.1%;
+    --primary-foreground: 0 0% 98%;
+    --secondary: 0 0% 96.1%;
+    --secondary-foreground: 0 0% 9%;
+    --muted: 0 0% 96.1%;
+    --muted-foreground: 0 0% 45.1%;
+    --accent: 0 0% 96.1%;
+    --accent-foreground: 0 84.7% 64.1%;
+    --destructive: 0 84.2% 60.2%;
+    --destructive-foreground: 0 0% 98%;
+    --border: 0 0% 89.8%;
+    --input: 0 0% 89.8%;
+    --ring: 0 84.7% 64.1%;
+    --chart-1: 0 84.7% 64.1%;
+    --chart-2: 173 58% 39%;
+    --chart-3: 197 37% 24%;
+    --chart-4: 43 74% 66%;
+    --chart-5: 27 87% 67%;
+    --sidebar-background: 0 0% 98%;
+    --sidebar-foreground: 240 5.3% 26.1%;
+    --sidebar-primary: 0 84.7% 64.1%;
+    --sidebar-primary-foreground: 0 0% 98%;
+    --sidebar-accent: 240 4.8% 95.9%;
+    --sidebar-accent-foreground: 240 5.9% 10%;
+    --sidebar-border: 220 13% 91%;
+    --sidebar-ring: 0 84.7% 64.1%;
+}
+
+
 .green,
 .green .app-theme-scope,
 .orange,
 .orange .app-theme-scope,
 .azalea,
-.azalea .app-theme-scope {
+.azalea .app-theme-scope,
+.newyear,
+.newyear .app-theme-scope {
     --card: var(--background);
     --popover: var(--background);
 }
 
 .green .app-theme-scope button[variant="outline"],
 .orange .app-theme-scope button[variant="outline"],
-.azalea .app-theme-scope button[variant="outline"] {
+.azalea .app-theme-scope button[variant="outline"],
+.newyear .app-theme-scope button[variant="outline"] {
     border: 1px solid hsl(var(--border));
     background: transparent;
 }
 
 .green .app-theme-scope button[variant="ghost"],
 .orange .app-theme-scope button[variant="ghost"],
-.azalea .app-theme-scope button[variant="ghost"] {
+.azalea .app-theme-scope button[variant="ghost"],
+.newyear .app-theme-scope button[variant="ghost"] {
     border: none;
     background: transparent;
 }
 
 .green .app-theme-scope hr, .green .app-theme-scope .divider,
 .orange .app-theme-scope hr, .orange .app-theme-scope .divider,
-.azalea .app-theme-scope hr, .azalea .app-theme-scope .divider {
+.azalea .app-theme-scope hr, .azalea .app-theme-scope .divider,
+.newyear .app-theme-scope hr, .newyear .app-theme-scope .divider {
     border-color: hsl(var(--border));
     opacity: 0.8;
 }
 
 .green .app-theme-scope .separator,
 .orange .app-theme-scope .separator,
-.azalea .app-theme-scope .separator {
+.azalea .app-theme-scope .separator,
+.newyear .app-theme-scope .separator {
     height: 1px;
     background: hsl(var(--border));
     opacity: 0.6;

--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -56,7 +56,7 @@ export default function RootLayout({
         signUpUrl="/sign-up"
       >
         <ThemeProvider
-            themes={['light', 'dark', 'green', 'orange', 'azalea']}
+            themes={['light', 'dark', 'green', 'orange', 'azalea', 'newyear']}
             attribute="class"
             defaultTheme="system"
             enableSystem

--- a/components/app/profile/settings.tsx
+++ b/components/app/profile/settings.tsx
@@ -128,6 +128,7 @@ export default function Settings({
               <SelectItem value="green">{t.themeGreen}</SelectItem>
               <SelectItem value="orange">{t.themeOrange}</SelectItem>
               <SelectItem value="azalea">{t.themeAzalea}</SelectItem>
+              <SelectItem value="newyear">New Year</SelectItem>
               <SelectItem value="system">{t.themeSystem}</SelectItem>
             </SelectContent>
           </Select>

--- a/components/app/profile/shared-event.tsx
+++ b/components/app/profile/shared-event.tsx
@@ -3,6 +3,7 @@
 import { zhCN, enUS } from "date-fns/locale";
 import { useEffect, useState } from "react";
 import { useRouter } from "next/navigation";
+import Image from "next/image";
 import { format } from "date-fns";
 import {
   MapPin,
@@ -310,9 +311,9 @@ export default function SharedEventView({ shareId }: SharedEventViewProps) {
 
         <div className="relative z-10 flex w-full max-w-sm flex-col gap-6">
           <a href="/" className="flex items-center gap-2 self-center font-medium">
-          <Calendar className="size-4" color="#0066ff" />
-          One Calendar
-        </a>
+            <Image src="/icon.svg" alt="One Calendar" width={16} height={16} className="size-4" />
+            One Calendar
+          </a>
 
           <motion.div initial={{ opacity: 0, y: 20 }} animate={{ opacity: 1, y: 0 }} transition={{ duration: 0.5 }}>
             <Card className="max-w-md w-full overflow-hidden">
@@ -414,9 +415,9 @@ export default function SharedEventView({ shareId }: SharedEventViewProps) {
 
         <div className="relative z-10 flex w-full max-w-sm flex-col gap-6">
           <a href="/" className="flex items-center gap-2 self-center font-medium">
-          <Calendar className="size-4" color="#0066ff" />
-          One Calendar
-        </a>
+            <Image src="/icon.svg" alt="One Calendar" width={16} height={16} className="size-4" />
+            One Calendar
+          </a>
 
           <motion.div initial={{ opacity: 0, y: 20 }} animate={{ opacity: 1, y: 0 }} transition={{ duration: 0.5 }}>
             <Card className="max-w-md w-full overflow-hidden">
@@ -477,9 +478,9 @@ export default function SharedEventView({ shareId }: SharedEventViewProps) {
 
       <div className="relative z-10 flex w-full max-w-sm flex-col gap-6">
         <a href="/" className="flex items-center gap-2 self-center font-medium">
-          <Calendar className="size-4" color="#0066ff" />
-          One Calendar
-        </a>
+            <Image src="/icon.svg" alt="One Calendar" width={16} height={16} className="size-4" />
+            One Calendar
+          </a>
 
         <motion.div initial={{ opacity: 0, y: 20 }} animate={{ opacity: 1, y: 0 }} transition={{ duration: 0.5 }}>
           <Card className="max-w-md w-full overflow-hidden">

--- a/components/auth/auth-brand.tsx
+++ b/components/auth/auth-brand.tsx
@@ -1,10 +1,10 @@
-import { Calendar } from "lucide-react"
+import Image from "next/image"
 
 export function AuthBrand() {
   return (
     <a href="https://xyehr.cn" className="flex items-center gap-2 self-center font-medium text-foreground">
       <span className="flex size-6 items-center justify-center rounded-md bg-primary/15 text-primary">
-        <Calendar className="size-4" />
+        <Image src="/icon.svg" alt="One Calendar" width={16} height={16} className="size-4" />
       </span>
       <span>Tech-Art</span>
     </a>

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "one-calendar",
-  "version": "2.1.0",
+  "version": "2.1.3",
   "private": true,
   "packageManager": "bun@1.3.6",
   "scripts": {


### PR DESCRIPTION
### Motivation
- Provide a New Year theme that uses the requested accent color (#F15656) while otherwise matching the existing light-mode appearance, and update the share page branding to use the project's `icon.svg`.

### Description
- Register the `newyear` theme in the app `ThemeProvider` so it is selectable (`app/layout.tsx`) and add a corresponding `SelectItem` in the settings UI (`components/app/profile/settings.tsx`).
- Add `newyear` CSS variables in `app/globals.css` that reuse the light-mode variables and set the primary-related variables to the HSL value corresponding to `#F15656` (`0 84.7% 64.1%`).
- Replace the top-left share-page branding icon with an `<Image src="/icon.svg" />` and add the `Image` import in `components/app/profile/shared-event.tsx` so password/empty/error/content states use `/icon.svg`.
- Set the share route metadata `icons.icon` to `/icon.svg` in `app/(app)/share/[id]/layout.tsx` so the share page has the correct favicon/preview icon.

### Testing
- Ran `bun run generate:locales`, which completed successfully and regenerated `lib/locales.ts`.
- Ran `bunx tsc --noEmit`, which failed in this environment due to missing project dependencies/type packages (multiple `Cannot find module` errors).
- Attempted `bun run dev` to preview the UI, but it failed because `next` is not available in the execution environment.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6992b3873e3483329fcafdce4e7baf92)

## Summary by Sourcery

添加新年主题，并更新分享页面品牌以使用新的 SVG 图标。

新功能：
- 引入可选择的 `newyear` 主题，使用与现有浅色主题一致的红色强调色调。

增强改进：
- 为 `newyear` 主题的按钮、分隔线和分割符设置样式，使其与其他浅色变体保持一致。
- 在全局 ThemeProvider 和设置界面的主题选择器中暴露 `newyear` 主题。
- 更新共享活动页面的页眉品牌以使用项目 SVG 图标，并将其应用为分享路由的 favicon。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Add a New Year theme and update share page branding to use the new SVG icon.

New Features:
- Introduce a selectable `newyear` theme with a red accent palette aligned to the existing light theme.

Enhancements:
- Style buttons, dividers, and separators for the `newyear` theme consistently with other light variants.
- Expose the `newyear` theme in the global ThemeProvider and settings UI theme selector.
- Update the shared event page header branding to use the project SVG icon and apply it as the share route favicon.

</details>