### PR TITLE
fix(at-oauth): resolve invalid submission by using PAR request_uri + proper callback txn

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,6 +1,5 @@
 # Required
 NEXT_PUBLIC_BASE_URL=http://localhost:3000
-NEXT_PUBLIC_APP_URL=http://localhost:3000
 SALT=Backup-Salt
 
 # Auth (Required)
@@ -8,18 +7,7 @@ NEXT_PUBLIC_CLERK_PUBLISHABLE_KEY=your-clerk-publishable-key
 CLERK_SECRET_KEY=your-clerk-secret
 
 # ATProto / Atmosphere (Required if enabling ATProto login)
-# Preferred: key rotation format (first key is active): kid:secret,kid_old:secret_old
-ATPROTO_SESSION_KEYS=v1:replace-with-strong-random-secret
-# Alternative rotation envs (used when ATPROTO_SESSION_KEYS is empty)
-ATPROTO_SESSION_SECRET_CURRENT=
-ATPROTO_SESSION_SECRET_PREVIOUS=
-# Legacy fallback secret (used only when rotation envs above are empty)
-ATPROTO_SESSION_SECRET=
-# Optional explicit OAuth client_id. If empty, app uses: ${NEXT_PUBLIC_APP_URL}/oauth-client-metadata.json
-ATPROTO_CLIENT_ID=
-
-# Optional fallback secret for legacy compatibility
-NEXTAUTH_SECRET=
+ATPROTO_SESSION_SECRET=replace-with-strong-random-secret
 
 # Optional, database
 POSTGRES_URL=postgres://postgres:postgres@localhost:5432/onecalendar

--- a/.env.example
+++ b/.env.example
@@ -1,10 +1,25 @@
-# Required 
+# Required
 NEXT_PUBLIC_BASE_URL=http://localhost:3000
+NEXT_PUBLIC_APP_URL=http://localhost:3000
 SALT=Backup-Salt
 
 # Auth (Required)
 NEXT_PUBLIC_CLERK_PUBLISHABLE_KEY=your-clerk-publishable-key
 CLERK_SECRET_KEY=your-clerk-secret
+
+# ATProto / Atmosphere (Required if enabling ATProto login)
+# Preferred: key rotation format (first key is active): kid:secret,kid_old:secret_old
+ATPROTO_SESSION_KEYS=v1:replace-with-strong-random-secret
+# Alternative rotation envs (used when ATPROTO_SESSION_KEYS is empty)
+ATPROTO_SESSION_SECRET_CURRENT=
+ATPROTO_SESSION_SECRET_PREVIOUS=
+# Legacy fallback secret (used only when rotation envs above are empty)
+ATPROTO_SESSION_SECRET=
+# Optional explicit OAuth client_id. If empty, app uses: ${NEXT_PUBLIC_APP_URL}/oauth-client-metadata.json
+ATPROTO_CLIENT_ID=
+
+# Optional fallback secret for legacy compatibility
+NEXTAUTH_SECRET=
 
 # Optional, database
 POSTGRES_URL=postgres://postgres:postgres@localhost:5432/onecalendar

--- a/README.md
+++ b/README.md
@@ -123,6 +123,30 @@ Then visit `http://localhost:3000`
 
 Copy `.env.example` to `.env` and fill in.
 
