### PR TITLE
fix: show auth waiting while Clerk validates __session cookie

### DIFF
--- a/app/(app)/app/page.tsx
+++ b/app/(app)/app/page.tsx
@@ -3,46 +3,23 @@
 import Calendar from "@/components/app/calendar"
 import AuthWaitingLoading from "@/components/app/auth-waiting-loading"
 import { useUser } from "@clerk/nextjs"
-import { useEffect, useMemo, useState } from "react"
+import { useMemo, useState } from "react"
 
-const AUTH_FLOW_ROUTES = ["/sign-in", "/sign-up", "/reset-password", "/sso-callback"]
+function hasClerkSessionCookie() {
+  if (typeof document === "undefined") return false
 
-function isFromAuthFlow(referrer: string) {
-  if (!referrer) return false
-
-  try {
-    const refUrl = new URL(referrer)
-    return AUTH_FLOW_ROUTES.some((route) => refUrl.pathname.includes(route))
-  } catch {
-    return false
-  }
+  return document.cookie
+    .split(";")
+    .some((cookie) => cookie.trim().startsWith("__session="))
 }
 
 export default function Home() {
   const { isLoaded } = useUser()
-  const [cameFromAuthFlow, setCameFromAuthFlow] = useState(false)
-  const [showDelayedWait, setShowDelayedWait] = useState(false)
-
-  useEffect(() => {
-    setCameFromAuthFlow(isFromAuthFlow(document.referrer))
-  }, [])
-
-  useEffect(() => {
-    if (!cameFromAuthFlow || isLoaded) {
-      setShowDelayedWait(false)
-      return
-    }
-
-    const timer = window.setTimeout(() => {
-      setShowDelayedWait(true)
-    }, 300)
-
-    return () => window.clearTimeout(timer)
-  }, [cameFromAuthFlow, isLoaded])
+  const [hasSessionCookie] = useState(hasClerkSessionCookie)
 
   const shouldShowAuthWait = useMemo(() => {
-    return cameFromAuthFlow && !isLoaded && showDelayedWait
-  }, [cameFromAuthFlow, isLoaded, showDelayedWait])
+    return hasSessionCookie && !isLoaded
+  }, [hasSessionCookie, isLoaded])
 
   if (shouldShowAuthWait) {
     return <AuthWaitingLoading />


### PR DESCRIPTION
### Motivation
- Fix the issue where the Auth waiting UI was not displayed while Clerk was validating an existing session after a page refresh. 
- Detect Clerk session restoration via the `__session` cookie instead of relying on referrer-based heuristics so the waiting UI appears only when Clerk is actually restoring a session. 

### Description
- Replaced the referrer-based auth-flow detection and delayed timer with a cookie check by adding `hasClerkSessionCookie()` in `app/(app)/app/page.tsx`. 
- Changed `shouldShowAuthWait` to `hasSessionCookie && !isLoaded` so `AuthWaitingLoading` renders only when a `__session` cookie exists and Clerk is still loading. 
- Removed the previous `cameFromAuthFlow` and delayed show logic since the cookie check covers the intended scenario. 

### Testing
- Ran `git diff` and confirmed the intended changes to `app/(app)/app/page.tsx` were applied and committed successfully. 
- Attempted `bun run build`, which failed due to `next` not being available in the environment (`next: command not found`). 
- Attempted `bun install`, which failed to resolve dependencies because npm registry requests returned 403, preventing full runtime validation.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6994523197448332bf998d8ac76f9022)

## Summary by Sourcery

更新身份验证等待界面的逻辑，不再依赖基于来源页（referrer）的启发式判断，而是依赖 Clerk 的 `__session` cookie 是否存在，这样加载界面只会在恢复已有会话时显示。

Bug 修复：
- 确保在页面刷新后，当 Clerk 正在主动恢复会话时，会显示身份验证等待界面。
- 消除依赖基于来源页路由检测和延迟计时器所导致的不正确的身份验证等待行为。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Update the auth waiting UI logic to rely on the presence of Clerk's __session cookie instead of referrer-based heuristics so that the loading screen appears only while an existing session is being restored.

Bug Fixes:
- Ensure the Auth waiting UI is shown after a page refresh when Clerk is actively restoring a session.
- Eliminate incorrect auth-waiting behavior that depended on referrer-based route detection and delayed timers.

</details>