### PR TITLE
Disable ATProto login channel and public API access

### DIFF
--- a/app/(auth)/at-oauth/page.tsx
+++ b/app/(auth)/at-oauth/page.tsx
@@ -1,32 +1,5 @@
-import { AuthBrand } from "@/components/auth/auth-brand";
-import { AtprotoLoginForm } from "@/components/auth/atproto-login-form";
+import { redirect } from "next/navigation";
 
 export default function AtprotoLoginPage() {
-  return (
-    <div className="relative flex min-h-svh flex-col items-center justify-center overflow-hidden from-blue-500 via-indigo-500 to-purple-500 p-6 md:p-10">
-      <div className="fixed -z-10 inset-0">
-        <div className="absolute inset-0 bg-white dark:bg-black">
-          <div
-            className="absolute inset-0"
-            style={{
-              backgroundImage: `radial-gradient(circle at 1px 1px, rgba(0, 0, 0, 0.1) 1px, transparent 0)`,
-              backgroundSize: "24px 24px",
-            }}
-          />
-          <div
-            className="absolute inset-0 dark:block hidden"
-            style={{
-              backgroundImage: `radial-gradient(circle at 1px 1px, rgba(255, 255, 255, 0.15) 1px, transparent 0)`,
-              backgroundSize: "24px 24px",
-            }}
-          />
-        </div>
-      </div>
-
-      <div className="relative z-10 flex w-full max-w-sm flex-col gap-6">
-        <AuthBrand />
-        <AtprotoLoginForm />
-      </div>
-    </div>
-  );
+  redirect("/sign-in");
 }

--- a/app/api/atproto/callback/route.ts
+++ b/app/api/atproto/callback/route.ts
@@ -1,4 +1,5 @@
 import { NextRequest, NextResponse } from "next/server";
+import { ATPROTO_DISABLED } from "@/lib/atproto-feature";
 import { getActorProfileRecord, getProfile, profileAvatarBlobUrl } from "@/lib/atproto";
 import { setAtprotoSession } from "@/lib/atproto-auth";
 import { clearAtprotoOAuthTxnCookie, consumeAtprotoOAuthTxn, getAtprotoOAuthTxnFromRequest } from "@/lib/atproto-oauth-txn";