+Key variables:
+
+```env
+# Core
+NEXT_PUBLIC_BASE_URL=http://localhost:3000
+NEXT_PUBLIC_APP_URL=http://localhost:3000
+SALT=Backup-Salt
+
+# Clerk
+NEXT_PUBLIC_CLERK_PUBLISHABLE_KEY=...
+CLERK_SECRET_KEY=...
+
+# ATProto / Atmosphere (required for /at-oauth)
+ATPROTO_SESSION_KEYS=v1:...,v0:...   # key rotation (first key is active)
+ATPROTO_SESSION_SECRET_CURRENT=...   # optional alt rotation vars
+ATPROTO_SESSION_SECRET_PREVIOUS=...
+ATPROTO_SESSION_SECRET=...           # legacy fallback
+ATPROTO_CLIENT_ID=                   # optional override; defaults to ${NEXT_PUBLIC_APP_URL}/oauth-client-metadata.json
+NEXTAUTH_SECRET=                     # optional legacy fallback
+
+# Optional DB (backup/share sync)
+POSTGRES_URL=postgres://postgres:postgres@localhost:5432/onecalendar
+```
+
 ## Tech Stack
 
 - [Next.js](https://nextjs.org)

--- a/README.md
+++ b/README.md
@@ -128,7 +128,6 @@ Key variables:
 ```env
 # Core
 NEXT_PUBLIC_BASE_URL=http://localhost:3000
-NEXT_PUBLIC_APP_URL=http://localhost:3000
 SALT=Backup-Salt
 
 # Clerk
@@ -136,12 +135,7 @@ NEXT_PUBLIC_CLERK_PUBLISHABLE_KEY=...
 CLERK_SECRET_KEY=...
 
 # ATProto / Atmosphere (required for /at-oauth)
-ATPROTO_SESSION_KEYS=v1:...,v0:...   # key rotation (first key is active)
-ATPROTO_SESSION_SECRET_CURRENT=...   # optional alt rotation vars
-ATPROTO_SESSION_SECRET_PREVIOUS=...
-ATPROTO_SESSION_SECRET=...           # legacy fallback
-ATPROTO_CLIENT_ID=                   # optional override; defaults to ${NEXT_PUBLIC_APP_URL}/oauth-client-metadata.json
-NEXTAUTH_SECRET=                     # optional legacy fallback
+ATPROTO_SESSION_SECRET=...
 
 # Optional DB (backup/share sync)
 POSTGRES_URL=postgres://postgres:postgres@localhost:5432/onecalendar

--- a/app/(app)/app/page.tsx
+++ b/app/(app)/app/page.tsx
@@ -14,9 +14,10 @@ function hasClerkSessionCookie() {
 }
 
 export default function Home() {
-  const { isLoaded } = useUser()
+  const { isLoaded, isSignedIn } = useUser()
   const [hasSessionCookie, setHasSessionCookie] = useState(hasClerkSessionCookie)
   const [minimumWaitDone, setMinimumWaitDone] = useState(false)
+  const [atprotoLogoutDone, setAtprotoLogoutDone] = useState(false)
 
   useEffect(() => {
     const waitTimer = window.setTimeout(() => {
@@ -34,6 +35,13 @@ export default function Home() {
       window.clearInterval(cookieCheckTimer)
     }
   }, [])
+
+  useEffect(() => {
+    if (!isLoaded || !isSignedIn || atprotoLogoutDone) return
+    fetch("/api/atproto/logout", { method: "POST" })
+      .catch(() => undefined)
+      .finally(() => setAtprotoLogoutDone(true))
+  }, [isLoaded, isSignedIn, atprotoLogoutDone])
 
   const shouldShowAuthWait = useMemo(() => {
     if (!minimumWaitDone) return true

--- a/app/(auth)/sign-in/sso-callback/page.tsx
+++ b/app/(auth)/sign-in/sso-callback/page.tsx
@@ -7,6 +7,7 @@ export default function SSOSignInCallback() {
   const { setSession } = useClerk();
 
   useEffect(() => {
+    fetch("/api/atproto/logout", { method: "POST" }).catch(() => undefined);
     setSession?.({ forceRedirectUrl: '/app' });
   }, [setSession]);
 

--- a/app/(auth)/sign-up/sso-callback/page.tsx
+++ b/app/(auth)/sign-up/sso-callback/page.tsx
@@ -7,6 +7,7 @@ export default function SSOSignUpCallback() {
   const { setSession } = useClerk();
 
   useEffect(() => {
+    fetch("/api/atproto/logout", { method: "POST" }).catch(() => undefined);
     setSession?.({ forceRedirectUrl: '/app' });
   }, [setSession]);
 

--- a/app/[handle]/[shareId]/page.tsx
+++ b/app/[handle]/[shareId]/page.tsx
@@ -1,0 +1,9 @@
+"use client";
+
+import SharedEventView from "@/components/app/profile/shared-event";
+import { useParams } from "next/navigation";
+
+export default function AtprotoSharePage() {
+  const params = useParams();
+  return <SharedEventView handle={params.handle as string} shareId={params.shareId as string} />;
+}

--- a/app/api/atproto/callback/route.ts
+++ b/app/api/atproto/callback/route.ts
@@ -1,0 +1,160 @@
+import { NextRequest, NextResponse } from "next/server";
+import { getActorProfileRecord, getProfile, profileAvatarBlobUrl } from "@/lib/atproto";
+import { setAtprotoSession } from "@/lib/atproto-auth";
+import { clearAtprotoOAuthTxnCookie, consumeAtprotoOAuthTxn, getAtprotoOAuthTxnFromRequest } from "@/lib/atproto-oauth-txn";
+import { createDpopProof, type DpopPublicJwk } from "@/lib/dpop";
+
+function parseJsonSafe<T>(value: string): T | null {
+  try {
+    return JSON.parse(value) as T;
+  } catch {
+    return null;
+  }
+}
+
+function redirectWithError(baseUrl: string, error: string, reason?: string) {
+  const url = new URL(`${baseUrl}/at-oauth`);
+  url.searchParams.set("error", error);
+  if (reason) {
+    url.searchParams.set("reason", reason);
+  }
+
+  const response = NextResponse.redirect(url.toString());
+  clearAtprotoOAuthTxnCookie(response);
+  return response;
+}
+
+function normalizeIssuerOrigin(value: string) {
+  const parsed = new URL(value);
+  if (parsed.protocol !== "https:") {
+    throw new Error("Issuer must use https");
+  }
+  return parsed.origin;
+}
+
+export async function GET(request: NextRequest) {
+  const code = request.nextUrl.searchParams.get("code");
+  const state = request.nextUrl.searchParams.get("state");
+  const iss = request.nextUrl.searchParams.get("iss");
+
+  const baseUrl = process.env.NEXT_PUBLIC_APP_URL || request.nextUrl.origin;
+  const txn = getAtprotoOAuthTxnFromRequest(request);
+
+  if (!code || !state || !txn || state !== txn.state) {
+    return redirectWithError(baseUrl, "oauth_state_mismatch");
+  }
+
+  if (!consumeAtprotoOAuthTxn(txn)) {
+    return redirectWithError(baseUrl, "oauth_state_mismatch", "transaction_already_used");
+  }
+
+  const { verifier, handle, pds, did, dpopPrivateKeyPem, dpopPublicJwk } = txn;
+
+  if (!dpopPublicJwk?.kty || !dpopPublicJwk?.crv || !dpopPublicJwk?.x || !dpopPublicJwk?.y) {
+    return redirectWithError(baseUrl, "invalid_dpop_key");
+  }
+
+  let issuerOrigin: string;
+  let pdsOrigin: string;
+  try {
+    pdsOrigin = normalizeIssuerOrigin(pds);
+    issuerOrigin = iss ? normalizeIssuerOrigin(iss) : pdsOrigin;
+  } catch {
+    return redirectWithError(baseUrl, "invalid_issuer");
+  }
+
+  if (issuerOrigin !== pdsOrigin) {
+    return redirectWithError(baseUrl, "invalid_issuer", "issuer_mismatch");
+  }
+
+  const clientId = process.env.ATPROTO_CLIENT_ID || `${baseUrl}/oauth-client-metadata.json`;
+  const redirectUri = `${baseUrl}/api/atproto/callback`;
+  const tokenUrl = `${issuerOrigin}/oauth/token`;
+
+  const makeTokenRequest = async (nonce?: string) => {
+    const dpopProof = createDpopProof({
+      htu: tokenUrl,
+      htm: "POST",
+      privateKeyPem: dpopPrivateKeyPem,
+      publicJwk: dpopPublicJwk as DpopPublicJwk,
+      nonce,
+    });
+
+    return fetch(tokenUrl, {
+      method: "POST",
+      headers: {
+        "Content-Type": "application/x-www-form-urlencoded",
+        DPoP: dpopProof,
+      },
+      body: new URLSearchParams({
+        grant_type: "authorization_code",
+        code,
+        redirect_uri: redirectUri,
+        client_id: clientId,
+        code_verifier: verifier,
+      }),
+    });
+  };
+
+  let tokenRes = await makeTokenRequest();
+  if (!tokenRes.ok) {
+    const nonce = tokenRes.headers.get("DPoP-Nonce") || tokenRes.headers.get("dpop-nonce");
+    if (nonce) {
+      tokenRes = await makeTokenRequest(nonce);
+    }
+  }
+
+  if (!tokenRes.ok) {
+    const detailText = await tokenRes.text();
+    const detailJson = parseJsonSafe<{ error?: string; error_description?: string }>(detailText);
+    const reason = detailJson?.error_description || detailJson?.error || detailText.slice(0, 160) || "token_exchange_failed";
+    return redirectWithError(baseUrl, "token_exchange_failed", reason);
+  }
+
+  const tokenData = (await tokenRes.json()) as { access_token?: string; refresh_token?: string; sub?: string };
+  if (!tokenData.access_token) {
+    return redirectWithError(baseUrl, "missing_access_token");
+  }
+
+  const actorDid = tokenData.sub || did;
+  if (!actorDid) {
+    return redirectWithError(baseUrl, "missing_subject");
+  }
+
+  const profile = await getProfile(pds, actorDid, tokenData.access_token, {
+    privateKeyPem: dpopPrivateKeyPem,
+    publicJwk: dpopPublicJwk,
+  });
+
+  const actorProfile = await getActorProfileRecord({
+    pds,
+    repo: actorDid,
+    accessToken: tokenData.access_token,
+    dpopPrivateKeyPem,
+    dpopPublicJwk,
+  }).catch(() => undefined);
+
+  const avatarCid = actorProfile?.avatar?.ref?.$link;
+  const avatarUrl = profileAvatarBlobUrl({ pds, did: actorDid, cid: avatarCid }) || profile?.avatar;
+
+  await setAtprotoSession({
+    did: actorDid,
+    handle: profile?.handle || handle,
+    pds,
+    accessToken: tokenData.access_token,
+    refreshToken: tokenData.refresh_token,
+    displayName: actorProfile?.displayName || profile?.displayName,
+    avatar: avatarUrl,
+    dpopPrivateKeyPem,
+    dpopPublicJwk,
+  });
+
+  const response = NextResponse.redirect(`${baseUrl}/app`);
+  clearAtprotoOAuthTxnCookie(response);
+
+  ["__session", "__client_uat", "__clerk_db_jwt", "__clerk_handshake"].forEach((key) => {
+    response.cookies.delete(key);
+  });
+
+  return response;
+}

--- a/app/api/atproto/callback/route.ts
+++ b/app/api/atproto/callback/route.ts
@@ -37,7 +37,7 @@ export async function GET(request: NextRequest) {
   const state = request.nextUrl.searchParams.get("state");
   const iss = request.nextUrl.searchParams.get("iss");
 
-  const baseUrl = process.env.NEXT_PUBLIC_APP_URL || request.nextUrl.origin;
+  const baseUrl = process.env.NEXT_PUBLIC_BASE_URL || request.nextUrl.origin;
   const txn = getAtprotoOAuthTxnFromRequest(request);
 
   if (!code || !state || !txn || state !== txn.state) {
@@ -67,7 +67,7 @@ export async function GET(request: NextRequest) {
     return redirectWithError(baseUrl, "invalid_issuer", "issuer_mismatch");
   }
 
-  const clientId = process.env.ATPROTO_CLIENT_ID || `${baseUrl}/oauth-client-metadata.json`;
+  const clientId = `${baseUrl}/oauth-client-metadata.json`;
   const redirectUri = `${baseUrl}/api/atproto/callback`;
   const tokenUrl = `${issuerOrigin}/oauth/token`;
 

--- a/app/api/atproto/login/route.ts
+++ b/app/api/atproto/login/route.ts
@@ -1,0 +1,118 @@
+import { randomUUID } from "node:crypto";
+import { NextRequest, NextResponse } from "next/server";
+import { createPkcePair, resolveHandle } from "@/lib/atproto";
+import { generateDpopKeyMaterial } from "@/lib/dpop";
+import { setAtprotoOAuthTxnCookie } from "@/lib/atproto-oauth-txn";
+
+const LOGIN_RATE_WINDOW_MS = 10 * 60 * 1000;
+const LOGIN_RATE_LIMIT = 20;
+const loginRateCache = new Map<string, { count: number; resetAt: number }>();
+
+function getExpectedBaseUrl(request: NextRequest) {
+  return process.env.NEXT_PUBLIC_APP_URL || request.nextUrl.origin;
+}
+
+function isAllowedOrigin(request: NextRequest, expectedBaseUrl: string) {
+  const expected = new URL(expectedBaseUrl);
+  const origin = request.headers.get("origin");
+  if (origin) {
+    try {
+      const parsed = new URL(origin);
+      if (parsed.origin !== expected.origin) return false;
+    } catch {
+      return false;
+    }
+  }
+
+  const host = (request.headers.get("x-forwarded-host") || request.headers.get("host") || "").toLowerCase();
+  if (host && host !== expected.host.toLowerCase()) {
+    return false;
+  }
+
+  return true;
+}
+
+function checkRateLimit(request: NextRequest, handle: string) {
+  const now = Date.now();
+  for (const [key, value] of loginRateCache.entries()) {
+    if (value.resetAt <= now) loginRateCache.delete(key);
+  }
+
+  const ip = request.headers.get("x-forwarded-for")?.split(",")[0]?.trim() || "unknown";
+  const key = `${ip}:${handle}`;
+  const record = loginRateCache.get(key);
+
+  if (!record || record.resetAt <= now) {
+    loginRateCache.set(key, { count: 1, resetAt: now + LOGIN_RATE_WINDOW_MS });
+    return true;
+  }
+
+  if (record.count >= LOGIN_RATE_LIMIT) {
+    return false;
+  }
+
+  record.count += 1;
+  loginRateCache.set(key, record);
+  return true;
+}
+
+export async function POST(request: NextRequest) {
+  const expectedBaseUrl = getExpectedBaseUrl(request);
+  if (!isAllowedOrigin(request, expectedBaseUrl)) {
+    return NextResponse.json({ error: "Forbidden" }, { status: 403 });
+  }
+
+  const { handle } = (await request.json()) as { handle?: string };
+  if (!handle) return NextResponse.json({ error: "Missing handle" }, { status: 400 });
+
+  const normalizedHandle = handle.replace(/^@/, "").toLowerCase();
+  if (!/^[a-z0-9.-]{3,253}$/.test(normalizedHandle)) {
+    return NextResponse.json({ error: "Invalid handle" }, { status: 400 });
+  }
+
+  if (!checkRateLimit(request, normalizedHandle)) {
+    return NextResponse.json({ error: "Too many requests" }, { status: 429 });
+  }
+
+  const { did, pds } = await resolveHandle(normalizedHandle);
+  const { verifier, challenge } = createPkcePair();
+  const state = randomUUID();
+  const dpop = generateDpopKeyMaterial();
+
+  const redirectUri = `${expectedBaseUrl}/api/atproto/callback`;
+  const clientId = process.env.ATPROTO_CLIENT_ID || `${expectedBaseUrl}/oauth-client-metadata.json`;
+
+  const authUrl = new URL(`${pds.replace(/\/$/, "")}/oauth/authorize`);
+  authUrl.searchParams.set("client_id", clientId);
+  authUrl.searchParams.set("redirect_uri", redirectUri);
+  authUrl.searchParams.set("response_type", "code");
+  authUrl.searchParams.set("scope", "atproto transition:generic");
+  authUrl.searchParams.set("state", state);
+  authUrl.searchParams.set("code_challenge", challenge);
+  authUrl.searchParams.set("code_challenge_method", "S256");
+  authUrl.searchParams.set("dpop_jkt", dpop.jkt);
+
+  const response = NextResponse.json({ authorizeUrl: authUrl.toString(), pds, did });
+  const secure = request.nextUrl.protocol === "https:" || process.env.NODE_ENV === "production";
+  setAtprotoOAuthTxnCookie(
+    response,
+    {
+      jti: randomUUID(),
+      state,
+      verifier,
+      handle: normalizedHandle,
+      pds,
+      did,
+      dpopPrivateKeyPem: dpop.privateKeyPem,
+      dpopPublicJwk: dpop.publicJwk,
+      issuedAt: Math.floor(Date.now() / 1000),
+    },
+    secure,
+  );
+
+  ["__session", "__client_uat", "__clerk_db_jwt", "__clerk_handshake"].forEach((key) => {
+    response.cookies.delete(key);
+  });
+
+  return response;
+}

--- a/app/api/atproto/login/route.ts
+++ b/app/api/atproto/login/route.ts
@@ -9,7 +9,7 @@ const LOGIN_RATE_LIMIT = 20;
 const loginRateCache = new Map<string, { count: number; resetAt: number }>();
 
 function getExpectedBaseUrl(request: NextRequest) {
-  return process.env.NEXT_PUBLIC_APP_URL || request.nextUrl.origin;
+  return process.env.NEXT_PUBLIC_BASE_URL || request.nextUrl.origin;
 }
 
 function isAllowedOrigin(request: NextRequest, expectedBaseUrl: string) {
@@ -80,7 +80,7 @@ export async function POST(request: NextRequest) {
   const dpop = generateDpopKeyMaterial();
 
   const redirectUri = `${expectedBaseUrl}/api/atproto/callback`;
-  const clientId = process.env.ATPROTO_CLIENT_ID || `${expectedBaseUrl}/oauth-client-metadata.json`;
+  const clientId = `${expectedBaseUrl}/oauth-client-metadata.json`;
 
   const authUrl = new URL(`${pds.replace(/\/$/, "")}/oauth/authorize`);
   authUrl.searchParams.set("client_id", clientId);

--- a/app/api/atproto/logout/route.ts
+++ b/app/api/atproto/logout/route.ts
@@ -1,0 +1,7 @@
+import { NextResponse } from "next/server";
+import { clearAtprotoSession } from "@/lib/atproto-auth";
+
+export async function POST() {
+  await clearAtprotoSession();
+  return NextResponse.json({ success: true });
+}

--- a/app/api/atproto/register-url/route.ts
+++ b/app/api/atproto/register-url/route.ts
@@ -1,0 +1,73 @@
+import { randomUUID } from "node:crypto";
+import { NextRequest, NextResponse } from "next/server";
+import { createPkcePair } from "@/lib/atproto";
+import { setAtprotoOAuthTxnCookie } from "@/lib/atproto-oauth-txn";
+import { generateDpopKeyMaterial } from "@/lib/dpop";
+
+const ROSE_PDS_ORIGIN = "https://rose.madebydanny.uk";
+
+function getBaseUrl(request: NextRequest) {
+  return process.env.NEXT_PUBLIC_APP_URL || request.nextUrl.origin;
+}
+
+export async function POST(request: NextRequest) {
+  const baseUrl = getBaseUrl(request);
+  const clientId = process.env.ATPROTO_CLIENT_ID || `${baseUrl}/oauth-client-metadata.json`;
+  const authorizeUrl = new URL(`${ROSE_PDS_ORIGIN}/oauth/authorize`);
+
+  const { verifier, challenge } = createPkcePair();
+  const state = randomUUID();
+  const dpop = generateDpopKeyMaterial();
+  const redirectUri = `${baseUrl}/api/atproto/callback`;
+
+  const parRes = await fetch(`${ROSE_PDS_ORIGIN}/oauth/par`, {
+    method: "POST",
+    headers: {
+      "Content-Type": "application/x-www-form-urlencoded",
+    },
+    body: new URLSearchParams({
+      client_id: clientId,
+      redirect_uri: redirectUri,
+      response_type: "code",
+      scope: "atproto transition:generic",
+      state,
+      code_challenge: challenge,
+      code_challenge_method: "S256",
+      dpop_jkt: dpop.jkt,
+    }),
+    cache: "no-store",
+  });
+
+  if (!parRes.ok) {
+    const detail = (await parRes.text()).slice(0, 200) || "par_failed";
+    return NextResponse.json({ error: `Rose PAR failed: ${detail}` }, { status: 502 });
+  }
+
+  const parJson = (await parRes.json()) as { request_uri?: string };
+  if (!parJson.request_uri) {
+    return NextResponse.json({ error: "Rose PAR response missing request_uri" }, { status: 502 });
+  }
+
+  authorizeUrl.searchParams.set("client_id", clientId);
+  authorizeUrl.searchParams.set("request_uri", parJson.request_uri);
+
+  const response = NextResponse.json({ authorizeUrl: authorizeUrl.toString() });
+  const secure = request.nextUrl.protocol === "https:" || process.env.NODE_ENV === "production";
+  setAtprotoOAuthTxnCookie(
+    response,
+    {
+      jti: randomUUID(),
+      state,
+      verifier,
+      handle: "",
+      pds: ROSE_PDS_ORIGIN,
+      did: "",
+      dpopPrivateKeyPem: dpop.privateKeyPem,
+      dpopPublicJwk: dpop.publicJwk,
+      issuedAt: Math.floor(Date.now() / 1000),
+    },
+    secure,
+  );
+
+  return response;
+}

--- a/app/api/atproto/register-url/route.ts
+++ b/app/api/atproto/register-url/route.ts
@@ -7,12 +7,12 @@ import { generateDpopKeyMaterial } from "@/lib/dpop";
 const ROSE_PDS_ORIGIN = "https://rose.madebydanny.uk";
 
 function getBaseUrl(request: NextRequest) {
-  return process.env.NEXT_PUBLIC_APP_URL || request.nextUrl.origin;
+  return process.env.NEXT_PUBLIC_BASE_URL || request.nextUrl.origin;
 }
 
 export async function POST(request: NextRequest) {
   const baseUrl = getBaseUrl(request);
-  const clientId = process.env.ATPROTO_CLIENT_ID || `${baseUrl}/oauth-client-metadata.json`;
+  const clientId = `${baseUrl}/oauth-client-metadata.json`;
   const authorizeUrl = new URL(`${ROSE_PDS_ORIGIN}/oauth/authorize`);
 
   const { verifier, challenge } = createPkcePair();

--- a/app/api/atproto/session/route.ts
+++ b/app/api/atproto/session/route.ts
@@ -1,0 +1,43 @@
+import { NextResponse } from "next/server";
+import { getActorProfileRecord, profileAvatarBlobUrl } from "@/lib/atproto";
+import { getAtprotoSession, setAtprotoSession } from "@/lib/atproto-auth";
+
+export async function GET() {
+  const session = await getAtprotoSession();
+  if (!session) return NextResponse.json({ signedIn: false });
+
+  let avatar = session.avatar;
+  let displayName = session.displayName;
+
+  if (session.accessToken && session.did && session.pds) {
+    const actorProfile = await getActorProfileRecord({
+      pds: session.pds,
+      repo: session.did,
+      accessToken: session.accessToken,
+      dpopPrivateKeyPem: session.dpopPrivateKeyPem,
+      dpopPublicJwk: session.dpopPublicJwk,
+    }).catch(() => undefined);
+
+    const avatarCid = actorProfile?.avatar?.ref?.$link;
+    const resolvedAvatar = profileAvatarBlobUrl({ pds: session.pds, did: session.did, cid: avatarCid });
+
+    if (resolvedAvatar || actorProfile?.displayName) {
+      avatar = resolvedAvatar || avatar;
+      displayName = actorProfile?.displayName || displayName;
+      await setAtprotoSession({
+        ...session,
+        avatar,
+        displayName,
+      });
+    }
+  }
+
+  return NextResponse.json({
+    signedIn: true,
+    handle: session.handle,
+    did: session.did,
+    pds: session.pds,
+    displayName,
+    avatar,
+  });
+}

--- a/app/api/blob/route.ts
+++ b/app/api/blob/route.ts
@@ -1,20 +1,21 @@
+import { NextRequest, NextResponse } from "next/server";
+import { currentUser } from "@clerk/nextjs/server";
+import { Pool } from "pg";
+import { getAtprotoSession } from "@/lib/atproto-auth";
+import { deleteRecord, getRecord, putRecord } from "@/lib/atproto";
 
-import { NextRequest, NextResponse } from "next/server"
-import { currentUser } from "@clerk/nextjs/server"
-import { Pool } from "pg"
-
-export const runtime = "nodejs"
+export const runtime = "nodejs";
 
 const pool = new Pool({
   connectionString: process.env.POSTGRES_URL,
   ssl: { rejectUnauthorized: false },
-})
+});
 
-let inited = false
+let inited = false;
 
 async function initDB() {
-  if (inited) return
-  const client = await pool.connect()
+  if (inited) return;
+  const client = await pool.connect();
   try {
     await client.query(`
       CREATE TABLE IF NOT EXISTS calendar_backups (
@@ -23,29 +24,52 @@ async function initDB() {
         iv TEXT NOT NULL,
         timestamp TIMESTAMP NOT NULL
       )
-    `)
-    inited = true
+    `);
+    inited = true;
   } finally {
-    client.release()
+    client.release();
   }
 }
 
