### PR TITLE
Fix profile avatar loading and auth splash timing

### DIFF
--- a/app/(app)/app/page.tsx
+++ b/app/(app)/app/page.tsx
@@ -3,7 +3,7 @@
 import Calendar from "@/components/app/calendar"
 import AuthWaitingLoading from "@/components/app/auth-waiting-loading"
 import { useUser } from "@clerk/nextjs"
-import { useMemo, useState } from "react"
+import { useEffect, useMemo, useState } from "react"
 
 function hasClerkSessionCookie() {
   if (typeof document === "undefined") return false
@@ -15,11 +15,30 @@ function hasClerkSessionCookie() {
 
 export default function Home() {
   const { isLoaded } = useUser()
-  const [hasSessionCookie] = useState(hasClerkSessionCookie)
+  const [hasSessionCookie, setHasSessionCookie] = useState(hasClerkSessionCookie)
+  const [minimumWaitDone, setMinimumWaitDone] = useState(false)
+
+  useEffect(() => {
+    const waitTimer = window.setTimeout(() => {
+      setMinimumWaitDone(true)
+    }, 500)
+
+    const cookieCheckTimer = window.setInterval(() => {
+      if (hasClerkSessionCookie()) {
+        setHasSessionCookie(true)
+      }
+    }, 50)
+
+    return () => {
+      window.clearTimeout(waitTimer)
+      window.clearInterval(cookieCheckTimer)
+    }
+  }, [])
 
   const shouldShowAuthWait = useMemo(() => {
+    if (!minimumWaitDone) return true
     return hasSessionCookie && !isLoaded
-  }, [hasSessionCookie, isLoaded])
+  }, [minimumWaitDone, hasSessionCookie, isLoaded])
 
   if (shouldShowAuthWait) {
     return <AuthWaitingLoading />

--- a/components/app/profile/user-profile-button.tsx
+++ b/components/app/profile/user-profile-button.tsx
@@ -46,7 +46,6 @@ import { useCalendar } from "@/components/providers/calendar-context"
 import { translations, useLanguage } from "@/lib/i18n"
 import { useUser, SignOutButton } from "@clerk/nextjs"
 import { useRouter } from "next/navigation"
-import Image from "next/image"
 import { decryptPayload, encryptPayload, isEncryptedPayload } from "@/lib/crypto"
 import {
   clearEncryptionPassword,
@@ -509,7 +508,15 @@ export default function UserProfileButton({
           <DropdownMenuTrigger asChild>
             {isSignedIn && user?.imageUrl ? (
               <Button variant="ghost" size="icon" className="rounded-full overflow-hidden h-8 w-8 p-0">
-                <Image src={user.imageUrl} alt="avatar" width={32} height={32} className="rounded-full object-cover" />
+                <img
+                  src={user.imageUrl}
+                  alt="avatar"
+                  width={32}
+                  height={32}
+                  className="rounded-full object-cover"
+                  loading="lazy"
+                  referrerPolicy="no-referrer"
+                />
               </Button>
             ) : (
               <Button variant={variant} size="icon" className={`rounded-full h-10 w-10 ${className}`}>
@@ -573,12 +580,14 @@ export default function UserProfileButton({
           {isSignedIn ? (
             <>
               <div className="flex items-center gap-3">
-                <Image
+                <img
                   src={user?.imageUrl || "/placeholder.svg"}
                   alt="avatar"
                   width={40}
                   height={40}
                   className="h-10 w-10 rounded-full border object-cover"
+                  loading="lazy"
+                  referrerPolicy="no-referrer"
                 />
                 <div className="min-w-0">
                   <p className="font-medium truncate">{[user?.firstName, user?.lastName].filter(Boolean).join(" ") || user?.username || "User"}</p>
@@ -667,12 +676,14 @@ export default function UserProfileButton({
                 <div className="space-y-2">
                   <Label>{t.avatar}</Label>
                   <div className="flex items-center gap-3">
-                    <Image
+                    <img
                       src={user?.imageUrl || "/placeholder.svg"}
                       alt="avatar"
                       width={52}
                       height={52}
                       className="h-12 w-12 rounded-full border object-cover"
+                      loading="lazy"
+                      referrerPolicy="no-referrer"
                     />
                     <Label
                       htmlFor="profile-avatar-input"


### PR DESCRIPTION
### Motivation
- Fix avatar images in the user profile dropdown/panel that fail to load for certain remote formats (e.g. `.avif`) due to Next.js remote image optimization issues. 
- Prevent a brief flash of the calendar before the auth state is settled by enforcing a minimum auth-loading splash while still allowing early exit when Clerk is ready.

### Description
- Replaced `next/image` with native `<img>` for avatar rendering in `UserProfileButton` to avoid Next's remote optimization path and support arbitrary remote formats, and added `loading="lazy"` and `referrerPolicy="no-referrer"` for privacy and performance (`components/app/profile/user-profile-button.tsx`).
- Implemented a 500ms minimum auth splash in `app/(app)/app/page.tsx` by adding a `minimumWaitDone` state, polling for the Clerk session cookie during that window, and updating `shouldShowAuthWait` so the app continues to wait only when a session cookie exists and Clerk is not yet loaded.
- Added cleanup for timers used in the cookie polling and minimum-wait timer to avoid leaks during unmount.

### Testing
- Ran `npx tsc --noEmit` to type-check; the run failed in this environment due to missing project dependencies and global type resolution errors unrelated to these changes. 
- Attempted an automated Playwright navigation to `http://127.0.0.1:3000/app` to capture the auth view, but it failed with `ERR_EMPTY_RESPONSE` because no dev server was running in the environment.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6994560509a48332800fc82666b11b04)

## 由 Sourcery 提供的摘要

提升用户头像渲染的可靠性，并优化认证启动时的闪屏行为，避免在认证初始化阶段出现视觉闪烁。

错误修复：
- 通过使用原生图片标签而不是 Next.js 的图片优化，确保用户个人资料头像在远程图片格式下能够正确渲染。
- 通过将最小认证加载时间与 Clerk 会话就绪状态关联，防止在认证状态尚未解析完成前日历视图短暂闪现。

功能增强：
- 为个人资料头像图片添加懒加载和 no-referrer 策略，以提升性能并保护隐私。
- 为认证闪屏计时器添加清理逻辑，以避免组件卸载时可能出现的资源泄漏。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Improve reliability of user avatar rendering and refine the authentication splash behavior to avoid visual glitches during auth initialization.

Bug Fixes:
- Ensure user profile avatars render correctly for remote image formats by using native image tags instead of Next.js image optimization.
- Prevent the calendar view from flashing before authentication state is resolved by enforcing a minimum auth loading period tied to Clerk session readiness.

Enhancements:
- Add lazy loading and no-referrer policy to profile avatar images for better performance and privacy.
- Introduce cleanup for auth splash timers to avoid potential leaks on component unmount.

</details>