### PR TITLE
feat: add Bluesky (atproto) OAuth login and PDS-backed backup/share

### DIFF
--- a/app/(app)/[handle]/[id]/page.tsx
+++ b/app/(app)/[handle]/[id]/page.tsx
@@ -1,0 +1,9 @@
+"use client"
+
+import SharedEventView from "@/components/app/profile/shared-event"
+import { useParams } from "next/navigation"
+
+export default function AtprotoSharePage() {
+  const params = useParams()
+  return <SharedEventView shareId={params.id as string} handle={params.handle as string} />
+}

--- a/app/(auth)/atproto/page.tsx
+++ b/app/(auth)/atproto/page.tsx
@@ -1,0 +1,58 @@
+"use client"
+
+import { useState } from "react"
+import { Button } from "@/components/ui/button"
+import { Card, CardContent, CardDescription, CardHeader, CardTitle } from "@/components/ui/card"
+import { Input } from "@/components/ui/input"
+import { Label } from "@/components/ui/label"
+
+export default function AtprotoLoginPage() {
+  const [handle, setHandle] = useState("")
+  const [error, setError] = useState("")
+  const [loading, setLoading] = useState(false)
+
+  const startOauth = async () => {
+    try {
+      setLoading(true)
+      setError("")
+      const res = await fetch("/api/atproto/oauth/start", {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({ handle }),
+      })
+      const payload = await res.json()
+      if (!res.ok) {
+        setError(payload?.error || "Failed to start atproto OAuth")
+        return
+      }
+      window.location.href = payload.authUrl
+    } catch {
+      setError("Failed to start atproto OAuth")
+    } finally {
+      setLoading(false)
+    }
+  }
+
+  return (
+    <div className="relative flex min-h-svh flex-col items-center justify-center p-6 md:p-10">
+      <div className="relative z-10 flex w-full max-w-sm flex-col gap-6">
+        <Card>
+          <CardHeader className="text-center">
+            <CardTitle className="text-xl">Sign in with Bluesky / atproto</CardTitle>
+            <CardDescription>Enter your handle and continue with OAuth on your PDS.</CardDescription>
+          </CardHeader>
+          <CardContent className="grid gap-4">
+            <div className="grid gap-2">
+              <Label htmlFor="handle">Handle</Label>
+              <Input id="handle" placeholder="alice.bsky.social" value={handle} onChange={(e) => setHandle(e.target.value)} />
+            </div>
+            {error ? <p className="text-sm text-red-500">{error}</p> : null}
+            <Button disabled={!handle || loading} onClick={startOauth}>
+              {loading ? "Redirecting..." : "Continue with atproto OAuth"}
+            </Button>
+          </CardContent>
+        </Card>
+      </div>
+    </div>
+  )
+}

--- a/app/api/atproto/logout/route.ts
+++ b/app/api/atproto/logout/route.ts
@@ -1,0 +1,7 @@
+import { NextResponse } from "next/server"
+import { clearAtprotoSession } from "@/lib/atproto"
+
+export async function POST() {
+  await clearAtprotoSession()
+  return NextResponse.json({ success: true })
+}