+const ATPROTO_BACKUP_COLLECTION = "app.onecalendar.backup";
+const ATPROTO_BACKUP_RKEY = "latest";
+
 export async function POST(req: NextRequest) {
   try {
-    const user = await currentUser()
-    if (!user) return NextResponse.json({ error: "Unauthorized" }, { status: 401 })
-
-    const body = await req.json()
-    const encrypted_data = body?.ciphertext
-    const iv = body?.iv
+    const body = await req.json();
+    const encrypted_data = body?.ciphertext;
+    const iv = body?.iv;
 
     if (typeof encrypted_data !== "string" || typeof iv !== "string") {
-      return NextResponse.json({ error: "Invalid payload" }, { status: 400 })
+      return NextResponse.json({ error: "Invalid payload" }, { status: 400 });
     }
 
-    await initDB()
+    const atproto = await getAtprotoSession();
+    if (atproto) {
+      await putRecord({
+        pds: atproto.pds,
+        repo: atproto.did,
+        collection: ATPROTO_BACKUP_COLLECTION,
+        rkey: ATPROTO_BACKUP_RKEY,
+        accessToken: atproto.accessToken,
+        dpopPrivateKeyPem: atproto.dpopPrivateKeyPem,
+        dpopPublicJwk: atproto.dpopPublicJwk,
+        record: {
+          $type: ATPROTO_BACKUP_COLLECTION,
+          ciphertext: encrypted_data,
+          iv,
+          updatedAt: new Date().toISOString(),
+        },
+      });
+      return NextResponse.json({ success: true, backend: "atproto" });
+    }
 
-    const client = await pool.connect()
+    const user = await currentUser();
+    if (!user) return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
+
+    await initDB();
+
+    const client = await pool.connect();
     try {
       await client.query(
         `
@@ -58,52 +82,91 @@ export async function POST(req: NextRequest) {
           timestamp = EXCLUDED.timestamp
         `,
         [user.id, encrypted_data, iv, new Date().toISOString()],
-      )
-      return NextResponse.json({ success: true })
+      );
+      return NextResponse.json({ success: true, backend: "postgres" });
     } finally {
-      client.release()
+      client.release();
     }
-  } catch (e: any) {
-    console.error(e)
-    return NextResponse.json({ error: e?.message || "Internal error" }, { status: 500 })
+  } catch (e: unknown) {
+    const message = e instanceof Error ? e.message : "Internal error";
+    return NextResponse.json({ error: message }, { status: 500 });
   }
 }
 
 export async function GET() {
-  const user = await currentUser()
-  if (!user) return NextResponse.json({ error: "Unauthorized" }, { status: 401 })
+  const atproto = await getAtprotoSession();
+  if (atproto) {
+    try {
+      const record = await getRecord({
+        pds: atproto.pds,
+        repo: atproto.did,
+        collection: ATPROTO_BACKUP_COLLECTION,
+        rkey: ATPROTO_BACKUP_RKEY,
+        accessToken: atproto.accessToken,
+        dpopPrivateKeyPem: atproto.dpopPrivateKeyPem,
+        dpopPublicJwk: atproto.dpopPublicJwk,
+      });
+      const value = record.value ?? {};
+      return NextResponse.json({
+        ciphertext: value.ciphertext,
+        iv: value.iv,
+        timestamp: value.updatedAt,
+        backend: "atproto",
+      });
+    } catch {
+      return NextResponse.json({ error: "Not found" }, { status: 404 });
+    }
+  }
 
-  await initDB()
+  const user = await currentUser();
+  if (!user) return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
 
-  const client = await pool.connect()
+  await initDB();
+
+  const client = await pool.connect();
   try {
     const result = await client.query(
       `SELECT encrypted_data, iv, timestamp FROM calendar_backups WHERE user_id = $1`,
       [user.id],
-    )
-    if (result.rowCount === 0) return NextResponse.json({ error: "Not found" }, { status: 404 })
+    );
+    if (result.rowCount === 0) return NextResponse.json({ error: "Not found" }, { status: 404 });
 
     return NextResponse.json({
       ciphertext: result.rows[0].encrypted_data,
       iv: result.rows[0].iv,
       timestamp: result.rows[0].timestamp,
-    })
+      backend: "postgres",
+    });
   } finally {
-    client.release()
+    client.release();
   }
 }
 
 export async function DELETE() {
-  const user = await currentUser()
-  if (!user) return NextResponse.json({ error: "Unauthorized" }, { status: 401 })
+  const atproto = await getAtprotoSession();
+  if (atproto) {
+    await deleteRecord({
+      pds: atproto.pds,
+      repo: atproto.did,
+      collection: ATPROTO_BACKUP_COLLECTION,
+      rkey: ATPROTO_BACKUP_RKEY,
+      accessToken: atproto.accessToken,
+      dpopPrivateKeyPem: atproto.dpopPrivateKeyPem,
+      dpopPublicJwk: atproto.dpopPublicJwk,
+    });
+    return NextResponse.json({ success: true, backend: "atproto" });
+  }
 
-  await initDB()
+  const user = await currentUser();
+  if (!user) return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
 
-  const client = await pool.connect()
+  await initDB();
+
+  const client = await pool.connect();
   try {
-    await client.query(`DELETE FROM calendar_backups WHERE user_id = $1`, [user.id])
-    return NextResponse.json({ success: true })
+    await client.query(`DELETE FROM calendar_backups WHERE user_id = $1`, [user.id]);
+    return NextResponse.json({ success: true, backend: "postgres" });
   } finally {
-    client.release()
+    client.release();
   }
 }

