### PR TITLE
Fix atproto OAuth env handling and add client-metadata endpoint

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -12,3 +12,10 @@ POSTGRES_URL=postgres://postgres:postgres@localhost:5432/onecalendar
 # Optional, Cloudflare turnstile captcha
 NEXT_PUBLIC_TURNSTILE_SITE_KEY=site-key
 TURNSTILE_SECRET_KEY=secret-key
+
+# Optional, Bluesky / atproto OAuth
+# If omitted, NEXT_PUBLIC_BASE_URL is used.
+ATPROTO_OAUTH_BASE_URL=http://localhost:3000
+# Optional overrides (normally not needed)
+# ATPROTO_OAUTH_CLIENT_ID=https://your-domain.com/api/atproto/oauth/client-metadata
+# ATPROTO_OAUTH_REDIRECT_URI=https://your-domain.com/api/atproto/oauth/callback

--- a/README.md
+++ b/README.md
@@ -123,6 +123,26 @@ Then visit `http://localhost:3000`
 
 Copy `.env.example` to `.env` and fill in.
 
+#### Bluesky / atproto OAuth
+
+`/atproto` now supports automatic OAuth client metadata, so in most cases you only need:
+
+- `ATPROTO_OAUTH_BASE_URL` (or `NEXT_PUBLIC_BASE_URL`) set to your public app URL.
+
+The app will auto-generate:
+
+- `ATPROTO_OAUTH_CLIENT_ID` => `<BASE_URL>/api/atproto/oauth/client-metadata`
+- `ATPROTO_OAUTH_REDIRECT_URI` => `<BASE_URL>/api/atproto/oauth/callback`
+
+You can still set `ATPROTO_OAUTH_CLIENT_ID` / `ATPROTO_OAUTH_REDIRECT_URI` manually if you already have a custom atproto OAuth client configuration.
+
+To get a valid setup:
+
+1. Deploy the app on a public HTTPS domain (local `localhost` may not work with every PDS).
+2. Set `ATPROTO_OAUTH_BASE_URL` to that public URL.
+3. Open `<BASE_URL>/api/atproto/oauth/client-metadata` and ensure it returns JSON.
+4. Use `/atproto` login flow with your Bluesky handle.
+
 ## Tech Stack
 
 - [Next.js](https://nextjs.org)

--- a/app/api/atproto/oauth/callback/route.ts
+++ b/app/api/atproto/oauth/callback/route.ts
@@ -1,5 +1,6 @@
 import { NextRequest, NextResponse } from "next/server"
 import { clearAtprotoOauthState, getAtprotoOauthState, setAtprotoSession } from "@/lib/atproto"
+import { getAtprotoOauthConfig } from "@/lib/atproto-oauth"
 
 export async function GET(request: NextRequest) {
   const code = request.nextUrl.searchParams.get("code")
@@ -11,11 +12,12 @@ export async function GET(request: NextRequest) {
       return NextResponse.redirect(new URL("/atproto?error=oauth_state", request.url))
     }
 
-    const clientId = process.env.ATPROTO_OAUTH_CLIENT_ID
-    const redirectUri = process.env.ATPROTO_OAUTH_REDIRECT_URI
-    if (!clientId || !redirectUri) {
+    const oauthConfig = getAtprotoOauthConfig(request.url)
+    if (!oauthConfig) {
       return NextResponse.redirect(new URL("/atproto?error=oauth_config", request.url))
     }
+
+    const { clientId, redirectUri } = oauthConfig
 
     const tokenRes = await fetch(`${oauth.pds}/oauth/token`, {
       method: "POST",

--- a/app/api/atproto/oauth/client-metadata/route.ts
+++ b/app/api/atproto/oauth/client-metadata/route.ts
@@ -1,0 +1,20 @@
+import { NextRequest, NextResponse } from "next/server"
+import { getAtprotoOauthConfig } from "@/lib/atproto-oauth"
+
+export async function GET(request: NextRequest) {
+  const oauthConfig = getAtprotoOauthConfig(request.url)
+  if (!oauthConfig) {
+    return NextResponse.json({ error: "Missing ATPROTO OAuth base URL" }, { status: 500 })
+  }
+
+  return NextResponse.json({
+    client_id: oauthConfig.clientId,
+    client_name: "One Calendar",
+    application_type: "web",
+    grant_types: ["authorization_code", "refresh_token"],
+    response_types: ["code"],
+    redirect_uris: [oauthConfig.redirectUri],
+    scope: "atproto",
+    token_endpoint_auth_method: "none",
+  })
+}

--- a/app/api/atproto/oauth/start/route.ts
+++ b/app/api/atproto/oauth/start/route.ts
@@ -1,5 +1,6 @@
 import { NextRequest, NextResponse } from "next/server"
 import { createPkce, resolveAtprotoHandle, setAtprotoOauthState } from "@/lib/atproto"
+import { getAtprotoOauthConfig } from "@/lib/atproto-oauth"
 
 export async function POST(request: NextRequest) {
   try {
@@ -11,11 +12,12 @@ export async function POST(request: NextRequest) {
     const { verifier, challenge, state } = createPkce()
     await setAtprotoOauthState({ handle: normalized, pds, verifier, state })
 
-    const clientId = process.env.ATPROTO_OAUTH_CLIENT_ID
-    const redirectUri = process.env.ATPROTO_OAUTH_REDIRECT_URI
-    if (!clientId || !redirectUri) {
-      return NextResponse.json({ error: "Missing ATPROTO_OAUTH_CLIENT_ID or ATPROTO_OAUTH_REDIRECT_URI" }, { status: 500 })
+    const oauthConfig = getAtprotoOauthConfig(request.url)
+    if (!oauthConfig) {
+      return NextResponse.json({ error: "Missing ATPROTO OAuth base URL. Set ATPROTO_OAUTH_BASE_URL or NEXT_PUBLIC_BASE_URL." }, { status: 500 })
     }
+
+    const { clientId, redirectUri } = oauthConfig
 
     const authUrl = `${pds}/oauth/authorize?response_type=code&client_id=${encodeURIComponent(clientId)}&redirect_uri=${encodeURIComponent(redirectUri)}&scope=${encodeURIComponent("atproto")}&state=${encodeURIComponent(state)}&code_challenge=${encodeURIComponent(challenge)}&code_challenge_method=S256`
 

--- a/lib/atproto-oauth.ts
+++ b/lib/atproto-oauth.ts
@@ -1,0 +1,27 @@
+export type AtprotoOauthConfig = {
+  baseUrl: string
+  clientId: string
+  redirectUri: string
+}
+
+function trimTrailingSlash(value: string) {
+  return value.replace(/\/$/, "")
+}
+
+export function getAtprotoOauthConfig(requestUrl?: string): AtprotoOauthConfig | null {
+  const configuredBaseUrl = process.env.ATPROTO_OAUTH_BASE_URL || process.env.NEXT_PUBLIC_BASE_URL
+  const originFromRequest = requestUrl ? new URL(requestUrl).origin : undefined
+  const baseUrl = configuredBaseUrl || originFromRequest
+
+  if (!baseUrl) return null
+
+  const normalizedBaseUrl = trimTrailingSlash(baseUrl)
+  const redirectUri = process.env.ATPROTO_OAUTH_REDIRECT_URI || `${normalizedBaseUrl}/api/atproto/oauth/callback`
+  const clientId = process.env.ATPROTO_OAUTH_CLIENT_ID || `${normalizedBaseUrl}/api/atproto/oauth/client-metadata`
+
+  return {
+    baseUrl: normalizedBaseUrl,
+    clientId,
+    redirectUri,
+  }
+}


### PR DESCRIPTION
### Motivation

- The `/atproto` flow errored when `ATPROTO_OAUTH_CLIENT_ID` / `ATPROTO_OAUTH_REDIRECT_URI` were not set, so provide a safe default strategy that avoids hard failures. 
- Allow the app to serve OAuth client metadata so a deploy can use an auto-derived `client_id` instead of requiring manual values.

### Description

- Added `getAtprotoOauthConfig` in `lib/atproto-oauth.ts` which resolves OAuth settings from `ATPROTO_OAUTH_BASE_URL`, `NEXT_PUBLIC_BASE_URL`, or the request origin and derives `clientId` and `redirectUri` defaults. 
- Updated `app/api/atproto/oauth/start/route.ts` and `app/api/atproto/oauth/callback/route.ts` to use `getAtprotoOauthConfig(request.url)` and fall back with a clear error when no base URL can be determined. 
- Added `app/api/atproto/oauth/client-metadata/route.ts` to serve OAuth client metadata and used this URL as the default `client_id` (`<BASE_URL>/api/atproto/oauth/client-metadata`). 
- Documented the new behavior in `.env.example` and `README.md` and left optional overrides `ATPROTO_OAUTH_CLIENT_ID` and `ATPROTO_OAUTH_REDIRECT_URI` supported for custom setups. 

### Testing

- Ran `bun run generate:locales` which completed successfully. 
- Ran type-check `bunx tsc --noEmit` which reported repository-wide TypeScript/dependency errors unrelated to these changes (the change itself does not introduce new type errors).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69982058788c8332bf1d509fddcc2909)

## 由 Sourcery 提供的总结

通过从基础 URL 推导默认值并通过新端点暴露客户端元数据，改进 atproto OAuth 配置处理。

新功能：
- 通过已配置的或从请求推导出的基础 URL，自动推导 atproto OAuth 客户端 ID 和重定向 URI。
- 暴露一个 atproto OAuth 客户端元数据（client-metadata）API 端点，用作自动推导的客户端 ID。

错误修复：
- 当未显式设置 `ATPROTO_OAUTH_CLIENT_ID` 或 `ATPROTO_OAUTH_REDIRECT_URI` 时，通过回退到推导值，防止 atproto OAuth 流程失败。

增强：
- 在共享的辅助函数中集中处理 atproto OAuth 配置解析，从而简化 API 路由。

文档：
- 在 README 和 `.env.example` 中记录新的 atproto OAuth 配置行为及其默认值。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Improve atproto OAuth configuration handling by deriving defaults from a base URL and exposing client metadata via a new endpoint.

New Features:
- Add automatic derivation of atproto OAuth client ID and redirect URI from a configured or request-derived base URL.
- Expose an atproto OAuth client-metadata API endpoint for use as an auto-derived client ID.

Bug Fixes:
- Prevent atproto OAuth flows from failing when ATPROTO_OAUTH_CLIENT_ID or ATPROTO_OAUTH_REDIRECT_URI are not explicitly set by falling back to derived values.

Enhancements:
- Centralize atproto OAuth configuration resolution in a shared helper to simplify API routes.

Documentation:
- Document the new atproto OAuth configuration behavior and defaults in README and .env.example.

</details>