### PR TITLE
Validate signed atproto OAuth state token to prevent oauth_state callback failures

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -17,5 +17,6 @@ TURNSTILE_SECRET_KEY=secret-key
 # If omitted, NEXT_PUBLIC_BASE_URL is used.
 ATPROTO_OAUTH_BASE_URL=http://localhost:3000
 # Optional overrides (normally not needed)
-# ATPROTO_OAUTH_CLIENT_ID=https://your-domain.com/api/atproto/oauth/client-metadata
+# ATPROTO_OAUTH_CLIENT_METADATA_BASE_URL=https://your-vercel-deployment.vercel.app
+# ATPROTO_OAUTH_CLIENT_ID=https://your-domain.com/oauth/client-metadata
 # ATPROTO_OAUTH_REDIRECT_URI=https://your-domain.com/api/atproto/oauth/callback

--- a/README.md
+++ b/README.md
@@ -131,7 +131,7 @@ Copy `.env.example` to `.env` and fill in.
 
 The app will auto-generate:
 
-- `ATPROTO_OAUTH_CLIENT_ID` => `<BASE_URL>/api/atproto/oauth/client-metadata`
+- `ATPROTO_OAUTH_CLIENT_ID` => `<BASE_URL>/oauth/client-metadata`
 - `ATPROTO_OAUTH_REDIRECT_URI` => `<BASE_URL>/api/atproto/oauth/callback`
 
 You can still set `ATPROTO_OAUTH_CLIENT_ID` / `ATPROTO_OAUTH_REDIRECT_URI` manually if you already have a custom atproto OAuth client configuration.
@@ -140,7 +140,7 @@ To get a valid setup:
 
 1. Deploy the app on a public HTTPS domain (local `localhost` may not work with every PDS).
 2. Set `ATPROTO_OAUTH_BASE_URL` to that public URL.
-3. Open `<BASE_URL>/api/atproto/oauth/client-metadata` and ensure it returns JSON.
+3. Open `<BASE_URL>/oauth/client-metadata` and ensure it returns JSON.
 4. Use `/atproto` login flow with your Bluesky handle.
 
 If you see `Unable to obtain client metadata ... Too Many Requests`, make sure this endpoint can be heavily cached by public CDNs and does not require bot checks/firewall challenges. The app now returns cache headers for this route, but upstream protection (WAF/rate-limit) must still allow anonymous GET requests from PDS servers.

--- a/README.md
+++ b/README.md
@@ -136,6 +136,8 @@ The app will auto-generate:
 
 You can still set `ATPROTO_OAUTH_CLIENT_ID` / `ATPROTO_OAUTH_REDIRECT_URI` manually if you already have a custom atproto OAuth client configuration.
 
+If your custom domain is protected by Cloudflare/WAF and PDS requests get 429 before reaching Vercel, set `ATPROTO_OAUTH_CLIENT_METADATA_BASE_URL` to a publicly reachable host (for example your `*.vercel.app` deployment URL). The app will use `<ATPROTO_OAUTH_CLIENT_METADATA_BASE_URL>/oauth/client-metadata` as the default client metadata URL.
+
 To get a valid setup:
 
 1. Deploy the app on a public HTTPS domain (local `localhost` may not work with every PDS).
@@ -143,7 +145,7 @@ To get a valid setup:
 3. Open `<BASE_URL>/oauth/client-metadata` and ensure it returns JSON.
 4. Use `/atproto` login flow with your Bluesky handle.
 
-If you see `Unable to obtain client metadata ... Too Many Requests`, make sure this endpoint can be heavily cached by public CDNs and does not require bot checks/firewall challenges. The app now returns cache headers for this route, but upstream protection (WAF/rate-limit) must still allow anonymous GET requests from PDS servers.
+If you see `Unable to obtain client metadata ... Too Many Requests`, make sure this endpoint can be heavily cached by public CDNs and does not require bot checks/firewall challenges. If Vercel logs show no request, the 429 is likely returned by an upstream layer (for example Cloudflare) before traffic reaches Vercel.
 
 ## Tech Stack
 