--- a/app/api/atproto/oauth/callback/route.ts
+++ b/app/api/atproto/oauth/callback/route.ts
@@ -1,0 +1,65 @@
+import { NextRequest, NextResponse } from "next/server"
+import { clearAtprotoOauthState, getAtprotoOauthState, setAtprotoSession } from "@/lib/atproto"
+
+export async function GET(request: NextRequest) {
+  const code = request.nextUrl.searchParams.get("code")
+  const state = request.nextUrl.searchParams.get("state")
+
+  try {
+    const oauth = await getAtprotoOauthState()
+    if (!oauth || !code || !state || oauth.state !== state) {
+      return NextResponse.redirect(new URL("/atproto?error=oauth_state", request.url))
+    }
+
+    const clientId = process.env.ATPROTO_OAUTH_CLIENT_ID
+    const redirectUri = process.env.ATPROTO_OAUTH_REDIRECT_URI
+    if (!clientId || !redirectUri) {
+      return NextResponse.redirect(new URL("/atproto?error=oauth_config", request.url))
+    }
+
+    const tokenRes = await fetch(`${oauth.pds}/oauth/token`, {
+      method: "POST",
+      headers: { "Content-Type": "application/x-www-form-urlencoded" },
+      body: new URLSearchParams({
+        grant_type: "authorization_code",
+        code,
+        redirect_uri: redirectUri,
+        client_id: clientId,
+        code_verifier: oauth.verifier,
+      }),
+    })
+
+    if (!tokenRes.ok) {
+      return NextResponse.redirect(new URL("/atproto?error=oauth_token", request.url))
+    }
+
+    const token = await tokenRes.json() as {
+      access_token: string
+      refresh_token?: string
+      sub?: string
+    }
+
+    const did = token.sub || ""
+    if (!did) {
+      return NextResponse.redirect(new URL("/atproto?error=oauth_sub", request.url))
+    }
+
+    const profileRes = await fetch(`https://public.api.bsky.app/xrpc/app.bsky.actor.getProfile?actor=${encodeURIComponent(did)}`)
+    const profile = profileRes.ok ? await profileRes.json() as { handle?: string; displayName?: string; avatar?: string } : null
+
+    await setAtprotoSession({
+      did,
+      handle: profile?.handle || oauth.handle,
+      pds: oauth.pds,
+      accessToken: token.access_token,
+      refreshToken: token.refresh_token,
+      displayName: profile?.displayName,
+      avatar: profile?.avatar,
+    })
+    await clearAtprotoOauthState()
+
+    return NextResponse.redirect(new URL("/app", request.url))
+  } catch {
+    return NextResponse.redirect(new URL("/atproto?error=oauth_unknown", request.url))
+  }
+}

--- a/app/api/atproto/oauth/start/route.ts
+++ b/app/api/atproto/oauth/start/route.ts
@@ -1,0 +1,26 @@
+import { NextRequest, NextResponse } from "next/server"
+import { createPkce, resolveAtprotoHandle, setAtprotoOauthState } from "@/lib/atproto"
+
+export async function POST(request: NextRequest) {
+  try {
+    const { handle } = (await request.json()) as { handle?: string }
+    if (!handle) return NextResponse.json({ error: "Handle is required" }, { status: 400 })
+
+    const normalized = handle.replace(/^@/, "").trim().toLowerCase()
+    const { pds } = await resolveAtprotoHandle(normalized)
+    const { verifier, challenge, state } = createPkce()
+    await setAtprotoOauthState({ handle: normalized, pds, verifier, state })
+
+    const clientId = process.env.ATPROTO_OAUTH_CLIENT_ID
+    const redirectUri = process.env.ATPROTO_OAUTH_REDIRECT_URI
+    if (!clientId || !redirectUri) {
+      return NextResponse.json({ error: "Missing ATPROTO_OAUTH_CLIENT_ID or ATPROTO_OAUTH_REDIRECT_URI" }, { status: 500 })
+    }
+
+    const authUrl = `${pds}/oauth/authorize?response_type=code&client_id=${encodeURIComponent(clientId)}&redirect_uri=${encodeURIComponent(redirectUri)}&scope=${encodeURIComponent("atproto")}&state=${encodeURIComponent(state)}&code_challenge=${encodeURIComponent(challenge)}&code_challenge_method=S256`
+
+    return NextResponse.json({ authUrl, pds, handle: normalized })
+  } catch (error) {
+    return NextResponse.json({ error: error instanceof Error ? error.message : "Failed to start OAuth" }, { status: 500 })
+  }
+}

--- a/app/api/atproto/session/route.ts
+++ b/app/api/atproto/session/route.ts
@@ -1,0 +1,14 @@
+import { NextResponse } from "next/server"
+import { getAtprotoSession } from "@/lib/atproto"
+
+export async function GET() {
+  const session = await getAtprotoSession()
+  if (!session) return NextResponse.json({ authenticated: false })
+  return NextResponse.json({
+    authenticated: true,
+    handle: session.handle,
+    displayName: session.displayName,
+    avatar: session.avatar,
+    did: session.did,
+  })
+}