@@ -33,6 +34,7 @@ function normalizeIssuerOrigin(value: string) {
 }
 
 export async function GET(request: NextRequest) {
+  if (ATPROTO_DISABLED) return redirectWithError(process.env.NEXT_PUBLIC_BASE_URL || request.nextUrl.origin, "atproto_disabled");
   const code = request.nextUrl.searchParams.get("code");
   const state = request.nextUrl.searchParams.get("state");
   const iss = request.nextUrl.searchParams.get("iss");

--- a/app/api/atproto/login/route.ts
+++ b/app/api/atproto/login/route.ts
@@ -1,5 +1,6 @@
 import { randomUUID } from "node:crypto";
 import { NextRequest, NextResponse } from "next/server";
+import { ATPROTO_DISABLED, atprotoDisabledResponse } from "@/lib/atproto-feature";
 import { createPkcePair, resolveHandle } from "@/lib/atproto";
 import { generateDpopKeyMaterial } from "@/lib/dpop";
 import { setAtprotoOAuthTxnCookie } from "@/lib/atproto-oauth-txn";
@@ -57,6 +58,7 @@ function checkRateLimit(request: NextRequest, handle: string) {
 }
 
 export async function POST(request: NextRequest) {
+  if (ATPROTO_DISABLED) return atprotoDisabledResponse();
   const expectedBaseUrl = getExpectedBaseUrl(request);
   if (!isAllowedOrigin(request, expectedBaseUrl)) {
     return NextResponse.json({ error: "Forbidden" }, { status: 403 });

--- a/app/api/atproto/register-url/route.ts
+++ b/app/api/atproto/register-url/route.ts
@@ -1,5 +1,6 @@
 import { randomUUID } from "node:crypto";
 import { NextRequest, NextResponse } from "next/server";
+import { ATPROTO_DISABLED, atprotoDisabledResponse } from "@/lib/atproto-feature";
 import { createPkcePair } from "@/lib/atproto";
 import { setAtprotoOAuthTxnCookie } from "@/lib/atproto-oauth-txn";
 import { generateDpopKeyMaterial } from "@/lib/dpop";
@@ -11,6 +12,7 @@ function getBaseUrl(request: NextRequest) {
 }
 
 export async function POST(request: NextRequest) {
+  if (ATPROTO_DISABLED) return atprotoDisabledResponse();
   const baseUrl = getBaseUrl(request);
   const clientId = `${baseUrl}/oauth-client-metadata.json`;
   const authorizeUrl = new URL(`${ROSE_PDS_ORIGIN}/oauth/authorize`);

--- a/app/api/atproto/session/route.ts
+++ b/app/api/atproto/session/route.ts
@@ -1,8 +1,10 @@
 import { NextResponse } from "next/server";
+import { ATPROTO_DISABLED, atprotoDisabledResponse } from "@/lib/atproto-feature";
 import { getActorProfileRecord, profileAvatarBlobUrl } from "@/lib/atproto";
 import { getAtprotoSession, setAtprotoSession } from "@/lib/atproto-auth";
 
 export async function GET() {
+  if (ATPROTO_DISABLED) return atprotoDisabledResponse();
   const session = await getAtprotoSession();
   if (!session) return NextResponse.json({ signedIn: false });
 

--- a/app/api/share/public/route.ts
+++ b/app/api/share/public/route.ts
@@ -2,6 +2,7 @@ import { NextRequest, NextResponse } from "next/server";
 import crypto from "crypto";
 import { Pool } from "pg";
 import { getRecord, resolveHandle } from "@/lib/atproto";
+import { ATPROTO_DISABLED, atprotoDisabledResponse } from "@/lib/atproto-feature";
 
 const ALGORITHM = "aes-256-gcm";
 const ATPROTO_SHARE_COLLECTION = "app.onecalendar.share";
@@ -79,6 +80,7 @@ function decryptWithKey(encryptedData: string, iv: string, authTag: string, key:
 }
 
 export async function GET(request: NextRequest) {
+  if (ATPROTO_DISABLED) return atprotoDisabledResponse();
   const handle = request.nextUrl.searchParams.get("handle");
   const id = request.nextUrl.searchParams.get("id");
   const password = request.nextUrl.searchParams.get("password") ?? "";

--- a/components/auth/login-form.tsx
+++ b/components/auth/login-form.tsx
@@ -153,22 +153,6 @@ export function LoginForm({
                   variant="outline"
                   className="w-full"
                   type="button"
-                  onClick={() => (window.location.href = "/at-oauth")}
-                >
-                  <svg
-                    xmlns="http://www.w3.org/2000/svg"
-                    viewBox="0 0 640 560"
-                    className="h-5 w-auto shrink-0"
-                    aria-hidden="true"
-                  >
-                    <path fill="#0066ff" d="M133 47c74 56 152 169 197 260 45-91 123-204 197-260 53-40 140-70 140 28 0 20-11 170-18 194-22 85-103 106-175 93 124 22 156 91 87 161-131 134-188-34-203-75-2-6-3-12-3-18 0 6-1 12-3 18-15 41-72 209-203 75-69-70-37-139 87-161-72 13-153-8-175-93-7-24-18-174-18-194 0-98 87-68 140-28z"/>
-                  </svg>
-                  <span className="ml-2">Login with Atmosphere</span>
-                </Button>
-                <Button
-                  variant="outline"
-                  className="w-full"
-                  type="button"
                   onClick={() => handleOAuthLogin("oauth_github")}
                 >
                   <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" width="20" height="20">

--- a/components/auth/sign-up-form.tsx
+++ b/components/auth/sign-up-form.tsx
@@ -258,22 +258,6 @@ export function SignUpForm({
                   variant="outline"
                   className="w-full"
                   type="button"
-                  onClick={() => (window.location.href = "/at-oauth")}
-                >
-                  <svg
-                    xmlns="http://www.w3.org/2000/svg"
-                    viewBox="0 0 640 560"
-                    className="h-5 w-auto shrink-0"
-                    aria-hidden="true"
-                  >
-                    <path fill="#0066ff" d="M133 47c74 56 152 169 197 260 45-91 123-204 197-260 53-40 140-70 140 28 0 20-11 170-18 194-22 85-103 106-175 93 124 22 156 91 87 161-131 134-188-34-203-75-2-6-3-12-3-18 0 6-1 12-3 18-15 41-72 209-203 75-69-70-37-139 87-161-72 13-153-8-175-93-7-24-18-174-18-194 0-98 87-68 140-28z"/>
-                  </svg>
-                  <span className="ml-2">Continue with Atmosphere</span>
-                </Button>
-                <Button
-                  variant="outline"
-                  className="w-full"
-                  type="button"
                   onClick={() => handleOAuthSignUp("oauth_github")}
                 >
                   <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" width="20" height="20">

--- a/lib/atproto-auth.ts
+++ b/lib/atproto-auth.ts
@@ -1,6 +1,7 @@
 import { createDecipheriv, createHash, createCipheriv, hkdfSync, randomBytes } from "node:crypto";
 import type { DpopPublicJwk } from "@/lib/dpop";
 import { cookies } from "next/headers";
+import { ATPROTO_DISABLED } from "@/lib/atproto-feature";
 
 export const ATPROTO_SESSION_COOKIE = "atproto_session";
 
@@ -111,6 +112,10 @@ function decodeSession(raw: string): AtprotoSession | null {
 
 export async function getAtprotoSession(): Promise<AtprotoSession | null> {
   const store = await cookies();
+  if (ATPROTO_DISABLED) {
+    store.delete(ATPROTO_SESSION_COOKIE);
+    return null;
+  }
   const raw = store.get(ATPROTO_SESSION_COOKIE)?.value;
   if (!raw) return null;
 
@@ -124,6 +129,10 @@ export async function getAtprotoSession(): Promise<AtprotoSession | null> {
 
 export async function setAtprotoSession(session: AtprotoSession) {
   const store = await cookies();
+  if (ATPROTO_DISABLED) {
+    store.delete(ATPROTO_SESSION_COOKIE);
+    return;
+  }
   const value = encodeSession(session);
   store.set(ATPROTO_SESSION_COOKIE, value, {
     httpOnly: true,

--- a/lib/atproto-feature.ts
+++ b/lib/atproto-feature.ts
@@ -1,0 +1,7 @@
+import { NextResponse } from "next/server";
+
+export const ATPROTO_DISABLED = true;
+
+export function atprotoDisabledResponse() {
+  return NextResponse.json({ error: "ATProto channel is disabled" }, { status: 410 });
+}


### PR DESCRIPTION
### Motivation
- Provide a hard-off switch for the ATProto/Bluesky integration so the feature is disabled at runtime while keeping the original code paths intact for future re-enable or inspection.
- Ensure users cannot log in via ATProto or use ATProto-backed public share APIs, and existing ATProto sessions are invalidated.

### Description
- Added a central hard-off flag and helper `lib/atproto-feature.ts` exposing `ATPROTO_DISABLED = true` and `atprotoDisabledResponse()` to produce a `410` response.
- Short-circuited server endpoints to disable ATProto behavior by returning the disabled response at entry points for `/api/atproto/login`, `/api/atproto/register-url`, `/api/atproto/session`, `/api/atproto/callback` (redirect with error), and `/api/share/public`.
- Made `getAtprotoSession()` and `setAtprotoSession()` no-ops when disabled and clear any existing ATProto session cookie so old sessions are invalidated (`lib/atproto-auth.ts`).
- Removed UI entry points for Atmosphere/ATProto by deleting the Atmosphere/at-oauth buttons from sign-in and sign-up forms and replaced the `/at-oauth` page with a redirect to `/sign-in` so users cannot initiate ATProto OAuth from the UI.

### Testing
- Ran `git diff --check` to validate patch formatting and found no issues.
- Verified modified file list and working tree status via `git status --short` after changes.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_699d47315f908332b2625eeabedcdd84)

## Summary by Sourcery

在保留底层实现以便未来可能重新启用的前提下，禁用所有 ATProto/Atmosphere 登录和公共分享入口。

New Features:
- 引入集中式 ATProto 功能开关及辅助方法，当通道被禁用时返回 410 响应。

Bug Fixes:
- 在功能被禁用时使现有 ATProto 会话失效，并阻止新会话创建，以避免残留的已认证状态。

Enhancements:
- 在禁用状态下，快速短路所有与 ATProto 相关的 API 路由和公共分享端点，返回标准化错误或重定向。
- 将专用的 ATProto OAuth 页面替换为跳转到标准登录流程。
- 从登录和注册表单中移除 Atmosphere/ATProto 登录按钮，防止在 UI 中发起 ATProto OAuth。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Disable all ATProto/Atmosphere login and public sharing entry points while keeping underlying implementation intact for potential future re‑enablement.

New Features:
- Introduce a central ATProto feature toggle and helper that returns a 410 response when the channel is disabled.

Bug Fixes:
- Invalidate and prevent creation of ATProto sessions when the feature is disabled to avoid lingering authenticated states.

Enhancements:
- Short-circuit ATProto-related API routes and the public share endpoint when disabled, returning a standardized error or redirect.
- Replace the dedicated ATProto OAuth page with a redirect to the standard sign-in flow.
- Remove Atmosphere/ATProto login buttons from sign-in and sign-up forms to prevent initiating ATProto OAuth from the UI.

</details>