--- a/README.md
+++ b/README.md
@@ -143,6 +143,8 @@ To get a valid setup:
 3. Open `<BASE_URL>/api/atproto/oauth/client-metadata` and ensure it returns JSON.
 4. Use `/atproto` login flow with your Bluesky handle.
 
+If you see `Unable to obtain client metadata ... Too Many Requests`, make sure this endpoint can be heavily cached by public CDNs and does not require bot checks/firewall challenges. The app now returns cache headers for this route, but upstream protection (WAF/rate-limit) must still allow anonymous GET requests from PDS servers.
+
 ## Tech Stack
 
 - [Next.js](https://nextjs.org)

--- a/README.md
+++ b/README.md
@@ -136,7 +136,7 @@ The app will auto-generate:
 
 You can still set `ATPROTO_OAUTH_CLIENT_ID` / `ATPROTO_OAUTH_REDIRECT_URI` manually if you already have a custom atproto OAuth client configuration.
 
-If your custom domain is protected by Cloudflare/WAF and PDS requests get 429 before reaching Vercel, set `ATPROTO_OAUTH_CLIENT_METADATA_BASE_URL` to a publicly reachable host (for example your `*.vercel.app` deployment URL). The app will use `<ATPROTO_OAUTH_CLIENT_METADATA_BASE_URL>/oauth/client-metadata` as the default client metadata URL.
+If your custom domain is protected by Cloudflare/WAF and PDS requests get 429 before reaching Vercel, set `ATPROTO_OAUTH_CLIENT_METADATA_BASE_URL` to a publicly reachable host. The app will use `<ATPROTO_OAUTH_CLIENT_METADATA_BASE_URL>/oauth/client-metadata` as the default client metadata URL. Do not use a protected Vercel preview URL that returns `Unauthorized` for anonymous requests.
 
 To get a valid setup:
 

--- a/app/(auth)/atproto/atproto-login-client.tsx
+++ b/app/(auth)/atproto/atproto-login-client.tsx
@@ -1,0 +1,69 @@
+"use client"
+
+import { useMemo, useState } from "react"
+import { useSearchParams } from "next/navigation"
+import { Button } from "@/components/ui/button"
+import { Card, CardContent, CardDescription, CardHeader, CardTitle } from "@/components/ui/card"
+import { Input } from "@/components/ui/input"
+import { Label } from "@/components/ui/label"
+
+export function AtprotoLoginClient() {
+  const [handle, setHandle] = useState("")
+  const [error, setError] = useState("")
+  const [loading, setLoading] = useState(false)
+  const searchParams = useSearchParams()
+  const queryError = searchParams.get("error") || ""
+  const queryErrorDescription = searchParams.get("error_description") || ""
+
+  const resolvedError = useMemo(() => {
+    if (error) return error
+    if (!queryError) return ""
+    if (queryErrorDescription) return `${queryError}: ${queryErrorDescription}`
+    return queryError
+  }, [error, queryError, queryErrorDescription])
+
+  const startOauth = async () => {
+    try {
+      setLoading(true)
+      setError("")
+      const res = await fetch("/api/atproto/oauth/start", {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({ handle }),
+      })
+      const payload = await res.json()
+      if (!res.ok) {
+        setError(payload?.error || "Failed to start atproto OAuth")
+        return
+      }
+      window.location.href = payload.authUrl
+    } catch {
+      setError("Failed to start atproto OAuth")
+    } finally {
+      setLoading(false)
+    }
+  }
+
+  return (
+    <div className="relative flex min-h-svh flex-col items-center justify-center p-6 md:p-10">
+      <div className="relative z-10 flex w-full max-w-sm flex-col gap-6">
+        <Card>
+          <CardHeader className="text-center">
+            <CardTitle className="text-xl">Sign in with Bluesky / atproto</CardTitle>
+            <CardDescription>Enter your handle and continue with OAuth on your PDS.</CardDescription>
+          </CardHeader>
+          <CardContent className="grid gap-4">
+            <div className="grid gap-2">
+              <Label htmlFor="handle">Handle</Label>
+              <Input id="handle" placeholder="alice.bsky.social" value={handle} onChange={(e) => setHandle(e.target.value)} />
+            </div>
+            {resolvedError ? <p className="text-sm text-red-500">{resolvedError}</p> : null}
+            <Button disabled={!handle || loading} onClick={startOauth}>
+              {loading ? "Redirecting..." : "Continue with atproto OAuth"}
+            </Button>
+          </CardContent>
+        </Card>
+      </div>
+    </div>
+  )
+}

--- a/app/(auth)/atproto/page.tsx
+++ b/app/(auth)/atproto/page.tsx
@@ -1,69 +1,10 @@
-"use client"
-
-import { useMemo, useState } from "react"
-import { Button } from "@/components/ui/button"
-import { Card, CardContent, CardDescription, CardHeader, CardTitle } from "@/components/ui/card"
-import { Input } from "@/components/ui/input"
-import { Label } from "@/components/ui/label"
-import { useSearchParams } from "next/navigation"
+import { Suspense } from "react"
+import { AtprotoLoginClient } from "./atproto-login-client"
 
 export default function AtprotoLoginPage() {
-  const [handle, setHandle] = useState("")
-  const [error, setError] = useState("")
-  const [loading, setLoading] = useState(false)
-  const searchParams = useSearchParams()
-  const queryError = searchParams.get("error") || ""
-  const queryErrorDescription = searchParams.get("error_description") || ""
-
-  const resolvedError = useMemo(() => {
-    if (error) return error
-    if (!queryError) return ""
-    if (queryErrorDescription) return `${queryError}: ${queryErrorDescription}`
-    return queryError
-  }, [error, queryError, queryErrorDescription])
-
-  const startOauth = async () => {
-    try {
-      setLoading(true)
-      setError("")
-      const res = await fetch("/api/atproto/oauth/start", {
-        method: "POST",
-        headers: { "Content-Type": "application/json" },
-        body: JSON.stringify({ handle }),
-      })
-      const payload = await res.json()
-      if (!res.ok) {
-        setError(payload?.error || "Failed to start atproto OAuth")
-        return
-      }
-      window.location.href = payload.authUrl
-    } catch {
-      setError("Failed to start atproto OAuth")
-    } finally {
-      setLoading(false)
-    }
-  }
-
   return (
-    <div className="relative flex min-h-svh flex-col items-center justify-center p-6 md:p-10">
-      <div className="relative z-10 flex w-full max-w-sm flex-col gap-6">
-        <Card>
-          <CardHeader className="text-center">
-            <CardTitle className="text-xl">Sign in with Bluesky / atproto</CardTitle>
-            <CardDescription>Enter your handle and continue with OAuth on your PDS.</CardDescription>
-          </CardHeader>
-          <CardContent className="grid gap-4">
-            <div className="grid gap-2">
-              <Label htmlFor="handle">Handle</Label>
-              <Input id="handle" placeholder="alice.bsky.social" value={handle} onChange={(e) => setHandle(e.target.value)} />
-            </div>
-            {resolvedError ? <p className="text-sm text-red-500">{resolvedError}</p> : null}
-            <Button disabled={!handle || loading} onClick={startOauth}>
-              {loading ? "Redirecting..." : "Continue with atproto OAuth"}
-            </Button>
-          </CardContent>
-        </Card>
-      </div>
-    </div>
+    <Suspense fallback={<div className="min-h-svh" />}>
+      <AtprotoLoginClient />
+    </Suspense>
   )
 }

--- a/app/(auth)/atproto/page.tsx
+++ b/app/(auth)/atproto/page.tsx
@@ -1,15 +1,26 @@
 "use client"
 
-import { useState } from "react"
+import { useMemo, useState } from "react"
 import { Button } from "@/components/ui/button"
 import { Card, CardContent, CardDescription, CardHeader, CardTitle } from "@/components/ui/card"
 import { Input } from "@/components/ui/input"
 import { Label } from "@/components/ui/label"
+import { useSearchParams } from "next/navigation"
 
 export default function AtprotoLoginPage() {
   const [handle, setHandle] = useState("")
   const [error, setError] = useState("")
   const [loading, setLoading] = useState(false)
+  const searchParams = useSearchParams()
+  const queryError = searchParams.get("error") || ""
+  const queryErrorDescription = searchParams.get("error_description") || ""
+
+  const resolvedError = useMemo(() => {
+    if (error) return error
+    if (!queryError) return ""
+    if (queryErrorDescription) return `${queryError}: ${queryErrorDescription}`
+    return queryError
+  }, [error, queryError, queryErrorDescription])
 
   const startOauth = async () => {
     try {
@@ -46,7 +57,7 @@ export default function AtprotoLoginPage() {
               <Label htmlFor="handle">Handle</Label>
               <Input id="handle" placeholder="alice.bsky.social" value={handle} onChange={(e) => setHandle(e.target.value)} />
             </div>
-            {error ? <p className="text-sm text-red-500">{error}</p> : null}
+            {resolvedError ? <p className="text-sm text-red-500">{resolvedError}</p> : null}
             <Button disabled={!handle || loading} onClick={startOauth}>
               {loading ? "Redirecting..." : "Continue with atproto OAuth"}
             </Button>

--- a/app/api/atproto/oauth/callback/route.ts
+++ b/app/api/atproto/oauth/callback/route.ts
@@ -7,11 +7,17 @@ export async function GET(request: NextRequest) {
   const state = request.nextUrl.searchParams.get("state")
   const issuer = request.nextUrl.searchParams.get("iss")
   const providerError = request.nextUrl.searchParams.get("error")
+  const providerErrorDescription = request.nextUrl.searchParams.get("error_description")
 
   try {
     if (providerError) {
       await clearAtprotoOauthState()
-      return NextResponse.redirect(new URL(`/atproto?error=${encodeURIComponent(`oauth_provider_${providerError}`)}`, request.url))
+      const redirectUrl = new URL("/atproto", request.url)
+      redirectUrl.searchParams.set("error", `oauth_provider_${providerError}`)
+      if (providerErrorDescription) {
+        redirectUrl.searchParams.set("error_description", providerErrorDescription)
+      }
+      return NextResponse.redirect(redirectUrl)
     }
 
     const oauthFromState = state ? parseAtprotoStateToken(state) : null

--- a/app/api/atproto/oauth/client-metadata/route.ts
+++ b/app/api/atproto/oauth/client-metadata/route.ts
@@ -2,7 +2,7 @@ import { NextResponse } from "next/server"
 import { getAtprotoOauthConfig } from "@/lib/atproto-oauth"
 
 export const dynamic = "force-static"
-export const revalidate = 60 * 60 * 24
+export const revalidate = 86400
 
 export async function GET() {
   const oauthConfig = getAtprotoOauthConfig()

--- a/app/api/atproto/oauth/client-metadata/route.ts
+++ b/app/api/atproto/oauth/client-metadata/route.ts
@@ -1,20 +1,30 @@
-import { NextRequest, NextResponse } from "next/server"
+import { NextResponse } from "next/server"
 import { getAtprotoOauthConfig } from "@/lib/atproto-oauth"
 
-export async function GET(request: NextRequest) {
-  const oauthConfig = getAtprotoOauthConfig(request.url)
+export const dynamic = "force-static"
+export const revalidate = 60 * 60 * 24
+
+export async function GET() {
+  const oauthConfig = getAtprotoOauthConfig()
   if (!oauthConfig) {
     return NextResponse.json({ error: "Missing ATPROTO OAuth base URL" }, { status: 500 })
   }
 
-  return NextResponse.json({
-    client_id: oauthConfig.clientId,
-    client_name: "One Calendar",
-    application_type: "web",
-    grant_types: ["authorization_code", "refresh_token"],
-    response_types: ["code"],
-    redirect_uris: [oauthConfig.redirectUri],
-    scope: "atproto",
-    token_endpoint_auth_method: "none",
-  })
+  return NextResponse.json(
+    {
+      client_id: oauthConfig.clientId,
+      client_name: "One Calendar",
+      application_type: "web",
+      grant_types: ["authorization_code", "refresh_token"],
+      response_types: ["code"],
+      redirect_uris: [oauthConfig.redirectUri],
+      scope: "atproto",
+      token_endpoint_auth_method: "none",
+    },
+    {
+      headers: {
+        "Cache-Control": "public, max-age=300, s-maxage=86400, stale-while-revalidate=604800",
+      },
+    },
+  )
 }

--- a/app/api/atproto/oauth/start/route.ts
+++ b/app/api/atproto/oauth/start/route.ts
@@ -10,7 +10,7 @@ export async function POST(request: NextRequest) {
     const normalized = handle.replace(/^@/, "").trim().toLowerCase()
     const { pds } = await resolveAtprotoHandle(normalized)
     const { verifier, challenge, state } = createPkce()
-    const stateToken = createAtprotoStateToken({ handle: normalized, pds, verifier })
+    const stateToken = createAtprotoStateToken(verifier)
     await setAtprotoOauthState({ handle: normalized, pds, verifier, state })
 
     const oauthConfig = getAtprotoOauthConfig(request.url)

--- a/app/api/atproto/oauth/start/route.ts
+++ b/app/api/atproto/oauth/start/route.ts
@@ -9,9 +9,9 @@ export async function POST(request: NextRequest) {
 
     const normalized = handle.replace(/^@/, "").trim().toLowerCase()
     const { pds } = await resolveAtprotoHandle(normalized)
-    const { verifier, challenge, state } = createPkce()
+    const { verifier, challenge } = createPkce()
     const stateToken = createAtprotoStateToken(verifier)
-    await setAtprotoOauthState({ handle: normalized, pds, verifier, state })
+    await setAtprotoOauthState({ handle: normalized, pds, verifier, state: stateToken })
 
     const oauthConfig = getAtprotoOauthConfig(request.url)
     if (!oauthConfig) {
@@ -20,7 +20,30 @@ export async function POST(request: NextRequest) {
 
     const { clientId, redirectUri } = oauthConfig
 
-    const authUrl = `${pds}/oauth/authorize?response_type=code&client_id=${encodeURIComponent(clientId)}&redirect_uri=${encodeURIComponent(redirectUri)}&scope=${encodeURIComponent("atproto")}&state=${encodeURIComponent(stateToken)}&code_challenge=${encodeURIComponent(challenge)}&code_challenge_method=S256`
+    const parRes = await fetch(`${pds}/oauth/par`, {
+      method: "POST",
+      headers: { "Content-Type": "application/x-www-form-urlencoded" },
+      body: new URLSearchParams({
+        response_type: "code",
+        client_id: clientId,
+        redirect_uri: redirectUri,
+        scope: "atproto",
+        state: stateToken,
+        code_challenge: challenge,
+        code_challenge_method: "S256",
+      }),
+    })
+
+    let authUrl: string
+    if (parRes.ok) {
+      const payload = await parRes.json() as { request_uri?: string }
+      if (!payload.request_uri) {
+        return NextResponse.json({ error: "PDS did not return request_uri" }, { status: 502 })
+      }
+      authUrl = `${pds}/oauth/authorize?client_id=${encodeURIComponent(clientId)}&request_uri=${encodeURIComponent(payload.request_uri)}`
+    } else {
+      authUrl = `${pds}/oauth/authorize?response_type=code&client_id=${encodeURIComponent(clientId)}&redirect_uri=${encodeURIComponent(redirectUri)}&scope=${encodeURIComponent("atproto")}&state=${encodeURIComponent(stateToken)}&code_challenge=${encodeURIComponent(challenge)}&code_challenge_method=S256`
+    }
 
     return NextResponse.json({ authUrl, pds, handle: normalized })
   } catch (error) {

--- a/app/oauth/client-metadata/route.ts
+++ b/app/oauth/client-metadata/route.ts
@@ -1,17 +1,18 @@
-import { NextRequest, NextResponse } from "next/server"
+import { NextResponse } from "next/server"
 import { getAtprotoOauthConfig } from "@/lib/atproto-oauth"
 
-export async function GET(request: NextRequest) {
-  const oauthConfig = getAtprotoOauthConfig(request.url)
+export const dynamic = "force-static"
+export const revalidate = 86400
+
+export async function GET() {
+  const oauthConfig = getAtprotoOauthConfig()
   if (!oauthConfig) {
     return NextResponse.json({ error: "Missing ATPROTO OAuth base URL" }, { status: 500 })
   }
 
-  const legacyClientId = process.env.ATPROTO_OAUTH_CLIENT_ID || `${oauthConfig.baseUrl}/api/atproto/oauth/client-metadata`
-
   return NextResponse.json(
     {
-      client_id: legacyClientId,
+      client_id: oauthConfig.clientId,
       client_name: "One Calendar",
       application_type: "web",
       grant_types: ["authorization_code", "refresh_token"],

--- a/lib/atproto-oauth.ts
+++ b/lib/atproto-oauth.ts
@@ -19,8 +19,7 @@ export function getAtprotoOauthConfig(requestUrl?: string): AtprotoOauthConfig |
   const redirectUri = process.env.ATPROTO_OAUTH_REDIRECT_URI || `${normalizedBaseUrl}/api/atproto/oauth/callback`
   const explicitClientId = process.env.ATPROTO_OAUTH_CLIENT_ID
   const metadataBaseUrl = process.env.ATPROTO_OAUTH_CLIENT_METADATA_BASE_URL
-  const vercelDeploymentUrl = process.env.VERCEL_URL ? `https://${process.env.VERCEL_URL}` : undefined
-  const fallbackMetadataBaseUrl = metadataBaseUrl || vercelDeploymentUrl || normalizedBaseUrl
+  const fallbackMetadataBaseUrl = metadataBaseUrl || normalizedBaseUrl
   const clientId = explicitClientId || `${trimTrailingSlash(fallbackMetadataBaseUrl)}/oauth/client-metadata`
 
   return {

--- a/lib/atproto-oauth.ts
+++ b/lib/atproto-oauth.ts
@@ -17,7 +17,11 @@ export function getAtprotoOauthConfig(requestUrl?: string): AtprotoOauthConfig |
 
   const normalizedBaseUrl = trimTrailingSlash(baseUrl)
   const redirectUri = process.env.ATPROTO_OAUTH_REDIRECT_URI || `${normalizedBaseUrl}/api/atproto/oauth/callback`
-  const clientId = process.env.ATPROTO_OAUTH_CLIENT_ID || `${normalizedBaseUrl}/oauth/client-metadata`
+  const explicitClientId = process.env.ATPROTO_OAUTH_CLIENT_ID
+  const metadataBaseUrl = process.env.ATPROTO_OAUTH_CLIENT_METADATA_BASE_URL
+  const vercelDeploymentUrl = process.env.VERCEL_URL ? `https://${process.env.VERCEL_URL}` : undefined
+  const fallbackMetadataBaseUrl = metadataBaseUrl || vercelDeploymentUrl || normalizedBaseUrl
+  const clientId = explicitClientId || `${trimTrailingSlash(fallbackMetadataBaseUrl)}/oauth/client-metadata`
 
   return {
     baseUrl: normalizedBaseUrl,

--- a/lib/atproto-oauth.ts
+++ b/lib/atproto-oauth.ts
@@ -17,7 +17,7 @@ export function getAtprotoOauthConfig(requestUrl?: string): AtprotoOauthConfig |
 
   const normalizedBaseUrl = trimTrailingSlash(baseUrl)
   const redirectUri = process.env.ATPROTO_OAUTH_REDIRECT_URI || `${normalizedBaseUrl}/api/atproto/oauth/callback`
-  const clientId = process.env.ATPROTO_OAUTH_CLIENT_ID || `${normalizedBaseUrl}/api/atproto/oauth/client-metadata`
+  const clientId = process.env.ATPROTO_OAUTH_CLIENT_ID || `${normalizedBaseUrl}/oauth/client-metadata`
 
   return {
     baseUrl: normalizedBaseUrl,

--- a/lib/atproto.ts
+++ b/lib/atproto.ts
@@ -107,8 +107,7 @@ export async function resolveAtprotoHandle(handle: string) {
 export function createPkce() {
   const verifier = base64url(crypto.randomBytes(32))
   const challenge = base64url(crypto.createHash("sha256").update(verifier).digest())
-  const state = base64url(crypto.randomBytes(16))
-  return { verifier, challenge, state }
+  return { verifier, challenge }
 }
 
 export function createAtprotoStateToken(verifier: string) {

--- a/proxy.ts
+++ b/proxy.ts
@@ -8,6 +8,7 @@ export default clerkMiddleware({
     "/sign-up",
     "/reset-password",
     "/atproto",
+    "/oauth/client-metadata",
     "/api/blob",
     "/api/share",
     "/api/verify",


### PR DESCRIPTION
### Motivation
- Callback requests were sometimes redirected to `/atproto?error=oauth_state` because the existing verification relied solely on a cookie-stored state that can be lost or not round-tripped reliably.
- The goal is to make callback verification robust by accepting a signed, expiring `state` token returned from the provider while keeping cookie-based fallback for compatibility.

### Description
- Add a signed/expiring state token implementation in `lib/atproto.ts` with `createAtprotoStateToken` and `parseAtprotoStateToken` using the existing `pack`/`unpack` signing helpers and a default 10 minute lifetime.  (file: `lib/atproto.ts`)
- Update the OAuth start endpoint to generate a signed state token and send it as the provider `state` parameter while still setting the legacy cookie state. (file: `app/api/atproto/oauth/start/route.ts`)
- Update the OAuth callback endpoint to prefer validating the signed `state` token and fall back to the cookie + state comparison when the token is not present or invalid. (file: `app/api/atproto/oauth/callback/route.ts`)
- The changes preserve existing cookie behavior for backward compatibility and limit reliance on cookies for successful verification.

### Testing
- Attempted a TypeScript check with `bunx tsc --noEmit`, which failed in this environment due to many missing project dependencies/type declarations unrelated to these changes; the failure appears to be environmental rather than introduced by this change. 
- No other automated tests were run in this environment.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69982290ea0c83328bfc8e6c693e957e)

## Summary by Sourcery

使用签名且会过期的 state token 验证 atproto OAuth 回调，同时保留基于 cookie 的回退机制以保持兼容性。

New Features:
- 引入签名的、限时有效的 atproto OAuth state token 格式，用于在 OAuth 流程中携带 handle、PDS 和 verifier。

Bug Fixes:
- 防止在旧的基于 cookie 的 state 缺失或未正确往返时，OAuth 回调因 oauth_state 错误而失败。

Enhancements:
- 更新 OAuth 启动与回调路由，将签名的 state token 作为主要验证机制，同时保留之前基于 cookie 的 state 作为回退方案。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Validate atproto OAuth callbacks using a signed, expiring state token while retaining cookie-based fallback for compatibility.

New Features:
- Introduce a signed, time-limited atproto OAuth state token format for carrying handle, PDS, and verifier through the OAuth flow.

Bug Fixes:
- Prevent OAuth callbacks from failing with oauth_state errors when the legacy cookie-based state is missing or not round-tripped.

Enhancements:
- Update OAuth start and callback routes to use the signed state token as the primary verification mechanism, with the previous cookie-based state kept as a fallback.

</details>