--- a/app/api/share/list/route.ts
+++ b/app/api/share/list/route.ts
@@ -1,89 +1,101 @@
-import { NextResponse } from "next/server";
-import { Pool } from "pg";
-import { currentUser } from "@clerk/nextjs/server";
-import crypto from "crypto";
+import { NextResponse } from "next/server"
+import { Pool } from "pg"
+import { currentUser } from "@clerk/nextjs/server"
+import crypto from "crypto"
+import { getAtprotoSession, listRecords } from "@/lib/atproto"
 
-const pool = new Pool({
-  connectionString: process.env.POSTGRES_URL,
-  ssl: { rejectUnauthorized: false },
-});
-
-const ALGORITHM = "aes-256-gcm";
+const pool = new Pool({ connectionString: process.env.POSTGRES_URL, ssl: { rejectUnauthorized: false } })
+const ALGORITHM = "aes-256-gcm"
+const ATPROTO_SHARE_COLLECTION = "app.onecalendar.record.share"
 
 function keyV2Unprotected(shareId: string) {
-  return crypto.createHash("sha256").update(shareId, "utf8").digest();
+  return crypto.createHash("sha256").update(shareId, "utf8").digest()
 }
 
 function decryptWithKey(encryptedData: string, iv: string, authTag: string, key: Buffer) {
-  const ivBuffer = Buffer.from(iv, "hex");
-  const authTagBuffer = Buffer.from(authTag, "hex");
-  const decipher = crypto.createDecipheriv(ALGORITHM, key, ivBuffer);
-  decipher.setAuthTag(authTagBuffer);
-  let decrypted = decipher.update(encryptedData, "hex", "utf8");
-  decrypted += decipher.final("utf8");
-  return decrypted;
+  const decipher = crypto.createDecipheriv(ALGORITHM, key, Buffer.from(iv, "hex"))
+  decipher.setAuthTag(Buffer.from(authTag, "hex"))
+  let decrypted = decipher.update(encryptedData, "hex", "utf8")
+  decrypted += decipher.final("utf8")
+  return decrypted
 }
 
 export async function GET() {
   try {
-    const user = await currentUser();
-    if (!user) return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
-    const userId = user.id;
+    const user = await currentUser()
+    const atproto = await getAtprotoSession()
+    if (!user && !atproto) return NextResponse.json({ error: "Unauthorized" }, { status: 401 })
 
-    const client = await pool.connect();
+    if (atproto) {
+      const records = await listRecords(atproto, ATPROTO_SHARE_COLLECTION)
+      const shares = records.map((record) => {
+        const value = record.value || {}
+        let eventId = ""
+        let eventTitle = ""
+        if (!value.isProtected) {
+          try {
+            const decrypted = decryptWithKey(value.encryptedData, value.iv, value.authTag, keyV2Unprotected(value.shareId))
+            const dataObj = JSON.parse(decrypted)
+            eventId = dataObj.id ?? ""
+            eventTitle = dataObj.title ?? ""
+          } catch {}
+        } else {
+          eventId = "受保护"
+          eventTitle = "受保护"
+        }
+        return {
+          id: value.shareId,
+          eventId,
+          eventTitle,
+          sharedBy: atproto.handle,
+          shareDate: value.timestamp,
+          shareLink: `/${atproto.handle.replace(/^@/, "")}/${value.shareId}`,
+          isProtected: !!value.isProtected,
+        }
+      })
+      return NextResponse.json({ shares })
+    }
+
+    const client = await pool.connect()
     try {
       const result = await client.query(
         `SELECT share_id, encrypted_data, iv, auth_tag, timestamp, is_protected
          FROM shares
          WHERE user_id = $1
          ORDER BY timestamp DESC`,
-        [userId]
-      );
+        [user!.id],
+      )
 
-      const shares = await Promise.all(
-        result.rows.map(async (row) => {
-          let eventId = "";
-          let eventTitle = "";
+      const shares = result.rows.map((row) => {
+        let eventId = ""
+        let eventTitle = ""
+        if (!row.is_protected) {
+          try {
+            const decrypted = decryptWithKey(row.encrypted_data, row.iv, row.auth_tag, keyV2Unprotected(row.share_id))
+            const dataObj = JSON.parse(decrypted)
+            eventId = dataObj.id ?? ""
+            eventTitle = dataObj.title ?? ""
+          } catch {}
+        } else {
+          eventId = "受保护"
+          eventTitle = "受保护"
+        }
+        return {
+          id: row.share_id,
+          eventId,
+          eventTitle,
+          sharedBy: user!.id,
+          shareDate: row.timestamp.toISOString(),
+          shareLink: `/share/${row.share_id}`,
+          isProtected: row.is_protected,
+        }
+      })
 
-          if (!row.is_protected) {
-            try {
-              const key = keyV2Unprotected(row.share_id);
-              const decrypted = decryptWithKey(row.encrypted_data, row.iv, row.auth_tag, key);
-              const dataObj = JSON.parse(decrypted);
-              eventId = dataObj.id ?? "";
-              eventTitle = dataObj.title ?? "";
-            } catch {
-              eventId = "";
-              eventTitle = "";
-            }
-          } else {
-            eventId = "受保护";
-            eventTitle = "受保护";
-          }
-
-          return {
-            id: row.share_id,
-            eventId,
-            eventTitle,
-            sharedBy: userId,
-            shareDate: row.timestamp.toISOString(),
-            shareLink: `/share/${row.share_id}`,
-            isProtected: row.is_protected,
-          };
-        })
-      );
-
-      return NextResponse.json({ shares });
+      return NextResponse.json({ shares })
     } finally {
-      client.release();
+      client.release()
     }
   } catch (error) {
-    return NextResponse.json(
-      {
-        error: error instanceof Error ? error.message : "Unknown error",
-        stack: error instanceof Error ? error.stack : undefined,
-      },
-      { status: 500 }
-    );
+    return NextResponse.json({ error: error instanceof Error ? error.message : "Unknown error" }, { status: 500 })
   }
 }

