### PR TITLE
Remove New Year theme support

### DIFF
--- a/app/globals.css
+++ b/app/globals.css
@@ -202,83 +202,41 @@ body {
 
 
 
-.newyear,
-.newyear .app-theme-scope {
-    --background: 0 0% 100%;
-    --foreground: 0 0% 3.9%;
-    --card: 0 0% 100%;
-    --card-foreground: 0 0% 3.9%;
-    --popover: 0 0% 100%;
-    --popover-foreground: 0 0% 3.9%;
-    --primary: 0 84.7% 64.1%;
-    --primary-foreground: 0 0% 98%;
-    --secondary: 0 0% 96.1%;
-    --secondary-foreground: 0 0% 9%;
-    --muted: 0 0% 96.1%;
-    --muted-foreground: 0 0% 45.1%;
-    --accent: 0 0% 96.1%;
-    --accent-foreground: 0 84.7% 64.1%;
-    --destructive: 0 84.2% 60.2%;
-    --destructive-foreground: 0 0% 98%;
-    --border: 0 0% 89.8%;
-    --input: 0 0% 89.8%;
-    --ring: 0 84.7% 64.1%;
-    --chart-1: 0 84.7% 64.1%;
-    --chart-2: 173 58% 39%;
-    --chart-3: 197 37% 24%;
-    --chart-4: 43 74% 66%;
-    --chart-5: 27 87% 67%;
-    --sidebar-background: 0 0% 98%;
-    --sidebar-foreground: 240 5.3% 26.1%;
-    --sidebar-primary: 0 84.7% 64.1%;
-    --sidebar-primary-foreground: 0 0% 98%;
-    --sidebar-accent: 240 4.8% 95.9%;
-    --sidebar-accent-foreground: 240 5.9% 10%;
-    --sidebar-border: 220 13% 91%;
-    --sidebar-ring: 0 84.7% 64.1%;
-}
-
 
 .green,
 .green .app-theme-scope,
 .orange,
 .orange .app-theme-scope,
 .azalea,
-.azalea .app-theme-scope,
-.newyear,
-.newyear .app-theme-scope {
+.azalea .app-theme-scope {
     --card: var(--background);
     --popover: var(--background);
 }
 
 .green .app-theme-scope button[variant="outline"],
 .orange .app-theme-scope button[variant="outline"],
-.azalea .app-theme-scope button[variant="outline"],
-.newyear .app-theme-scope button[variant="outline"] {
+.azalea .app-theme-scope button[variant="outline"] {
     border: 1px solid hsl(var(--border));
     background: transparent;
 }
 
 .green .app-theme-scope button[variant="ghost"],
 .orange .app-theme-scope button[variant="ghost"],
-.azalea .app-theme-scope button[variant="ghost"],
-.newyear .app-theme-scope button[variant="ghost"] {
+.azalea .app-theme-scope button[variant="ghost"] {
     border: none;
     background: transparent;
 }
 
 .green .app-theme-scope hr, .green .app-theme-scope .divider,
 .orange .app-theme-scope hr, .orange .app-theme-scope .divider,
-.azalea .app-theme-scope hr, .azalea .app-theme-scope .divider,
-.newyear .app-theme-scope hr, .newyear .app-theme-scope .divider {
+.azalea .app-theme-scope hr, .azalea .app-theme-scope .divider {
     border-color: hsl(var(--border));
     opacity: 0.8;
 }
 
 .green .app-theme-scope .separator,
 .orange .app-theme-scope .separator,
-.azalea .app-theme-scope .separator,
-.newyear .app-theme-scope .separator {
+.azalea .app-theme-scope .separator {
     height: 1px;
     background: hsl(var(--border));
     opacity: 0.6;

--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -56,7 +56,7 @@ export default function RootLayout({
         signUpUrl="/sign-up"
       >
         <ThemeProvider
-            themes={['light', 'dark', 'green', 'orange', 'azalea', 'newyear']}
+            themes={['light', 'dark', 'green', 'orange', 'azalea']}
             attribute="class"
             defaultTheme="system"
             enableSystem

--- a/components/app/profile/settings.tsx
+++ b/components/app/profile/settings.tsx
@@ -128,7 +128,6 @@ export default function Settings({
               <SelectItem value="green">{t.themeGreen}</SelectItem>
               <SelectItem value="orange">{t.themeOrange}</SelectItem>
               <SelectItem value="azalea">{t.themeAzalea}</SelectItem>
-              <SelectItem value="newyear">New Year</SelectItem>
               <SelectItem value="system">{t.themeSystem}</SelectItem>
             </SelectContent>
           </Select>


### PR DESCRIPTION
### Motivation
- The project should no longer include the `newyear` theme; remove all UI and style references to fully delete the theme from the codebase.

### Description
- Removed `newyear` from the `ThemeProvider` themes list in `app/layout.tsx` so the theme is no longer recognized at runtime.
- Removed the `New Year` option from the theme selector in `components/app/profile/settings.tsx` to prevent users from selecting it.
- Deleted the dedicated `.newyear` CSS variables block and cleaned up all `.newyear` references in `app/globals.css`, consolidating grouped selectors accordingly.
- Files changed: `app/layout.tsx`, `components/app/profile/settings.tsx`, and `app/globals.css`.

### Testing
- Ran `bun run generate:locales` which completed successfully.
- Attempted `bun run build` which failed in this environment due to `next` not being available on PATH (build exited with `command not found`).
- Attempted `bunx next --version` but registry access returned `403`, preventing a Next.js invocation in this environment.
- Verified with a code search that no remaining `newyear` or `New Year` references remain in the edited files using `rg` (no matches found).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6992b6531d7c8332967a293fe69cb4bb)

## Summary by Sourcery

在整个应用中移除对已弃用 `newyear` 主题的支持。

Enhancements:
- 从 ThemeProvider 配置中移除 `newyear`，使其不再作为可用的运行时主题。
- 从全局样式表中清理 `newyear` 专用的 CSS 变量和共享选择器。
- 从个人资料设置中的主题选择器 UI 中移除 `New Year` 选项。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Remove support for the deprecated `newyear` theme across the app.

Enhancements:
- Remove `newyear` from the ThemeProvider configuration so it is no longer an available runtime theme.
- Clean up `newyear`-specific CSS variables and shared selectors from the global stylesheet.
- Remove the `New Year` option from the profile settings theme selector UI.

</details>