--- a/app/api/share/public/route.ts
+++ b/app/api/share/public/route.ts
@@ -1,0 +1,115 @@
+import { NextRequest, NextResponse } from "next/server";
+import crypto from "crypto";
+import { Pool } from "pg";
+import { getRecord, resolveHandle } from "@/lib/atproto";
+
+const ALGORITHM = "aes-256-gcm";
+const ATPROTO_SHARE_COLLECTION = "app.onecalendar.share";
+
+const burnPool = process.env.POSTGRES_URL
+  ? new Pool({
+      connectionString: process.env.POSTGRES_URL,
+      ssl: { rejectUnauthorized: false },
+    })
+  : null;
+
+let burnTableReady = false;
+
+async function ensureBurnTable() {
+  if (!burnPool || burnTableReady) return;
+  const client = await burnPool.connect();
+  try {
+    await client.query(`
+      CREATE TABLE IF NOT EXISTS atproto_share_burn_reads (
+        handle TEXT NOT NULL,
+        owner_did TEXT,
+        share_id TEXT NOT NULL,
+        burned_at TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+        pds_delete_synced BOOLEAN NOT NULL DEFAULT FALSE,
+        PRIMARY KEY (share_id, handle)
+      )
+    `);
+    await client.query(`ALTER TABLE atproto_share_burn_reads ADD COLUMN IF NOT EXISTS owner_did TEXT`);
+    await client.query(`ALTER TABLE atproto_share_burn_reads ADD COLUMN IF NOT EXISTS pds_delete_synced BOOLEAN NOT NULL DEFAULT FALSE`);
+    await client.query(`CREATE UNIQUE INDEX IF NOT EXISTS idx_atproto_share_burn_reads_owner_share ON atproto_share_burn_reads(owner_did, share_id) WHERE owner_did IS NOT NULL`);
+    burnTableReady = true;
+  } finally {
+    client.release();
+  }
+}
+
+async function wasPublicBurnConsumed(ownerDid: string, handle: string, shareId: string) {
+  if (!burnPool) return false;
+  await ensureBurnTable();
+  const result = await burnPool.query(
+    "SELECT 1 FROM atproto_share_burn_reads WHERE (owner_did = $1 OR (owner_did IS NULL AND handle = $2)) AND share_id = $3 LIMIT 1",
+    [ownerDid, handle, shareId],
+  );
+  return result.rowCount > 0;
+}
+
+async function markPublicBurnConsumed(ownerDid: string, handle: string, shareId: string) {
+  if (!burnPool) return;
+  await ensureBurnTable();
+  await burnPool.query(
+    `
+      INSERT INTO atproto_share_burn_reads (handle, owner_did, share_id, pds_delete_synced)
+      VALUES ($1, $2, $3, FALSE)
+      ON CONFLICT (share_id, handle)
+      DO UPDATE SET owner_did = EXCLUDED.owner_did, pds_delete_synced = FALSE, burned_at = NOW()
+    `,
+    [handle, ownerDid, shareId],
+  );
+}
+
+function keyV2Unprotected(shareId: string) {
+  return crypto.createHash("sha256").update(shareId, "utf8").digest();
+}
+
+function keyV3Password(password: string, shareId: string) {
+  return crypto.scryptSync(password, shareId, 32);
+}
+
+function decryptWithKey(encryptedData: string, iv: string, authTag: string, key: Buffer): string {
+  const decipher = crypto.createDecipheriv(ALGORITHM, key, Buffer.from(iv, "hex"));
+  decipher.setAuthTag(Buffer.from(authTag, "hex"));
+  let decrypted = decipher.update(encryptedData, "hex", "utf8");
+  decrypted += decipher.final("utf8");
+  return decrypted;
+}
+
+export async function GET(request: NextRequest) {
+  const handle = request.nextUrl.searchParams.get("handle");
+  const id = request.nextUrl.searchParams.get("id");
+  const password = request.nextUrl.searchParams.get("password") ?? "";
+
+  if (!handle || !id) return NextResponse.json({ error: "Missing handle or id" }, { status: 400 });
+
+  const normalizedHandle = handle.replace(/^@/, "").toLowerCase();
+  const resolved = await resolveHandle(normalizedHandle);
+  const record = await getRecord({ pds: resolved.pds, repo: resolved.did, collection: ATPROTO_SHARE_COLLECTION, rkey: id });
+  const value = record.value ?? {};
+  const isProtected = !!value.isProtected;
+  const isBurn = !!value.isBurn;
+
+  if (isBurn && (await wasPublicBurnConsumed(resolved.did, normalizedHandle, id))) {
+    return NextResponse.json({ error: "Share not found" }, { status: 404 });
+  }
+
+  if (isProtected && !password) {
+    return NextResponse.json({ error: "Password required", requiresPassword: true, burnAfterRead: isBurn }, { status: 401 });
+  }
+
+  const key = isProtected ? keyV3Password(password, id) : keyV2Unprotected(id);
+  try {
+    const decryptedData = decryptWithKey(String(value.encryptedData), String(value.iv), String(value.authTag), key);
+
+    if (isBurn) {
+      await markPublicBurnConsumed(resolved.did, normalizedHandle, id);
+    }
+
+    return NextResponse.json({ success: true, data: decryptedData, protected: isProtected, burnAfterRead: isBurn, timestamp: value.timestamp });
+  } catch {
+    return NextResponse.json({ error: isProtected ? "Invalid password" : "Failed to decrypt" }, { status: 403 });
+  }
+}

--- a/app/api/share/route.ts
+++ b/app/api/share/route.ts
@@ -2,6 +2,8 @@ import { type NextRequest, NextResponse } from "next/server";
 import { currentUser } from "@clerk/nextjs/server";
 import { Pool } from "pg";
 import crypto from "crypto";