--- a/components/app/profile/shared-event.tsx
+++ b/components/app/profile/shared-event.tsx
@@ -50,6 +50,7 @@ interface SharedEvent {
 
 interface SharedEventViewProps {
   shareId: string;
+  handle?: string;
 }
 
 function getDarkerColorClass(color: string) {
@@ -68,7 +69,7 @@ function getDarkerColorClass(color: string) {
   return colorMapping[color] || '#3A3A3A';
 }
 
-export default function SharedEventView({ shareId }: SharedEventViewProps) {
+export default function SharedEventView({ shareId, handle }: SharedEventViewProps) {
   const router = useRouter();
   const { toast } = useToast();
   const [language] = useLanguage();
@@ -105,7 +106,7 @@ export default function SharedEventView({ shareId }: SharedEventViewProps) {
           return;
         }
 
-        const response = await fetch(`/api/share?id=${encodeURIComponent(shareId)}`);
+        const response = await fetch(`/api/share?id=${encodeURIComponent(shareId)}${handle ? `&handle=${encodeURIComponent(handle)}` : ""}`);
 
         if (!response.ok) {
           if (response.status === 401) {
@@ -137,7 +138,7 @@ export default function SharedEventView({ shareId }: SharedEventViewProps) {
     };
 
     fetchSharedEvent();
-  }, [shareId]);
+  }, [shareId, handle]);
 
   const tryDecryptWithPassword = async () => {
     if (!shareId) return;
@@ -152,7 +153,7 @@ export default function SharedEventView({ shareId }: SharedEventViewProps) {
       setPasswordSubmitting(true);
       setPasswordError(null);
 
-      const url = `/api/share?id=${encodeURIComponent(shareId)}&password=${encodeURIComponent(pwd)}`;
+      const url = `/api/share?id=${encodeURIComponent(shareId)}&password=${encodeURIComponent(pwd)}${handle ? `&handle=${encodeURIComponent(handle)}` : ""}`;
       const response = await fetch(url);
 
       if (!response.ok) {

--- a/components/auth/login-form.tsx
+++ b/components/auth/login-form.tsx
@@ -230,6 +230,11 @@ export function LoginForm({
                 </Button>
               </div>
               <div className="text-center text-sm">
+                <a href="/atproto" className="underline underline-offset-4">
+                  Sign in with Bluesky / atproto
+                </a>
+              </div>
+              <div className="text-center text-sm">
                 Don't have an account?{" "}
                 <a href="/sign-up" className="underline underline-offset-4">
                   Sign up

--- a/lib/atproto.ts
+++ b/lib/atproto.ts
@@ -1,0 +1,164 @@
+import crypto from "crypto"
+import { cookies } from "next/headers"
+
+const SESSION_COOKIE = "atproto_session"
+const OAUTH_COOKIE = "atproto_oauth"
+
+export type AtprotoSession = {
+  did: string
+  handle: string
+  pds: string
+  accessToken: string
+  refreshToken?: string
+  displayName?: string
+  avatar?: string
+}
+
+export type AtprotoOauthState = {
+  handle: string
+  pds: string
+  state: string
+  verifier: string
+}
+
+function base64url(input: Buffer | string) {
+  return Buffer.from(input).toString("base64url")
+}
+
+function getSecret() {
+  return process.env.ATPROTO_SESSION_SECRET || "dev-atproto-session-secret"
+}
+
+function sign(payload: string) {
+  return base64url(crypto.createHmac("sha256", getSecret()).update(payload).digest())
+}
+
+function pack<T>(value: T) {
+  const payload = base64url(JSON.stringify(value))
+  return `${payload}.${sign(payload)}`
+}
+
+function unpack<T>(raw?: string): T | null {
+  if (!raw) return null
+  const [payload, mac] = raw.split(".")
+  if (!payload || !mac) return null
+  if (sign(payload) !== mac) return null
+  try {
+    return JSON.parse(Buffer.from(payload, "base64url").toString("utf8")) as T
+  } catch {
+    return null
+  }
+}
+
+export async function getAtprotoSession(): Promise<AtprotoSession | null> {
+  const store = await cookies()
+  return unpack<AtprotoSession>(store.get(SESSION_COOKIE)?.value)
+}
+
+export async function setAtprotoSession(session: AtprotoSession) {
+  const store = await cookies()
+  store.set(SESSION_COOKIE, pack(session), {
+    httpOnly: true,
+    secure: process.env.NODE_ENV === "production",
+    sameSite: "lax",
+    path: "/",
+    maxAge: 60 * 60 * 24 * 30,
+  })
+}
+
+export async function clearAtprotoSession() {
+  const store = await cookies()
+  store.delete(SESSION_COOKIE)
+}
+
+export async function setAtprotoOauthState(payload: AtprotoOauthState) {
+  const store = await cookies()
+  store.set(OAUTH_COOKIE, pack(payload), {
+    httpOnly: true,
+    secure: process.env.NODE_ENV === "production",
+    sameSite: "lax",
+    path: "/",
+    maxAge: 60 * 10,
+  })
+}
+
+export async function getAtprotoOauthState() {
+  const store = await cookies()
+  return unpack<AtprotoOauthState>(store.get(OAUTH_COOKIE)?.value)
+}
+
+export async function clearAtprotoOauthState() {
+  const store = await cookies()
+  store.delete(OAUTH_COOKIE)
+}
+
+export async function resolveAtprotoHandle(handle: string) {
+  const resolved = await fetch(`https://public.api.bsky.app/xrpc/com.atproto.identity.resolveHandle?handle=${encodeURIComponent(handle)}`)
+  if (!resolved.ok) throw new Error("Failed to resolve handle")
+  const { did } = (await resolved.json()) as { did: string }
+  const plc = await fetch(`https://plc.directory/${did}`)
+  if (!plc.ok) throw new Error("Failed to resolve PDS")
+  const doc = await plc.json() as { service?: Array<{ id: string; serviceEndpoint: string }> }
+  const pds = doc.service?.find((s) => s.id === "#atproto_pds")?.serviceEndpoint
+  if (!pds) throw new Error("No PDS found for handle")
+  return { did, pds }
+}
+
+export function createPkce() {
+  const verifier = base64url(crypto.randomBytes(32))
+  const challenge = base64url(crypto.createHash("sha256").update(verifier).digest())
+  const state = base64url(crypto.randomBytes(16))
+  return { verifier, challenge, state }
+}
+
+export async function putRecord(session: AtprotoSession, collection: string, rkey: string, record: unknown) {
+  const res = await fetch(`${session.pds}/xrpc/com.atproto.repo.putRecord`, {
+    method: "POST",
+    headers: {
+      "Content-Type": "application/json",
+      Authorization: `Bearer ${session.accessToken}`,
+    },
+    body: JSON.stringify({
+      repo: session.did,
+      collection,
+      rkey,
+      record,
+    }),
+  })
+  if (!res.ok) {
+    throw new Error(`putRecord failed: ${res.status}`)
+  }
+}
+
+export async function getRecordFromPds(pds: string, repo: string, collection: string, rkey: string) {
+  const res = await fetch(`${pds}/xrpc/com.atproto.repo.getRecord?repo=${encodeURIComponent(repo)}&collection=${encodeURIComponent(collection)}&rkey=${encodeURIComponent(rkey)}`)
+  if (!res.ok) {
+    if (res.status === 400 || res.status === 404) return null
+    throw new Error(`getRecord failed: ${res.status}`)
+  }
+  const data = await res.json() as { value?: any }
+  return data.value ?? null
+}
+
+export async function listRecords(session: AtprotoSession, collection: string) {
+  const res = await fetch(`${session.pds}/xrpc/com.atproto.repo.listRecords?repo=${encodeURIComponent(session.did)}&collection=${encodeURIComponent(collection)}&limit=100`, {
+    headers: {
+      Authorization: `Bearer ${session.accessToken}`,
+    },
+  })
+  if (!res.ok) throw new Error(`listRecords failed: ${res.status}`)
+  const data = await res.json() as { records?: Array<{ uri: string; value: any }> }
+  return data.records || []
+}
+
+export async function deleteRecord(session: AtprotoSession, collection: string, rkey: string) {
+  const res = await fetch(`${session.pds}/xrpc/com.atproto.repo.deleteRecord`, {
+    method: "POST",
+    headers: {
+      "Content-Type": "application/json",
+      Authorization: `Bearer ${session.accessToken}`,
+    },
+    body: JSON.stringify({ repo: session.did, collection, rkey }),
+  })
+  if (!res.ok) throw new Error(`deleteRecord failed: ${res.status}`)
+}

--- a/proxy.ts
+++ b/proxy.ts
@@ -7,9 +7,12 @@ export default clerkMiddleware({
     "/sign-in",
     "/sign-up",
     "/reset-password",
+    "/atproto",
     "/api/blob",
     "/api/share",
-    "/api/verify"
+    "/api/verify",
+    "/api/atproto(.*)",
+    "/:handle/:id"
   ],
 })
 


### PR DESCRIPTION
### Motivation
- Add an alternative login flow using Bluesky / atproto handles and enable storing backups and shares directly in a user's PDS repo to provide decentralised storage for atproto users.
- Keep existing Clerk+Postgres flows working for non-atproto users while introducing a repo-backed path for backups and shares.
- Provide a single integration surface (PKCE + OAuth + signed session cookie) so client pages can detect an atproto session and read/write repo records.

### Description
- Added a new atproto helper library `lib/atproto.ts` that implements handle→DID/PDS resolution, PKCE helpers, signed cookie session packing/unpacking, and repo record helpers (`putRecord`, `getRecordFromPds`, `listRecords`, `deleteRecord`).
- Implemented an independent atproto login page at `/atproto` and OAuth endpoints `POST /api/atproto/oauth/start` and `GET /api/atproto/oauth/callback` which perform PDS discovery, PKCE flow, token exchange and persist an `atproto_session` cookie; added `/api/atproto/session` and `/api/atproto/logout` for client usage.
- Refactored backup endpoints (`app/api/blob/route.ts`) to support two storage channels: Clerk+Postgres for existing users, and when an atproto session is present save/load/delete the encrypted backup to/from the user's PDS repo collection `app.onecalendar.record.calendarEvents` (rkey `latest`).
- Refactored share endpoints (`app/api/share/route.ts` and `app/api/share/list/route.ts`) to support storing encrypted shares either in Postgres (existing flow) or in the atproto repo collection `app.onecalendar.record.share` for atproto users, and to resolve public fetches by `handle + shareId` by querying the correct PDS and decrypting server-side.
- Exposed atproto-aware share links `https://BASE_URL/{handle}/{shareId}` and added a dynamic public route `/{handle}/{id}` (`app/(app)/[handle]/[id]/page.tsx`) while updating the shared-event view to accept an optional `handle` parameter and include the atproto login entry in the existing sign-in UI.
- Updated middleware (`proxy.ts`) to allow public access to `/atproto`, `/api/atproto(.*)` and `/:handle/:id`; preserved DB-backed flows for users without atproto sessions and generated atproto-specific share links when applicable.

### Testing
- `npm run generate:locales` executed successfully in the environment and produced updated locales.
- `npm run build` could not complete in this environment because the `next` binary was not available (build aborted), so a full production build was not validated here.
- `npx tsc --noEmit` was attempted but failed due to missing installed dependencies/type definitions in this environment (global type errors unrelated to the atproto-specific changes were reported), so type-checking in a complete dev environment is recommended.
- A quick browser script trying to open `/atproto` failed because the local dev server was not running, so runtime verification requires starting the app and testing the PKCE/OAuth redirect flow against a configured atproto PDS; environment variables required for full flow are `ATPROTO_OAUTH_CLIENT_ID`, `ATPROTO_OAUTH_REDIRECT_URI`, and optionally `ATPROTO_SESSION_SECRET`.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69981b7f6ec883329f9a1fffa405878c)

## Summary by Sourcery

集成基于 Bluesky/atproto 的认证和存储，与现有的 Clerk/Postgres 流程并行使用，使其支持基于 PDS 的备份以及可通过 atproto handle 访问的共享事件链接。

新功能：
- 添加 atproto OAuth 登录流程，支持基于 handle 的登录发起、PKCE，以及通过签名 Cookie 进行会话管理。
- 引入基于 PDS 的存储，用于在独立的 atproto 仓库集合中保存加密的日历备份和共享事件。
- 为 atproto 用户提供可通过 `/{handle}/{shareId}` 访问的公共分享 URL，并在现有登录界面中展示 Bluesky/atproto 登录入口。

增强与改进：
- 扩展分享创建、获取、列表和删除 API，使其同时适用于 Clerk/Postgres 用户和通过 atproto 认证的用户，并保持加密和阅后即焚语义。
- 更新事件分享界面，以检测 atproto 会话，调整分享元数据，并根据当前的认证渠道生成相应的分享链接。
- 放宽认证中间件，以允许公共路由和与 atproto 相关的路由访问，同时继续保护应用的其他路径。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Integrate Bluesky/atproto-backed authentication and storage alongside existing Clerk/Postgres flows, enabling PDS-based backups and shared event links addressable by atproto handles.

New Features:
- Add atproto OAuth login flow with handle-based initiation, PKCE, and session management via signed cookies.
- Introduce PDS-backed storage for encrypted calendar backups and shared events in dedicated atproto repo collections.
- Expose public share URLs addressable as /{handle}/{shareId} for atproto users and surface Bluesky/atproto sign-in from the existing login UI.

Enhancements:
- Extend share creation, retrieval, listing, and deletion APIs to work for both Clerk/Postgres users and atproto-authenticated users, preserving encryption and burn-after-read semantics.
- Update event sharing UI to detect atproto sessions, adjust share metadata, and generate appropriate share links based on the active auth channel.
- Relax auth middleware to allow public and atproto-related routes while keeping protection for other app paths.

</details>