### PR TITLE
feat: small change

### DIFF
--- a/components/app/calendar.tsx
+++ b/components/app/calendar.tsx
@@ -146,6 +146,9 @@ export default function Calendar({ className, ...props }: CalendarProps) {
   const [quickCreateStartTime, setQuickCreateStartTime] = useState<Date | null>(
     null,
   );
+  const [quickCreateEndTime, setQuickCreateEndTime] = useState<Date | null>(
+    null,
+  );
 
   const [defaultView, setDefaultView] = useLocalStorage<ViewType>(
     "default-view",
@@ -440,8 +443,9 @@ export default function Calendar({ className, ...props }: CalendarProps) {
     setPreviewOpen(false);
   };
 
-  const handleTimeSlotClick = (clickTime: Date) => {
-    setQuickCreateStartTime(clickTime);
+  const handleTimeRangeSelect = (startTime: Date, endTime?: Date) => {
+    setQuickCreateStartTime(startTime);
+    setQuickCreateEndTime(endTime ?? null);
 
     setSelectedEvent(null);
     setEventDialogOpen(true);
@@ -728,7 +732,7 @@ export default function Calendar({ className, ...props }: CalendarProps) {
                 date={date}
                 events={filteredEvents}
                 onEventClick={handleEventClick}
-                onTimeSlotClick={handleTimeSlotClick}
+                onTimeSlotClick={handleTimeRangeSelect}
                 language={language}
                 timezone={timezone}
                 timeFormat={timeFormat}
@@ -756,7 +760,7 @@ export default function Calendar({ className, ...props }: CalendarProps) {
                 date={date}
                 events={filteredEvents}
                 onEventClick={handleEventClick}
-                onTimeSlotClick={handleTimeSlotClick}
+                onTimeSlotClick={handleTimeRangeSelect}
                 language={language}
                 firstDayOfWeek={firstDayOfWeek}
                 timezone={timezone}
@@ -785,7 +789,7 @@ export default function Calendar({ className, ...props }: CalendarProps) {
                 date={date}
                 events={filteredEvents}
                 onEventClick={handleEventClick}
-                onTimeSlotClick={handleTimeSlotClick}
+                onTimeSlotClick={handleTimeRangeSelect}
                 language={language}
                 firstDayOfWeek={firstDayOfWeek}
                 timezone={timezone}
@@ -900,6 +904,7 @@ export default function Calendar({ className, ...props }: CalendarProps) {
           onEventUpdate={handleEventUpdate}
           onEventDelete={handleEventDelete}
           initialDate={quickCreateStartTime || date}
+          initialEndDate={quickCreateEndTime}
           event={selectedEvent}
           language={language}
           timezone={timezone}

--- a/components/app/calendar.tsx
+++ b/components/app/calendar.tsx
@@ -580,7 +580,7 @@ export default function Calendar({ className, ...props }: CalendarProps) {
 
         <div className="flex min-h-0 min-w-0 flex-1 flex-col pr-14">
           {" "}
-          <header className="flex items-center justify-between px-4 h-16 border-b relative z-40 bg-background">
+          <header className="flex items-center px-4 h-16 border-b relative z-40 bg-background">
             <div className="flex items-center space-x-4">
               <Button variant="outline" onClick={toggleSidebar} size="sm">
                 <PanelLeft />
@@ -588,9 +588,6 @@ export default function Calendar({ className, ...props }: CalendarProps) {
               <Button variant="outline" size="sm" onClick={handleTodayClick}>
                 {t.today || "今天"}
               </Button>
-            </div>
-
-            <div className="flex items-center space-x-2">
               {view !== "analytics" && view !== "settings" && (
                 <>
                   <div className="flex items-center space-x-1">
@@ -610,7 +607,7 @@ export default function Calendar({ className, ...props }: CalendarProps) {
               )}
             </div>
 
-            <div className="flex items-center space-x-2">
+            <div className="ml-auto flex items-center space-x-2">
               <div className="relative z-50">
                 <Select
                   value={

--- a/components/app/event/event-dialog.tsx
+++ b/components/app/event/event-dialog.tsx
@@ -100,6 +100,7 @@ interface EventDialogProps {
   onEventUpdate: (event: CalendarEvent) => void;
   onEventDelete: (eventId: string) => void;
   initialDate: Date;
+  initialEndDate?: Date | null;
   event: CalendarEvent | null;
   language: Language;
   timezone: string;
@@ -119,6 +120,7 @@ export default function EventDialog({
   onEventUpdate,
   onEventDelete,
   initialDate,
+  initialEndDate,
   event,
   language,
   timezone,
@@ -309,34 +311,38 @@ export default function EventDialog({
       } else {
         resetForm();
         if (initialDate) {
-          setStartDate(initialDate);
+          const dialogStartDate = new Date(initialDate);
+          const dialogEndDate =
+            initialEndDate && initialEndDate > initialDate
+              ? new Date(initialEndDate)
+              : new Date(initialDate.getTime() + 30 * 60000);
+
+          setStartDate(dialogStartDate);
           if (calendars.length > 0) {
             setColor(getEventColorByCalendarId(calendars[0].id));
           }
-          setEndDate(initialDate);
+          setEndDate(dialogEndDate);
 
-          const initialHour = getHours(initialDate);
-          const initialMinute = getMinutes(initialDate);
-          const endTime = new Date(initialDate);
-          endTime.setMinutes(initialMinute + 30);
+          const initialHour = getHours(dialogStartDate);
+          const initialMinute = getMinutes(dialogStartDate);
 
           setStartTime({
             hours: initialHour.toString().padStart(2, "0"),
             minutes: initialMinute.toString().padStart(2, "0"),
-            rawInput: format(initialDate, "HH:mm"),
+            rawInput: format(dialogStartDate, "HH:mm"),
             isCustomInput: false,
           });
 
           setEndTime({
-            hours: getHours(endTime).toString().padStart(2, "0"),
-            minutes: getMinutes(endTime).toString().padStart(2, "0"),
-            rawInput: format(endTime, "HH:mm"),
+            hours: getHours(dialogEndDate).toString().padStart(2, "0"),
+            minutes: getMinutes(dialogEndDate).toString().padStart(2, "0"),
+            rawInput: format(dialogEndDate, "HH:mm"),
             isCustomInput: false,
           });
         }
       }
     }
-  }, [event, calendars, initialDate, open]);
+  }, [event, calendars, initialDate, initialEndDate, open]);
 
   const resetForm = () => {
     const now = new Date();


### PR DESCRIPTION
Codex generated this pull request, but encountered an unexpected error after generation. This is a placeholder PR message.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6996f2041cb483329372d351d1d75353)

## Summary by Sourcery

在日视图和周视图中启用拖拽选择时间段以快速创建事件，并将所选时间范围传递到事件对话框中。

新功能：
- 允许用户在日视图和周视图的网格上拖拽选择时间范围来创建事件，带有可视化的选区覆盖效果，并按 15 分钟间隔对齐（四分之一个小时的时间刻度）。
- 在事件对话框中，根据用户选择的时间范围同时初始化新事件的开始和结束时间，而不是使用固定时长。

增强：
- 更新日历视图的回调函数，使其在时间槽交互时接收开始时间和可选的结束时间，并将这些信息向上传递到主日历组件中的快速创建状态。
- 改进拖拽预览样式，在日视图和周视图中为被拖拽的事件添加明显的拖拽手柄指示。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Enable drag-to-select time ranges for quick event creation in day and week calendar views and plumb the selected range into the event dialog.

New Features:
- Allow users to drag across the day and week view grids to select a time range for creating events, with a visual selection overlay and quarter-hour snapping.
- Initialize new events in the event dialog with both start and end times based on the selected time range instead of a fixed duration.

Enhancements:
- Update calendar view callbacks to accept both start and optional end times for time slot interactions and propagate this through to quick-create state in the main calendar component.
- Improve drag preview styling by adding a visible handle indicator for dragged events in day and week views.

</details>