+import { deleteRecord, getRecord, putRecord } from "@/lib/atproto";
+import { getAtprotoSession } from "@/lib/atproto-auth";
 
 const pool = new Pool({
   connectionString: process.env.POSTGRES_URL,
@@ -38,6 +40,7 @@ async function initializeDatabase() {
 }
 
 const ALGORITHM = "aes-256-gcm";
+const ATPROTO_SHARE_COLLECTION = "app.onecalendar.share";
 
 function keyV2Unprotected(shareId: string) {
   return crypto.createHash("sha256").update(shareId, "utf8").digest();
@@ -45,12 +48,6 @@ function keyV2Unprotected(shareId: string) {
 
 function keyV3Password(password: string, shareId: string) {
   return crypto.scryptSync(password, shareId, 32);
-}
-
-function keyV1Legacy(shareId: string) {
-  const salt = process.env.SALT;
-  if (!salt) throw new Error("SALT environment variable is not set");
-  return crypto.scryptSync(shareId, salt, 32);
 }
 
 function encryptWithKey(data: string, key: Buffer): { encryptedData: string; iv: string; authTag: string } {
@@ -74,14 +71,10 @@ function decryptWithKey(encryptedData: string, iv: string, authTag: string, key:
 
 export async function POST(request: NextRequest) {
   try {
-    const user = await currentUser()
-    if (!user) {
-      return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
-    }
     const body = await request.json();
     const { id, data, password, burnAfterRead } = body as {
       id?: string;
-      data?: any;
+      data?: unknown;
       password?: string;
       burnAfterRead?: boolean;
     };
@@ -92,20 +85,40 @@ export async function POST(request: NextRequest) {
 
     const hasPassword = typeof password === "string" && password.length > 0;
     const burn = !!burnAfterRead;
-
-    if (burn && !hasPassword) {
-      return NextResponse.json({ error: "burnAfterRead requires password protection" }, { status: 400 });
-    }
-
-    const POSTGRES_URL = process.env.POSTGRES_URL;
-    if (!POSTGRES_URL) throw new Error("POSTGRES_URL is not set");
-
-    await initializeDatabase();
-
     const dataString = typeof data === "string" ? data : JSON.stringify(data);
-    const encVersion = hasPassword ? 3 : 2;
     const key = hasPassword ? keyV3Password(password as string, id) : keyV2Unprotected(id);
     const { encryptedData, iv, authTag } = encryptWithKey(dataString, key);
+
+    const atproto = await getAtprotoSession();
+    if (atproto) {
+      await putRecord({
+        pds: atproto.pds,
+        repo: atproto.did,
+        collection: ATPROTO_SHARE_COLLECTION,
+        rkey: id,
+        accessToken: atproto.accessToken,
+        dpopPrivateKeyPem: atproto.dpopPrivateKeyPem,
+        dpopPublicJwk: atproto.dpopPublicJwk,
+        record: {
+          $type: ATPROTO_SHARE_COLLECTION,
+          encryptedData,
+          iv,
+          authTag,
+          isProtected: hasPassword,
+          isBurn: burn,
+          timestamp: new Date().toISOString(),
+        },
+      });
+
+      return NextResponse.json({ success: true, id, protected: hasPassword, burnAfterRead: burn, shareLink: `/${atproto.handle}/${id}` });
+    }
+
+    const user = await currentUser();
+    if (!user) {
+      return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
+    }
+
+    await initializeDatabase();
 
     const client = await pool.connect();
     try {
@@ -114,181 +127,120 @@ export async function POST(request: NextRequest) {
         INSERT INTO shares (user_id, share_id, encrypted_data, iv, auth_tag, timestamp, is_protected, is_burn, enc_version)
         VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9)
         ON CONFLICT (share_id)
-        DO UPDATE SET
-          encrypted_data = EXCLUDED.encrypted_data,
-          iv = EXCLUDED.iv,
-          auth_tag = EXCLUDED.auth_tag,
-          timestamp = EXCLUDED.timestamp,
-          is_protected = EXCLUDED.is_protected,
-          is_burn = EXCLUDED.is_burn,
-          enc_version = EXCLUDED.enc_version,
-          user_id = EXCLUDED.user_id
+        DO UPDATE SET encrypted_data = EXCLUDED.encrypted_data, iv = EXCLUDED.iv, auth_tag = EXCLUDED.auth_tag,
+          timestamp = EXCLUDED.timestamp, is_protected = EXCLUDED.is_protected, is_burn = EXCLUDED.is_burn,
+          enc_version = EXCLUDED.enc_version, user_id = EXCLUDED.user_id
         `,
-        [user.id, id, encryptedData, iv, authTag, new Date().toISOString(), hasPassword, burn, encVersion]
+        [user.id, id, encryptedData, iv, authTag, new Date().toISOString(), hasPassword, burn, hasPassword ? 3 : 2],
       );
 
-      return NextResponse.json({
-        success: true,
-        path: `shares/${id}/data.json`,
-        id,
-        message: "Share created successfully.",
-        protected: hasPassword,
-        burnAfterRead: burn,
-      });
+      return NextResponse.json({ success: true, id, protected: hasPassword, burnAfterRead: burn, shareLink: `/share/${id}` });
     } finally {
       client.release();
     }
   } catch (error) {
-    return NextResponse.json(
-      {
-        error: error instanceof Error ? error.message : "Unknown error occurred",
-        stack: error instanceof Error ? error.stack : undefined,
-      },
-      { status: 500 }
-    );
+    return NextResponse.json({ error: error instanceof Error ? error.message : "Unknown error occurred" }, { status: 500 });
   }
+}
+
+async function getAtprotoShare(id: string, password: string, handleParam?: string) {
+  const atproto = await getAtprotoSession();
+  if (atproto) {
+    const record = await getRecord({ pds: atproto.pds, repo: atproto.did, collection: ATPROTO_SHARE_COLLECTION, rkey: id, accessToken: atproto.accessToken, dpopPrivateKeyPem: atproto.dpopPrivateKeyPem, dpopPublicJwk: atproto.dpopPublicJwk });
+    const value = record.value ?? {};
+    const isProtected = !!value.isProtected;
+    if (isProtected && !password) {
+      return NextResponse.json({ error: "Password required", requiresPassword: true, burnAfterRead: value.isBurn }, { status: 401 });
+    }
+    const key = isProtected ? keyV3Password(password, id) : keyV2Unprotected(id);
+    const decryptedData = decryptWithKey(String(value.encryptedData), String(value.iv), String(value.authTag), key);
+
+    if (value.isBurn) {
+      await deleteRecord({ pds: atproto.pds, repo: atproto.did, collection: ATPROTO_SHARE_COLLECTION, rkey: id, accessToken: atproto.accessToken, dpopPrivateKeyPem: atproto.dpopPrivateKeyPem, dpopPublicJwk: atproto.dpopPublicJwk });
+    }
+
+    return NextResponse.json({ success: true, data: decryptedData, timestamp: value.timestamp, protected: isProtected, burnAfterRead: !!value.isBurn });
+  }
+
+  if (handleParam) {
+    return NextResponse.json({ error: "Public atproto retrieval requires owner session support not configured" }, { status: 400 });
+  }
+
+  return null;
 }
 
 export async function GET(request: NextRequest) {
   const id = request.nextUrl.searchParams.get("id");
   const password = request.nextUrl.searchParams.get("password") ?? "";
+  const handle = request.nextUrl.searchParams.get("handle") ?? undefined;
 
-  if (!id) {
-    return NextResponse.json({ error: "Missing share ID" }, { status: 400 });
-  }
+  if (!id) return NextResponse.json({ error: "Missing share ID" }, { status: 400 });
 
   try {
-    const POSTGRES_URL = process.env.POSTGRES_URL;
-    if (!POSTGRES_URL) throw new Error("POSTGRES_URL is not set");
+    const atprotoResult = await getAtprotoShare(id, password, handle);
+    if (atprotoResult) return atprotoResult;
 
     await initializeDatabase();
-
     const client = await pool.connect();
     try {
       await client.query("BEGIN");
-
       const result = await client.query(
-        "SELECT encrypted_data, iv, auth_tag, timestamp, is_protected, is_burn, enc_version FROM shares WHERE share_id = $1 FOR UPDATE",
-        [id]
+        "SELECT encrypted_data, iv, auth_tag, timestamp, is_protected, is_burn FROM shares WHERE share_id = $1 FOR UPDATE",
+        [id],
       );
-
       if (result.rows.length === 0) {
         await client.query("ROLLBACK");
         return NextResponse.json({ error: "Share not found" }, { status: 404 });
       }
-
-      const row = result.rows[0] as {
-        encrypted_data: string;
-        iv: string;
-        auth_tag: string;
-        timestamp: Date;
-        is_protected: boolean;
-        is_burn: boolean;
-        enc_version: number | null;
-      };
-
+      const row = result.rows[0];
       if (row.is_protected && !password) {
         await client.query("COMMIT");
-        return NextResponse.json(
-          { error: "Password required", requiresPassword: true, burnAfterRead: row.is_burn },
-          { status: 401 }
-        );
+        return NextResponse.json({ error: "Password required", requiresPassword: true, burnAfterRead: row.is_burn }, { status: 401 });
       }
-
-      const encVersion = row.enc_version ?? 1;
-
-      let key: Buffer;
-      if (row.is_protected) {
-        key = keyV3Password(password, id);
-      } else {
-        key = encVersion === 1 ? keyV1Legacy(id) : keyV2Unprotected(id);
-      }
-
+      const key = row.is_protected ? keyV3Password(password, id) : keyV2Unprotected(id);
       let decryptedData: string;
       try {
         decryptedData = decryptWithKey(row.encrypted_data, row.iv, row.auth_tag, key);
       } catch {
         await client.query("COMMIT");
-        if (row.is_protected) return NextResponse.json({ error: "Invalid password" }, { status: 403 });
-        return NextResponse.json({ error: "Failed to decrypt share data." }, { status: 403 });
+        return NextResponse.json({ error: row.is_protected ? "Invalid password" : "Failed to decrypt share data." }, { status: 403 });
       }
-
       if (row.is_burn) {
         await client.query("DELETE FROM shares WHERE share_id = $1", [id]);
       }
-
       await client.query("COMMIT");
-
-      return NextResponse.json({
-        success: true,
-        data: decryptedData,
-        timestamp: row.timestamp.toISOString(),
-        protected: row.is_protected,
-        burnAfterRead: row.is_burn,
-      });
+      return NextResponse.json({ success: true, data: decryptedData, timestamp: row.timestamp.toISOString(), protected: row.is_protected, burnAfterRead: row.is_burn });
     } catch (e) {
-      try {
-        await client.query("ROLLBACK");
-      } catch {}
+      await client.query("ROLLBACK");
       throw e;
     } finally {
       client.release();
     }
   } catch (error) {
-    return NextResponse.json(
-      {
-        error: error instanceof Error ? error.message : "Unknown error occurred",
-        stack: error instanceof Error ? error.stack : undefined,
-      },
-      { status: 500 }
-    );
+    return NextResponse.json({ error: error instanceof Error ? error.message : "Unknown error occurred" }, { status: 500 });
   }
 }
 
 export async function DELETE(request: NextRequest) {
+  const body = await request.json();
+  const { id } = body as { id?: string };
+  if (!id) return NextResponse.json({ error: "Missing share ID" }, { status: 400 });
+
+  const atproto = await getAtprotoSession();
+  if (atproto) {
+    await deleteRecord({ pds: atproto.pds, repo: atproto.did, collection: ATPROTO_SHARE_COLLECTION, rkey: id, accessToken: atproto.accessToken, dpopPrivateKeyPem: atproto.dpopPrivateKeyPem, dpopPublicJwk: atproto.dpopPublicJwk });
+    return NextResponse.json({ success: true });
+  }
+
+  const user = await currentUser();
+  if (!user) return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
+
+  await initializeDatabase();
+  const client = await pool.connect();
   try {
-    const user = await currentUser()
-    if (!user) {
-      return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
-    }
-    
-    const body = await request.json();
-    const { id } = body as { id?: string };
-
-    if (!id) {
-      return NextResponse.json({ error: "Missing share ID" }, { status: 400 });
-    }
-
-    const POSTGRES_URL = process.env.POSTGRES_URL;
-    if (!POSTGRES_URL) throw new Error("POSTGRES_URL is not set");
-
-    await initializeDatabase();
-
-    const client = await pool.connect();
-    try {
-      const result = await client.query("DELETE FROM shares WHERE share_id = $1 AND user_id = $2 RETURNING *", [id, user.id]);
-
-      if (result.rowCount === 0) {
-        return NextResponse.json({
-          success: true,
-          message: `No share found with ID: ${id}, nothing to delete.`,
-        });
-      }
-
-      return NextResponse.json({
-        success: true,
-        message: `Successfully deleted share with ID: ${id}`,
-      });
-    } finally {
-      client.release();
-    }
-  } catch (error) {
-    return NextResponse.json(
-      {
-        error: error instanceof Error ? error.message : "Unknown error occurred",
-        stack: error instanceof Error ? error.stack : undefined,
-      },
-      { status: 500 }
-    );
+    await client.query("DELETE FROM shares WHERE share_id = $1 AND user_id = $2", [id, user.id]);
+    return NextResponse.json({ success: true });
+  } finally {
+    client.release();
   }
 }

--- a/app/at-oauth/page.tsx
+++ b/app/at-oauth/page.tsx
@@ -1,0 +1,32 @@
+import { AuthBrand } from "@/components/auth/auth-brand";
+import { AtprotoLoginForm } from "@/components/auth/atproto-login-form";
+
+export default function AtprotoLoginPage() {
+  return (
+    <div className="relative flex min-h-svh flex-col items-center justify-center overflow-hidden from-blue-500 via-indigo-500 to-purple-500 p-6 md:p-10">
+      <div className="fixed -z-10 inset-0">
+        <div className="absolute inset-0 bg-white dark:bg-black">
+          <div
+            className="absolute inset-0"
+            style={{
+              backgroundImage: `radial-gradient(circle at 1px 1px, rgba(0, 0, 0, 0.1) 1px, transparent 0)`,
+              backgroundSize: "24px 24px",
+            }}
+          />
+          <div
+            className="absolute inset-0 dark:block hidden"
+            style={{
+              backgroundImage: `radial-gradient(circle at 1px 1px, rgba(255, 255, 255, 0.15) 1px, transparent 0)`,
+              backgroundSize: "24px 24px",
+            }}
+          />
+        </div>
+      </div>
+
+      <div className="relative z-10 flex w-full max-w-sm flex-col gap-6">
+        <AuthBrand />
+        <AtprotoLoginForm />
+      </div>
+    </div>
+  );
+}

--- a/components/app/calendar.tsx
+++ b/components/app/calendar.tsx
@@ -425,9 +425,10 @@ export default function Calendar({ className, ...props }: CalendarProps) {
     setEvents((prevEvents) => [...prevEvents, ...newEvents]);
   };
 
-  const handleEventEdit = () => {
-    if (previewEvent) {
-      setSelectedEvent(previewEvent);
+  const handleEventEdit = (event?: CalendarEvent) => {
+    const targetEvent = event ?? previewEvent;
+    if (targetEvent) {
+      setSelectedEvent(targetEvent);
       setQuickCreateStartTime(null);
       setEventDialogOpen(true);
       setPreviewOpen(false);

--- a/components/app/profile/shared-event.tsx
+++ b/components/app/profile/shared-event.tsx
@@ -50,6 +50,7 @@ interface SharedEvent {
 
 interface SharedEventViewProps {
   shareId: string;
+  handle?: string;
 }
 
 function getDarkerColorClass(color: string) {
@@ -68,7 +69,7 @@ function getDarkerColorClass(color: string) {
   return colorMapping[color] || '#3A3A3A';
 }
 
-export default function SharedEventView({ shareId }: SharedEventViewProps) {
+export default function SharedEventView({ shareId, handle }: SharedEventViewProps) {
   const router = useRouter();
   const { toast } = useToast();
   const [language] = useLanguage();
@@ -105,7 +106,9 @@ export default function SharedEventView({ shareId }: SharedEventViewProps) {
           return;
         }
 
-        const response = await fetch(`/api/share?id=${encodeURIComponent(shareId)}`);
+        const response = await fetch(handle
+          ? `/api/share/public?handle=${encodeURIComponent(handle)}&id=${encodeURIComponent(shareId)}`
+          : `/api/share?id=${encodeURIComponent(shareId)}`);
 
         if (!response.ok) {
           if (response.status === 401) {
@@ -137,7 +140,7 @@ export default function SharedEventView({ shareId }: SharedEventViewProps) {
     };
 
     fetchSharedEvent();
-  }, [shareId]);
+  }, [shareId, handle]);
 
   const tryDecryptWithPassword = async () => {
     if (!shareId) return;
@@ -152,7 +155,9 @@ export default function SharedEventView({ shareId }: SharedEventViewProps) {
       setPasswordSubmitting(true);
       setPasswordError(null);
 
-      const url = `/api/share?id=${encodeURIComponent(shareId)}&password=${encodeURIComponent(pwd)}`;
+      const url = handle
+        ? `/api/share/public?handle=${encodeURIComponent(handle)}&id=${encodeURIComponent(shareId)}&password=${encodeURIComponent(pwd)}`
+        : `/api/share?id=${encodeURIComponent(shareId)}&password=${encodeURIComponent(pwd)}`;
       const response = await fetch(url);
 
       if (!response.ok) {
@@ -483,16 +488,16 @@ export default function SharedEventView({ shareId }: SharedEventViewProps) {
           </a>
 
         <motion.div initial={{ opacity: 0, y: 20 }} animate={{ opacity: 1, y: 0 }} transition={{ duration: 0.5 }}>
-          <Card className="max-w-md w-full overflow-hidden">
-            <div className="relative">
-              <div className={cn("absolute left-0 top-0 h-full w-1")} style={{ backgroundColor: getDarkerColorClass(event.color) }}/>
+          <Card className="relative max-w-md w-full overflow-hidden">
+            <div className={cn("absolute inset-y-0 left-0 w-1")} style={{ backgroundColor: getDarkerColorClass(event.color) }}/>
+            <div>
               <CardContent className="p-6">
                 <div className="flex justify-between items-start mb-4">
                   <div>
                     <CardTitle className="text-2xl font-bold mb-1">{event.title}</CardTitle>
                     <CardDescription>
                       {isZh ? "分享者：" : "Shared by: "}
-                      <span className="font-medium">{event.sharedBy}</span>
+                      <a className="font-medium underline underline-offset-4" href={`https://bsky.app/profile/${String(event.sharedBy || "").replace(/^@/, "")}`} target="_blank" rel="noreferrer">{event.sharedBy}</a>
                     </CardDescription>
                     {burnAfterRead && (
                       <div className="mt-2 inline-flex items-center gap-2 text-sm text-red-500">

--- a/components/auth/atproto-login-form.tsx
+++ b/components/auth/atproto-login-form.tsx
@@ -1,0 +1,109 @@
+"use client";
+
+import { Suspense, useState } from "react";
+import { useSearchParams } from "next/navigation";
+import { Card, CardContent, CardDescription, CardHeader, CardTitle } from "@/components/ui/card";
+import { Input } from "@/components/ui/input";
+import { Button } from "@/components/ui/button";
+
+function AtprotoLoginContent() {
+  const [handle, setHandle] = useState("");
+  const [loading, setLoading] = useState(false);
+  const [error, setError] = useState("");
+  const [registerLoading, setRegisterLoading] = useState(false);
+  const searchParams = useSearchParams();
+
+  const startLogin = async () => {
+    setLoading(true);
+    setError("");
+    try {
+      const res = await fetch("/api/atproto/login", {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({ handle }),
+      });
+
+      const data = (await res.json()) as { authorizeUrl?: string; error?: string };
+      if (!res.ok || !data.authorizeUrl) {
+        throw new Error(data.error || "Failed to start OAuth login");
+      }
+
+      window.location.href = data.authorizeUrl;
+    } catch (e) {
+      setError(e instanceof Error ? e.message : "Unknown error");
+    } finally {
+      setLoading(false);
+    }
+  };
+
+  const queryError = searchParams.get("reason") || searchParams.get("error") || "";
+
+  const startRegister = async () => {
+    setRegisterLoading(true);
+    setError("");
+    try {
+      const res = await fetch("/api/atproto/register-url", {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+      });
+
+      const data = (await res.json()) as { authorizeUrl?: string; error?: string };
+      if (!res.ok || !data.authorizeUrl) {
+        throw new Error(data.error || "Failed to create registration OAuth URL");
+      }
+
+      window.location.href = data.authorizeUrl;
+    } catch (e) {
+      setError(e instanceof Error ? e.message : "Unknown error");
+    } finally {
+      setRegisterLoading(false);
+    }
+  };
+
+
+  return (
+    <div className="space-y-4">
+      <Card>
+      <CardHeader className="text-center">
+        <CardTitle className="text-xl">Sign in with Atmosphere</CardTitle>
+        <CardDescription>Enter your Atmosphere handle to continue with OAuth</CardDescription>
+      </CardHeader>
+      <CardContent className="space-y-4">
+        <Input
+          value={handle}
+          onChange={(e) => setHandle(e.target.value)}
+          placeholder="alice.bsky.social"
+          autoComplete="username"
+        />
+        <Button className="w-full bg-[#0066ff] hover:bg-[#0052cc] text-white" onClick={startLogin} disabled={!handle || loading}>
+          {loading ? "Redirecting..." : "Continue with Atmosphere OAuth"}
+        </Button>
+        {error || queryError ? <p className="text-sm text-red-500">{error || queryError}</p> : null}
+        <Button
+          variant="outline"
+          className="w-full"
+          type="button"
+          onClick={startRegister}
+          disabled={registerLoading}
+        >
+          {registerLoading ? "Preparing..." : "Create an Atmosphere account"}
+        </Button>
+        <p className="pt-1 text-center text-xs text-muted-foreground">
+          Not an Atmosphere user? Return to normal <a href="/sign-in" className="underline underline-offset-4 hover:text-primary">sign in</a>
+        </p>
+      </CardContent>
+      </Card>
+      <div className="text-balance text-center text-xs text-muted-foreground [&_a]:underline [&_a]:underline-offset-4 [&_a]:hover:text-primary">
+        By continuing, you agree to our <a href="/terms">Terms of Service</a> and <a href="/privacy">Privacy Policy</a>.
+      </div>
+    </div>
+  );
+}
+
+export function AtprotoLoginForm() {
+  return (
+    <Suspense fallback={<div className="text-sm text-muted-foreground text-center">Loading...</div>}>
+      <AtprotoLoginContent />
+    </Suspense>
+  );
+}

--- a/components/auth/auth-brand.tsx
+++ b/components/auth/auth-brand.tsx
@@ -6,7 +6,7 @@ export function AuthBrand() {
       <span className="flex size-6 items-center justify-center rounded-md bg-primary/15 text-primary">
         <Image src="/icon.svg" alt="One Calendar" width={16} height={16} className="size-4" />
       </span>
-      <span>Tech-Art</span>
+      <span>One Calendar</span>
     </a>
   )
 }

--- a/components/auth/login-form.tsx
+++ b/components/auth/login-form.tsx
@@ -5,7 +5,6 @@ import { cn } from "@/lib/utils";
 import {
   Card,
   CardContent,
-  CardDescription,
   CardHeader,
   CardTitle,
 } from "@/components/ui/card";
@@ -116,9 +115,6 @@ export function LoginForm({
       <Card>
         <CardHeader className="text-center">
           <CardTitle className="text-xl">Welcome back</CardTitle>
-          <CardDescription>
-            Login with your Microsoft, Google or GitHub account
-          </CardDescription>
         </CardHeader>
         <CardContent>
           <form onSubmit={handleEmailLogin}>
@@ -152,6 +148,22 @@ export function LoginForm({
                     <path d="M1 1h22v22H1z" fill="none"/>
                   </svg>
                   <span className="ml-2">Login with Google</span>
+                </Button>
+                <Button
+                  variant="outline"
+                  className="w-full"
+                  type="button"
+                  onClick={() => (window.location.href = "/at-oauth")}
+                >
+                  <svg
+                    xmlns="http://www.w3.org/2000/svg"
+                    viewBox="0 0 640 560"
+                    className="h-5 w-auto shrink-0"
+                    aria-hidden="true"
+                  >
+                    <path fill="#0066ff" d="M133 47c74 56 152 169 197 260 45-91 123-204 197-260 53-40 140-70 140 28 0 20-11 170-18 194-22 85-103 106-175 93 124 22 156 91 87 161-131 134-188-34-203-75-2-6-3-12-3-18 0 6-1 12-3 18-15 41-72 209-203 75-69-70-37-139 87-161-72 13-153-8-175-93-7-24-18-174-18-194 0-98 87-68 140-28z"/>
+                  </svg>
+                  <span className="ml-2">Login with Atmosphere</span>
                 </Button>
                 <Button
                   variant="outline"

--- a/components/auth/sign-up-form.tsx
+++ b/components/auth/sign-up-form.tsx
@@ -5,7 +5,6 @@ import { cn } from "@/lib/utils";
 import {
   Card,
   CardContent,
-  CardDescription,
   CardHeader,
   CardTitle,
 } from "@/components/ui/card";
@@ -37,10 +36,7 @@ export function SignUpForm({
   );
   const turnstileRef = useRef<any>(null);
 
-  console.log("Site Key:", process.env.NEXT_PUBLIC_TURNSTILE_SITE_KEY || "Missing");
-
   const handleTurnstileSuccess = async (token: string) => {
-    console.log("Turnstile token received:", token.slice(0, 10) + "...");
     try {
       const response = await fetch("/api/verify", {
         method: "POST",
@@ -49,7 +45,6 @@ export function SignUpForm({
       });
 
       if (!response.ok) {
-        console.error("API error:", response.status, response.statusText);
         throw new Error(`HTTP error! Status: ${response.status}`);
       }
 
@@ -58,11 +53,9 @@ export function SignUpForm({
       try {
         data = JSON.parse(text);
       } catch (parseErr) {
-        console.error("JSON parse error:", parseErr.message, "Response text:", text);
         throw new Error("Invalid JSON response from server");
       }
 
-      console.log("Verification API response:", JSON.stringify(data, null, 2));
 
       if (data.success) {
         setIsCaptchaCompleted(true);
@@ -72,16 +65,13 @@ export function SignUpForm({
         setError(`CAPTCHA verification failed: ${data.details?.join(", ") || "Unknown error"}`);
         if (turnstileRef.current) {
           turnstileRef.current.reset();
-          console.log("Turnstile widget reset");
         }
       }
     } catch (err) {
-      console.error("Error in handleTurnstileSuccess:", err.message);
       setIsCaptchaCompleted(false);
       setError("Error verifying CAPTCHA. Please try again.");
       if (turnstileRef.current) {
         turnstileRef.current.reset();
-        console.log("Turnstile widget reset");
       }
     }
   };
@@ -155,7 +145,6 @@ export function SignUpForm({
         setIsCaptchaCompleted(false);
         if (turnstileRef.current) {
           turnstileRef.current.reset();
-          console.log("Turnstile widget reset due to submission error");
         }
       }
     } finally {
@@ -231,9 +220,6 @@ export function SignUpForm({
       <Card>
         <CardHeader className="text-center">
           <CardTitle className="text-xl">Create your account</CardTitle>
-          <CardDescription>
-            Continue with Microsoft, Google, GitHub account
-          </CardDescription>
         </CardHeader>
         <CardContent>
           <form onSubmit={handleSubmit}>
@@ -267,6 +253,22 @@ export function SignUpForm({
                     <path d="M1 1h22v22H1z" fill="none" />
                   </svg>
                   <span className="ml-2">Continue with Google</span>
+                </Button>
+                <Button
+                  variant="outline"
+                  className="w-full"
+                  type="button"
+                  onClick={() => (window.location.href = "/at-oauth")}
+                >
+                  <svg
+                    xmlns="http://www.w3.org/2000/svg"
+                    viewBox="0 0 640 560"
+                    className="h-5 w-auto shrink-0"
+                    aria-hidden="true"
+                  >
+                    <path fill="#0066ff" d="M133 47c74 56 152 169 197 260 45-91 123-204 197-260 53-40 140-70 140 28 0 20-11 170-18 194-22 85-103 106-175 93 124 22 156 91 87 161-131 134-188-34-203-75-2-6-3-12-3-18 0 6-1 12-3 18-15 41-72 209-203 75-69-70-37-139 87-161-72 13-153-8-175-93-7-24-18-174-18-194 0-98 87-68 140-28z"/>
+                  </svg>
+                  <span className="ml-2">Continue with Atmosphere</span>
                 </Button>
                 <Button
                   variant="outline"
@@ -359,9 +361,7 @@ export function SignUpForm({
                         }}
                       />
                     </div>
-                  ) : (
-                    <div className="text-sm text-yellow-500">CAPTCHA not configured: Missing site key</div>
-                  )}
+                  ) : null}
                 </div>
 
                 {error && <div className="text-sm text-red-500">{error}</div>}

--- a/lib/atproto-auth.ts
+++ b/lib/atproto-auth.ts
@@ -1,0 +1,170 @@
+import { createDecipheriv, createHash, createCipheriv, hkdfSync, randomBytes } from "node:crypto";
+import type { DpopPublicJwk } from "@/lib/dpop";
+import { cookies } from "next/headers";
+
+export const ATPROTO_SESSION_COOKIE = "atproto_session";
+
+export interface AtprotoSession {
+  did: string;
+  handle: string;
+  pds: string;
+  accessToken: string;
+  refreshToken?: string;
+  displayName?: string;
+  avatar?: string;
+  dpopPrivateKeyPem?: string;
+  dpopPublicJwk?: DpopPublicJwk;
+}
+
+export interface KeyEntry {
+  kid: string;
+  secret: string;
+}
+
+function shouldUseSecureCookies() {
+  return process.env.NODE_ENV === "production";
+}
+
+function getRawLegacySecret() {
+  return process.env.ATPROTO_SESSION_SECRET || process.env.NEXTAUTH_SECRET || "";
+}
+
+export function getKeyEntries(): KeyEntry[] {
+  const configured = process.env.ATPROTO_SESSION_KEYS?.trim();
+  if (configured) {
+    const parsed = configured
+      .split(",")
+      .map((part) => part.trim())
+      .filter(Boolean)
+      .map((pair) => {
+        const idx = pair.indexOf(":");
+        if (idx <= 0 || idx === pair.length - 1) return null;
+        return {
+          kid: pair.slice(0, idx).trim(),
+          secret: pair.slice(idx + 1).trim(),
+        };
+      })
+      .filter((v): v is KeyEntry => !!v && !!v.kid && !!v.secret);
+
+    if (parsed.length > 0) return parsed;
+  }
+
+  const current = process.env.ATPROTO_SESSION_SECRET_CURRENT?.trim();
+  const previous = process.env.ATPROTO_SESSION_SECRET_PREVIOUS?.trim();
+  const entries: KeyEntry[] = [];
+  if (current) entries.push({ kid: "v1", secret: current });
+  if (previous) entries.push({ kid: "v0", secret: previous });
+  if (entries.length > 0) return entries;
+
+  const legacy = getRawLegacySecret();
+  if (!legacy) return [];
+  return [{ kid: "legacy", secret: legacy }];
+}
+
+function deriveKey(secret: string, kid: string) {
+  const salt = createHash("sha256").update(`atproto-cookie-salt:${kid}`, "utf8").digest();
+  const info = Buffer.from("one-calendar:atproto:cookie:v2", "utf8");
+  return Buffer.from(hkdfSync("sha256", Buffer.from(secret, "utf8"), salt, info, 32));
+}
+
+function deriveLegacyKey(secret: string) {
+  return createHash("sha256").update(secret, "utf8").digest();
+}
+
+export function sealJsonPayload(payload: unknown, key: KeyEntry) {
+  const iv = randomBytes(12);
+  const derivedKey = deriveKey(key.secret, key.kid);
+  const cipher = createCipheriv("aes-256-gcm", derivedKey, iv);
+  const ciphertext = Buffer.concat([cipher.update(JSON.stringify(payload), "utf8"), cipher.final()]);
+  const tag = cipher.getAuthTag();
+  return `v2.${key.kid}.${iv.toString("base64url")}.${ciphertext.toString("base64url")}.${tag.toString("base64url")}`;
+}
+
+export function unsealJsonPayload<T>(raw: string): T | null {
+  const v2parts = raw.split(".");
+  if (v2parts.length === 5 && v2parts[0] === "v2") {
+    const [, kid, ivRaw, ciphertextRaw, tagRaw] = v2parts;
+    const keyEntry = getKeyEntries().find((entry) => entry.kid === kid);
+    if (!keyEntry) return null;
+
+    try {
+      const iv = Buffer.from(ivRaw, "base64url");
+      const ciphertext = Buffer.from(ciphertextRaw, "base64url");
+      const tag = Buffer.from(tagRaw, "base64url");
+      const key = deriveKey(keyEntry.secret, keyEntry.kid);
+
+      const decipher = createDecipheriv("aes-256-gcm", key, iv);
+      decipher.setAuthTag(tag);
+      const plaintext = Buffer.concat([decipher.update(ciphertext), decipher.final()]).toString("utf8");
+      return JSON.parse(plaintext) as T;
+    } catch {
+      return null;
+    }
+  }
+
+  // Backward compatibility with previous v1 format: v1.iv.ciphertext.tag
+  if (v2parts.length === 4 && v2parts[0] === "v1") {
+    const keys = getKeyEntries();
+    for (const keyEntry of keys) {
+      try {
+        const iv = Buffer.from(v2parts[1], "base64url");
+        const ciphertext = Buffer.from(v2parts[2], "base64url");
+        const tag = Buffer.from(v2parts[3], "base64url");
+        const key = deriveLegacyKey(keyEntry.secret);
+
+        const decipher = createDecipheriv("aes-256-gcm", key, iv);
+        decipher.setAuthTag(tag);
+        const plaintext = Buffer.concat([decipher.update(ciphertext), decipher.final()]).toString("utf8");
+        return JSON.parse(plaintext) as T;
+      } catch {
+        // try next key
+      }
+    }
+  }
+
+  return null;
+}
+
+function encodeSession(session: AtprotoSession) {
+  const keys = getKeyEntries();
+  const activeKey = keys[0];
+  if (!activeKey) {
+    throw new Error("Missing ATProto cookie key. Set ATPROTO_SESSION_KEYS or ATPROTO_SESSION_SECRET_CURRENT/ATPROTO_SESSION_SECRET");
+  }
+
+  return sealJsonPayload(session, activeKey);
+}
+
+function decodeSession(raw: string): AtprotoSession | null {
+  return unsealJsonPayload<AtprotoSession>(raw);
+}
+
+export async function getAtprotoSession(): Promise<AtprotoSession | null> {
+  const store = await cookies();
+  const raw = store.get(ATPROTO_SESSION_COOKIE)?.value;
+  if (!raw) return null;
+
+  const decoded = decodeSession(raw);
+  if (!decoded) {
+    store.delete(ATPROTO_SESSION_COOKIE);
+  }
+
+  return decoded;
+}
+
+export async function setAtprotoSession(session: AtprotoSession) {
+  const store = await cookies();
+  const value = encodeSession(session);
+  store.set(ATPROTO_SESSION_COOKIE, value, {
+    httpOnly: true,
+    secure: shouldUseSecureCookies(),
+    sameSite: "lax",
+    path: "/",
+    maxAge: 60 * 60 * 24 * 30,
+  });
+}
+
+export async function clearAtprotoSession() {
+  const store = await cookies();
+  store.delete(ATPROTO_SESSION_COOKIE);
+}

--- a/lib/atproto-oauth-txn.ts
+++ b/lib/atproto-oauth-txn.ts
@@ -1,0 +1,80 @@
+import { createHash } from "node:crypto";
+import type { DpopPublicJwk } from "@/lib/dpop";
+import type { NextRequest, NextResponse } from "next/server";
+import { getKeyEntries, sealJsonPayload, unsealJsonPayload } from "@/lib/atproto-auth";
+
+export const ATPROTO_OAUTH_TXN_COOKIE = "atproto_oauth_txn";
+const OAUTH_TXN_MAX_AGE_SECONDS = 600;
+
+export interface AtprotoOAuthTxn {
+  jti: string;
+  state: string;
+  verifier: string;
+  handle: string;
+  pds: string;
+  did: string;
+  dpopPrivateKeyPem: string;
+  dpopPublicJwk: DpopPublicJwk;
+  issuedAt: number;
+}
+
+const consumedTxnCache = new Map<string, number>();
+
+function cleanupConsumed(now: number) {
+  for (const [key, exp] of consumedTxnCache.entries()) {
+    if (exp <= now) consumedTxnCache.delete(key);
+  }
+}
+
+function txnCacheKey(jti: string) {
+  return createHash("sha256").update(jti, "utf8").digest("hex");
+}
+
+export function setAtprotoOAuthTxnCookie(response: NextResponse, txn: AtprotoOAuthTxn, secure: boolean) {
+  const keys = getKeyEntries();
+  const activeKey = keys[0];
+  if (!activeKey) {
+    throw new Error("Missing ATProto cookie key for OAuth transaction protection");
+  }
+
+  const value = sealJsonPayload(txn, activeKey);
+  response.cookies.set(ATPROTO_OAUTH_TXN_COOKIE, value, {
+    httpOnly: true,
+    secure,
+    sameSite: "lax",
+    path: "/",
+    maxAge: OAUTH_TXN_MAX_AGE_SECONDS,
+  });
+}
+
+export function getAtprotoOAuthTxnFromRequest(request: NextRequest) {
+  const raw = request.cookies.get(ATPROTO_OAUTH_TXN_COOKIE)?.value;
+  if (!raw) return null;
+
+  const txn = unsealJsonPayload<AtprotoOAuthTxn>(raw);
+  if (!txn) return null;
+
+  const now = Math.floor(Date.now() / 1000);
+  if (!txn.issuedAt || now - txn.issuedAt > OAUTH_TXN_MAX_AGE_SECONDS) {
+    return null;
+  }
+
+  return txn;
+}
+
+export function consumeAtprotoOAuthTxn(txn: AtprotoOAuthTxn) {
+  const now = Math.floor(Date.now() / 1000);
+  cleanupConsumed(now);
+
+  const key = txnCacheKey(txn.jti);
+  if (consumedTxnCache.has(key)) {
+    return false;
+  }
+
+  consumedTxnCache.set(key, now + OAUTH_TXN_MAX_AGE_SECONDS);
+  return true;
+}
+
+export function clearAtprotoOAuthTxnCookie(response: NextResponse) {
+  response.cookies.delete(ATPROTO_OAUTH_TXN_COOKIE);
+}

--- a/lib/atproto.ts
+++ b/lib/atproto.ts
@@ -1,0 +1,270 @@
+import { randomBytes, createHash } from "crypto";
+import { createDpopProof, type DpopPublicJwk } from "@/lib/dpop";
+
+export interface DidDocService {
+  id?: string;
+  type?: string;
+  serviceEndpoint?: string;
+}
+
+export interface DidDoc {
+  service?: DidDocService[];
+}
+
+export async function resolveHandle(handle: string): Promise<{ did: string; pds: string }> {
+  const normalized = handle.replace(/^@/, "").trim().toLowerCase();
+  const didRes = await fetch(`https://public.api.bsky.app/xrpc/com.atproto.identity.resolveHandle?handle=${encodeURIComponent(normalized)}`, { cache: "no-store" });
+  if (!didRes.ok) {
+    throw new Error("Failed to resolve handle");
+  }
+
+  const didData = (await didRes.json()) as { did?: string };
+  if (!didData.did) {
+    throw new Error("No DID found for handle");
+  }
+
+  const didDocRes = await fetch(`https://plc.directory/${encodeURIComponent(didData.did)}`, { cache: "no-store" });
+  if (!didDocRes.ok) {
+    throw new Error("Failed to resolve DID document");
+  }
+
+  const didDoc = (await didDocRes.json()) as DidDoc;
+  const pds = didDoc.service?.find((s) => s.type === "AtprotoPersonalDataServer")?.serviceEndpoint;
+  if (!pds) {
+    throw new Error("Could not find PDS endpoint");
+  }
+
+  return { did: didData.did, pds };
+}
+
+export function createPkcePair() {
+  const verifier = randomBytes(32).toString("base64url");
+  const challenge = createHash("sha256").update(verifier).digest("base64url");
+  return { verifier, challenge };
+}
+
+async function createAuthHeaders(params: {
+  url: string;
+  method: string;
+  accessToken?: string;
+  dpopPrivateKeyPem?: string;
+  dpopPublicJwk?: DpopPublicJwk;
+  contentType?: string;
+  nonce?: string;
+}) {
+  const headers: Record<string, string> = {};
+  if (params.contentType) headers["Content-Type"] = params.contentType;
+
+  if (!params.accessToken) return headers;
+
+  if (params.dpopPrivateKeyPem && params.dpopPublicJwk) {
+    const dpopProof = createDpopProof({
+      htu: params.url,
+      htm: params.method,
+      privateKeyPem: params.dpopPrivateKeyPem,
+      publicJwk: params.dpopPublicJwk,
+      accessToken: params.accessToken,
+      nonce: params.nonce,
+    });
+
+    headers.Authorization = `DPoP ${params.accessToken}`;
+    headers.DPoP = dpopProof;
+    return headers;
+  }
+
+  headers.Authorization = `Bearer ${params.accessToken}`;
+  return headers;
+}
+
+async function fetchWithDpopNonceRetry(params: {
+  url: string;
+  method: "GET" | "POST";
+  accessToken?: string;
+  dpopPrivateKeyPem?: string;
+  dpopPublicJwk?: DpopPublicJwk;
+  contentType?: string;
+  body?: string;
+}) {
+  const doFetch = async (nonce?: string) =>
+    fetch(params.url, {
+      method: params.method,
+      headers: await createAuthHeaders({
+        url: params.url,
+        method: params.method,
+        accessToken: params.accessToken,
+        dpopPrivateKeyPem: params.dpopPrivateKeyPem,
+        dpopPublicJwk: params.dpopPublicJwk,
+        contentType: params.contentType,
+        nonce,
+      }),
+      body: params.body,
+      cache: "no-store",
+    });
+
+  let res = await doFetch();
+  if (res.ok) return res;
+
+  let nonce = res.headers.get("DPoP-Nonce") || res.headers.get("dpop-nonce");
+  const hasDpop = !!params.accessToken && !!params.dpopPrivateKeyPem && !!params.dpopPublicJwk;
+
+  if (hasDpop && !nonce) {
+    const body = await res.clone().text();
+    try {
+      const parsed = JSON.parse(body) as { dpop_nonce?: string; nonce?: string };
+      nonce = parsed.dpop_nonce || parsed.nonce;
+    } catch {
+      nonce = nonce || undefined;
+    }
+  }
+
+  if (hasDpop && nonce) {
+    res = await doFetch(nonce);
+  }
+
+  return res;
+}
+
+export async function getProfile(pds: string, actor: string, accessToken: string, dpop?: { privateKeyPem?: string; publicJwk?: DpopPublicJwk }) {
+  const url = `${pds.replace(/\/$/, "")}/xrpc/app.bsky.actor.getProfile?actor=${encodeURIComponent(actor)}`;
+  const res = await fetchWithDpopNonceRetry({
+    url,
+    method: "GET",
+    accessToken,
+    dpopPrivateKeyPem: dpop?.privateKeyPem,
+    dpopPublicJwk: dpop?.publicJwk,
+  });
+  if (!res.ok) return null;
+  return res.json() as Promise<{ displayName?: string; avatar?: string; handle?: string }>;
+}
+
+
+export async function getActorProfileRecord(params: {
+  pds: string;
+  repo: string;
+  accessToken: string;
+  dpopPrivateKeyPem?: string;
+  dpopPublicJwk?: DpopPublicJwk;
+}) {
+  const record = await getRecord({
+    pds: params.pds,
+    repo: params.repo,
+    collection: "app.bsky.actor.profile",
+    rkey: "self",
+    accessToken: params.accessToken,
+    dpopPrivateKeyPem: params.dpopPrivateKeyPem,
+    dpopPublicJwk: params.dpopPublicJwk,
+  });
+
+  return record.value as
+    | {
+        displayName?: string;
+        avatar?: { ref?: { $link?: string } };
+      }
+    | undefined;
+}
+
+export function profileAvatarBlobUrl(params: { pds: string; did: string; cid?: string }) {
+  if (!params.cid) return undefined;
+  return `${params.pds.replace(/\/$/, "")}/xrpc/com.atproto.sync.getBlob?did=${encodeURIComponent(params.did)}&cid=${encodeURIComponent(params.cid)}`;
+}
+
+export async function putRecord(params: {
+  pds: string;
+  repo: string;
+  collection: string;
+  rkey: string;
+  record: Record<string, unknown>;
+  accessToken: string;
+  dpopPrivateKeyPem?: string;
+  dpopPublicJwk?: DpopPublicJwk;
+}) {
+  const { pds, accessToken, dpopPrivateKeyPem, dpopPublicJwk, ...payload } = params;
+  const url = `${pds.replace(/\/$/, "")}/xrpc/com.atproto.repo.putRecord`;
+  const res = await fetchWithDpopNonceRetry({
+    url,
+    method: "POST",
+    accessToken,
+    dpopPrivateKeyPem,
+    dpopPublicJwk,
+    contentType: "application/json",
+    body: JSON.stringify(payload),
+  });
+  if (!res.ok) {
+    throw new Error(`putRecord failed: ${await res.text()}`);
+  }
+  return res.json();
+}
+
+export async function getRecord(params: {
+  pds: string;
+  repo: string;
+  collection: string;
+  rkey: string;
+  accessToken?: string;
+  dpopPrivateKeyPem?: string;
+  dpopPublicJwk?: DpopPublicJwk;
+}) {
+  const { pds, repo, collection, rkey, accessToken, dpopPrivateKeyPem, dpopPublicJwk } = params;
+  const url = `${pds.replace(/\/$/, "")}/xrpc/com.atproto.repo.getRecord?repo=${encodeURIComponent(repo)}&collection=${encodeURIComponent(collection)}&rkey=${encodeURIComponent(rkey)}`;
+  const res = await fetchWithDpopNonceRetry({
+    url,
+    method: "GET",
+    accessToken,
+    dpopPrivateKeyPem,
+    dpopPublicJwk,
+  });
+  if (!res.ok) {
+    throw new Error(`getRecord failed: ${await res.text()}`);
+  }
+  return res.json() as Promise<{ value?: Record<string, unknown> }>;
+}
+
+export async function listRecords(params: {
+  pds: string;
+  repo: string;
+  collection: string;
+  accessToken: string;
+  dpopPrivateKeyPem?: string;
+  dpopPublicJwk?: DpopPublicJwk;
+}) {
+  const { pds, repo, collection, accessToken, dpopPrivateKeyPem, dpopPublicJwk } = params;
+  const url = `${pds.replace(/\/$/, "")}/xrpc/com.atproto.repo.listRecords?repo=${encodeURIComponent(repo)}&collection=${encodeURIComponent(collection)}&limit=100`;
+  const res = await fetchWithDpopNonceRetry({
+    url,
+    method: "GET",
+    accessToken,
+    dpopPrivateKeyPem,
+    dpopPublicJwk,
+  });
+
+  if (!res.ok) {
+    throw new Error(`listRecords failed: ${await res.text()}`);
+  }
+
+  return res.json() as Promise<{ records?: Array<{ uri: string; value?: Record<string, unknown> }> }>;
+}
+
+export async function deleteRecord(params: {
+  pds: string;
+  repo: string;
+  collection: string;
+  rkey: string;
+  accessToken: string;
+  dpopPrivateKeyPem?: string;
+  dpopPublicJwk?: DpopPublicJwk;
+}) {
+  const { pds, accessToken, dpopPrivateKeyPem, dpopPublicJwk, ...payload } = params;
+  const url = `${pds.replace(/\/$/, "")}/xrpc/com.atproto.repo.deleteRecord`;
+  const res = await fetchWithDpopNonceRetry({
+    url,
+    method: "POST",
+    accessToken,
+    dpopPrivateKeyPem,
+    dpopPublicJwk,
+    contentType: "application/json",
+    body: JSON.stringify(payload),
+  });
+  if (!res.ok) {
+    throw new Error(`deleteRecord failed: ${await res.text()}`);
+  }
+}

--- a/lib/dpop.ts
+++ b/lib/dpop.ts
@@ -1,0 +1,85 @@
+import { createHash, createPrivateKey, generateKeyPairSync, randomUUID, sign } from "crypto";
+
+export interface DpopPublicJwk {
+  kty: string;
+  crv: string;
+  x: string;
+  y: string;
+}
+
+function toBase64Url(input: Buffer | string) {
+  return Buffer.from(input).toString("base64url");
+}
+
+function jwkThumbprint(publicJwk: DpopPublicJwk) {
+  const canonical = JSON.stringify({
+    crv: publicJwk.crv,
+    kty: publicJwk.kty,
+    x: publicJwk.x,
+    y: publicJwk.y,
+  });
+
+  return createHash("sha256").update(canonical, "utf8").digest("base64url");
+}
+
+export function generateDpopKeyMaterial() {
+  const { privateKey, publicKey } = generateKeyPairSync("ec", { namedCurve: "P-256" });
+  const publicJwk = publicKey.export({ format: "jwk" }) as DpopPublicJwk;
+  const privateKeyPem = privateKey.export({ type: "pkcs8", format: "pem" }).toString();
+
+  if (!publicJwk?.kty || !publicJwk?.crv || !publicJwk?.x || !publicJwk?.y) {
+    throw new Error("Failed to generate DPoP key material");
+  }
+
+  return {
+    publicJwk,
+    privateKeyPem,
+    jkt: jwkThumbprint(publicJwk),
+  };
+}
+
+export function createDpopProof(params: {
+  htu: string;
+  htm: string;
+  privateKeyPem: string;
+  publicJwk: DpopPublicJwk;
+  accessToken?: string;
+  nonce?: string;
+}) {
+  const header = {
+    typ: "dpop+jwt",
+    alg: "ES256",
+    jwk: {
+      kty: params.publicJwk.kty,
+      crv: params.publicJwk.crv,
+      x: params.publicJwk.x,
+      y: params.publicJwk.y,
+    },
+  };
+
+  const payload: Record<string, string | number> = {
+    jti: randomUUID(),
+    iat: Math.floor(Date.now() / 1000),
+    htm: params.htm.toUpperCase(),
+    htu: params.htu,
+  };
+
+  if (params.accessToken) {
+    payload.ath = createHash("sha256").update(params.accessToken, "utf8").digest("base64url");
+  }
+
+  if (params.nonce) {
+    payload.nonce = params.nonce;
+  }
+
+  const encodedHeader = toBase64Url(JSON.stringify(header));
+  const encodedPayload = toBase64Url(JSON.stringify(payload));
+  const signingInput = `${encodedHeader}.${encodedPayload}`;
+
+  const signature = sign("sha256", Buffer.from(signingInput, "utf8"), {
+    key: createPrivateKey(params.privateKeyPem),
+    dsaEncoding: "ieee-p1363",
+  });
+
+  return `${signingInput}.${toBase64Url(signature)}`;
+}

--- a/lib/gen-oauth-metadata.mjs
+++ b/lib/gen-oauth-metadata.mjs
@@ -1,0 +1,19 @@
+import { writeFileSync } from "node:fs";
+
+const baseUrl = process.env.NEXT_PUBLIC_APP_URL || "https://calendar.xyehr.cn";
+const normalizedBase = baseUrl.replace(/\/$/, "");
+
+const metadata = {
+  client_id: `${normalizedBase}/oauth-client-metadata.json`,
+  application_type: "web",
+  grant_types: ["authorization_code", "refresh_token"],
+  response_types: ["code"],
+  redirect_uris: [`${normalizedBase}/api/atproto/callback`],
+  token_endpoint_auth_method: "none",
+  scope: "atproto transition:generic",
+  dpop_bound_access_tokens: true,
+};
+
+writeFileSync("public/oauth-client-metadata.json", `${JSON.stringify(metadata, null, 2)}
+`, "utf8");
+console.log("Generated public/oauth-client-metadata.json");

--- a/lib/gen-oauth-metadata.mjs
+++ b/lib/gen-oauth-metadata.mjs
@@ -1,6 +1,6 @@
 import { writeFileSync } from "node:fs";
 
-const baseUrl = process.env.NEXT_PUBLIC_APP_URL || "https://calendar.xyehr.cn";
+const baseUrl = process.env.NEXT_PUBLIC_BASE_URL || "https://calendar.xyehr.cn";
 const normalizedBase = baseUrl.replace(/\/$/, "");
 
 const metadata = {

--- a/package.json
+++ b/package.json
@@ -1,17 +1,18 @@
 {
   "name": "one-calendar",
-  "version": "2.1.3",
+  "version": "2.2.0",
   "private": true,
   "packageManager": "bun@1.3.6",
   "scripts": {
-    "dev": "bun run generate:locales && next dev",
-    "build": "bun run generate:locales && next build",
+    "dev": "bun run generate:locales && bun run generate:oauth-metadata && next dev",
+    "build": "bun run generate:locales && bun run generate:oauth-metadata && next build",
     "start": "next start",
     "db": "docker-compose up -d",
     "db:down": "docker-compose down",
     "db:stop": "docker-compose stop",
     "db:clean": "docker-compose down -v",
-    "generate:locales": "bun lib/gen-locales.mjs"
+    "generate:locales": "bun lib/gen-locales.mjs",
+    "generate:oauth-metadata": "bun lib/gen-oauth-metadata.mjs"
   },
   "dependencies": {
     "@hookform/resolvers": "5.2.2",

--- a/proxy.ts
+++ b/proxy.ts
@@ -9,7 +9,11 @@ export default clerkMiddleware({
     "/reset-password",
     "/api/blob",
     "/api/share",
-    "/api/verify"
+    "/api/verify",
+    "/at-oauth",
+    "/api/atproto/(.*)",
+    "/oauth-client-metadata.json",
+    "/api/share/public"
   ],
 })
 

--- a/public/oauth-client-metadata.json
+++ b/public/oauth-client-metadata.json
@@ -1,0 +1,17 @@
+{
+  "client_id": "https://calendar.xyehr.cn/oauth-client-metadata.json",
+  "application_type": "web",
+  "grant_types": [
+    "authorization_code",
+    "refresh_token"
+  ],
+  "response_types": [
+    "code"
+  ],
+  "redirect_uris": [
+    "https://calendar.xyehr.cn/api/atproto/callback"
+  ],
+  "token_endpoint_auth_method": "none",
+  "scope": "atproto transition:generic",
+  "dpop_bound_access_tokens": true
+}


### PR DESCRIPTION
### Motivation
- Account creation was failing with `The data you submitted is invalid` because the authorize context sent to Rose was incomplete or stale (client-side static URL fallback without transaction state/DPoP/PKCE). 
- The OAuth registration/login flows need server-side PAR generation and a callback-bound transaction to guarantee `state`, `code_verifier`, and DPoP keys are available at token exchange time.
- Shares/backups should prefer a signed-in ATProto PDS when available to keep user data in the user's PDS and enable burn/read-sync semantics.

### Description
- Added realtime PAR-based registration endpoint at `POST /api/atproto/register-url` which performs a `POST /oauth/par` against Rose, returns an `authorize` URL with `request_uri`, and sets a secure OAuth txn cookie containing `state`, `verifier`, and DPoP key material. 
- Implemented full callback/token handling in `GET /api/atproto/callback` and hardened it to accept `sub` from the token response as the actor DID when the txn DID is empty, and to retry token exchange when a DPoP nonce is returned. 
- Introduced ATProto plumbing: `lib/dpop.ts`, `lib/atproto.ts`, `lib/atproto-auth.ts`, and `lib/atproto-oauth-txn.ts` for DPoP proof generation, repo record operations, secure sealed session cookies, and OAuth transaction protection. 
- Added endpoints for login/session/logout (`/api/atproto/login`, `/api/atproto/session`, `/api/atproto/logout`), and updated shares/backups handlers (`app/api/blob`, `app/api/share`, `app/api/share/list`, `app/api/share/public`) to prefer ATProto PDS storage when an ATProto session exists and fall back to Postgres otherwise, plus burn/read-sync support. 
- UI wiring: new `/at-oauth` page and `components/auth/atproto-login-form.tsx`, plus multiple UI changes to surface ATProto session state (event preview, profile button, calendar wiring) and to route registration through the new PAR flow. 
- Misc: added `lib/gen-oauth-metadata.mjs` and `public/oauth-client-metadata.json` generation integration, updated `.env.example` and `README.md` with ATProto env vars, and permitted ATProto public routes in `proxy.ts`.

### Testing
- Verified the register flow code and parameters by inspecting `app/api/atproto/register-url/route.ts` to confirm `request_uri`, `dpop_jkt`, PKCE `code_challenge`, `state`, and `redirect_uri` are sent and that the txn cookie is set (inspection succeeded). 
- Verified callback logic changes by inspecting `app/api/atproto/callback/route.ts` to confirm token exchange DPoP nonce retry and `sub`→`actorDid` fallback are implemented (inspection succeeded). 
- Ran type-check `bunx tsc --noEmit`, which reports pre-existing dependency/type errors in the environment unrelated to this focused patch (tooling/type check failed due to missing deps). 
- Attempted an automated Playwright navigation to `/at-oauth` to validate runtime behavior, but the local dev server was unreachable (`ERR_EMPTY_RESPONSE`), so end-to-end browser validation could not complete.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_699843c2da988332b94455934231841f)