### PR TITLE
Adjust delete button placement and styling in EventPreview and EventDialog

### DIFF
--- a/components/app/event/event-dialog.tsx
+++ b/components/app/event/event-dialog.tsx
@@ -931,14 +931,6 @@ export default function EventDialog({
           </div>
 
           <div className="flex justify-end gap-2">
-            <Button
-              type="button"
-              variant="outline"
-              onClick={() => onOpenChange(false)}
-            >
-              {t.cancel}
-            </Button>
-            <Button type="submit">{event ? t.update : t.save}</Button>
             {event && (
               <Button
                 type="button"
@@ -951,6 +943,14 @@ export default function EventDialog({
                 {t.delete}
               </Button>
             )}
+            <Button
+              type="button"
+              variant="outline"
+              onClick={() => onOpenChange(false)}
+            >
+              {t.cancel}
+            </Button>
+            <Button type="submit">{event ? t.update : t.save}</Button>
           </div>
         </form>
       </DialogContent>

--- a/components/app/event/event-preview.tsx
+++ b/components/app/event/event-preview.tsx
@@ -465,9 +465,6 @@ export default function EventPreview({
         <div className="flex justify-between items-center p-5">
           <div className="w-24"></div>
           <div className="flex space-x-2 ml-auto">
-            <Button variant="ghost" size="icon" onClick={handleDeleteClick} className="h-8 w-8 text-red-600 hover:text-red-600">
-              <Trash2 className="h-5 w-5" />
-            </Button>
             <Button variant="ghost" size="icon" onClick={() => onEdit()} className="h-8 w-8">
               <Edit2 className="h-5 w-5" />
             </Button>
@@ -490,6 +487,9 @@ export default function EventPreview({
             </Button>
             <Button variant="ghost" size="icon" onClick={toggleBookmark} className="h-8 w-8">
               <Bookmark className={cn("h-5 w-5", isBookmarked ? "fill-blue-500 text-blue-500" : "")} />
+            </Button>
+            <Button variant="ghost" size="icon" onClick={handleDeleteClick} className="h-8 w-8">
+              <Trash2 className="h-5 w-5" />
             </Button>
             <Button variant="ghost" size="icon" onClick={() => onOpenChange(false)} className="h-8 w-8 ml-2">
               <X className="h-5 w-5" />


### PR DESCRIPTION
### Motivation
- Make the delete action in the event preview use the normal ghost styling and place it to the right of the bookmark button for a more consistent toolbar layout. 
- Make the destructive delete action in the event dialog the leftmost action so it is separated from cancel/save and follows the intended visual order.

### Description
- Updated `components/app/event/event-preview.tsx` to remove the explicit red classes on the preview delete button and moved the delete button after the bookmark button so the order is Edit / Share / Bookmark / Delete / Close. 
- Updated `components/app/event/event-dialog.tsx` to move the destructive delete button to the leftmost position in the dialog footer so it appears before Cancel and Save/Update.

### Testing
- Searched and inspected affected files using `rg` and viewed the modified regions with `sed -n` and `nl`, and verified the diffs with `git diff`; all commands completed successfully. 
- Confirmed the changed UI markup and class updates in the two modified files (`event-preview.tsx`, `event-dialog.tsx`).
- No unit or lint tests were run per repository preferences.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_699956eb608c83329ade179ab2cb9e46)

## Summary by Sourcery

调整事件预览和对话框中事件删除按钮的位置和样式，使操作布局更加一致、清晰。

Enhancements:
- 更新事件预览工具栏，使删除按钮使用标准的 ghost 样式，并显示在收藏操作之后。
- 重新排列事件对话框底部的操作按钮，使具破坏性的删除按钮位于最左侧，其后依次为取消和保存/更新。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Adjust event delete button placement and styling for a more consistent and clear action layout in the event preview and dialog.

Enhancements:
- Update the event preview toolbar so the delete button uses standard ghost styling and appears after the bookmark action.
- Reorder the event dialog footer actions so the destructive delete button is leftmost, followed by cancel and save/update.

</details>