### PR TITLE
Refine signup E2EE recovery-key flow and move unlock prompt to profile

### DIFF
--- a/app/(auth)/sign-up/key/page.tsx
+++ b/app/(auth)/sign-up/key/page.tsx
@@ -1,0 +1,116 @@
+"use client"
+
+import { Button } from "@/components/ui/button"
+import { Card, CardContent, CardDescription, CardHeader, CardTitle } from "@/components/ui/card"
+import { initializeE2EEAccount, unlockAfterLogin } from "@/lib/e2ee/client"
+import { useUser } from "@clerk/nextjs"
+import { useRouter } from "next/navigation"
+import { useEffect, useState } from "react"
+
+const PENDING_KEY = "pending-signup-recovery-key"
+const PENDING_USER = "pending-signup-recovery-user"
+const ALLOW_INIT = "allow-signup-key-init"
+
+export default function SignUpKeyPage() {
+  const router = useRouter()
+  const { user, isLoaded, isSignedIn } = useUser()
+  const [status, setStatus] = useState<"loading" | "ready" | "blocked" | "error">("loading")
+  const [recoveryKey, setRecoveryKey] = useState("")
+  const [saved, setSaved] = useState(false)
+  const [error, setError] = useState("")
+
+  useEffect(() => {
+    if (!isLoaded) return
+    if (!isSignedIn || !user) {
+      setStatus("blocked")
+      return
+    }
+
+    const pendingKey = sessionStorage.getItem(PENDING_KEY)
+    const pendingUser = sessionStorage.getItem(PENDING_USER)
+    if (pendingKey && pendingUser === user.id) {
+      setRecoveryKey(pendingKey)
+      setStatus("ready")
+      return
+    }
+
+    const allowInit = sessionStorage.getItem(ALLOW_INIT) === "1"
+    if (!allowInit) {
+      setStatus("blocked")
+      return
+    }
+
+    unlockAfterLogin(user.id)
+      .then(() => {
+        setStatus("blocked")
+      })
+      .catch(async (err) => {
+        if (err instanceof Error && "code" in err && err.code === "E2EE_NOT_INITIALIZED") {
+          try {
+            const result = await initializeE2EEAccount(user.id)
+            setRecoveryKey(result.recoveryKey)
+            setStatus("ready")
+          } catch (initErr) {
+            setError(initErr instanceof Error ? initErr.message : "Failed to generate recovery key")
+            setStatus("error")
+          }
+          return
+        }
+        setStatus("blocked")
+      })
+  }, [isLoaded, isSignedIn, user])
+
+  const finish = () => {
+    sessionStorage.removeItem(PENDING_KEY)
+    sessionStorage.removeItem(PENDING_USER)
+    sessionStorage.removeItem(ALLOW_INIT)
+    router.replace("/app")
+  }
+
+  if (status === "loading") {
+    return <div className="p-8 text-center text-sm text-muted-foreground">Preparing your recovery key...</div>
+  }
+
+  if (status === "blocked") {
+    return (
+      <div className="mx-auto flex min-h-[70vh] max-w-lg items-center px-4">
+        <Card className="w-full">
+          <CardHeader>
+            <CardTitle>Recovery key is unavailable</CardTitle>
+            <CardDescription>
+              This page only works right after registration. No new recovery key was generated.
+            </CardDescription>
+          </CardHeader>
+          <CardContent>
+            <Button className="w-full" onClick={() => router.replace("/app")}>Go to app</Button>
+          </CardContent>
+        </Card>
+      </div>
+    )
+  }
+
+  if (status === "error") {
+    return <div className="p-8 text-center text-sm text-red-500">{error}</div>
+  }
+
+  return (
+    <div className="mx-auto flex min-h-[70vh] max-w-lg items-center px-4">
+      <Card className="w-full">
+        <CardHeader>
+          <CardTitle>Save your recovery key</CardTitle>
+          <CardDescription>
+            Keep this key safely. You will need it to unlock encrypted data on a new device.
+          </CardDescription>
+        </CardHeader>
+        <CardContent className="space-y-4">
+          <p className="break-all rounded bg-muted p-3 font-mono text-xs">{recoveryKey}</p>
+          <label className="flex items-center gap-2 text-sm">
+            <input type="checkbox" checked={saved} onChange={(e) => setSaved(e.target.checked)} />
+            I saved this recovery key securely.
+          </label>
+          <Button className="w-full" disabled={!saved} onClick={finish}>Continue to app</Button>
+        </CardContent>
+      </Card>
+    </div>
+  )
+}

--- a/app/(auth)/sign-up/sso-callback/page.tsx
+++ b/app/(auth)/sign-up/sso-callback/page.tsx
@@ -8,7 +8,7 @@ export default function SSOSignUpCallback() {
 
   useEffect(() => {
     fetch("/api/atproto/logout", { method: "POST" }).catch(() => undefined);
-    setSession?.({ forceRedirectUrl: '/app' });
+    setSession?.({ forceRedirectUrl: '/sign-up/key' });
   }, [setSession]);
 
   return <AuthenticateWithRedirectCallback />;


### PR DESCRIPTION
### Motivation
- Prevent showing or forcing the recovery/rotate key inside the signup dialog and ensure the key is produced only as part of a successful signup flow. 
- Make direct visits to the recovery-key page a no-op (blocked) so keys cannot be generated outside the signup flow. 
- Move the interactive recovery-key unlock experience into the user profile and perform IndexedDB / trusted-device checks earlier (auth-wait phase) so the calendar only mounts when E2EE is allowed/unlocked.

### Description
- Removed the recovery key display and confirmation checkbox from `SignUpForm` and eliminated client-side generation/display during the signup form UI. 
- On successful email signup the server-side init is still run via `initializeE2EEAccount(userId)`, but the generated recovery key and user id are stored in `sessionStorage` and the app redirects to a new `/sign-up/key` page to show/save the key. 
- Added a new page `app/(auth)/sign-up/key/page.tsx` which only shows or generates a recovery key when reached from the signup flow and otherwise renders a blocked state (no key generation on direct access). 
- Unified OAuth SSO signup redirect to `/sign-up/key` (updated `app/(auth)/sign-up/sso-callback/page.tsx`) and added a small `sessionStorage` flag for OAuth initiation to allow the key-init flow. 
- Removed the full-page `UnlockGate` rendering in `/app` and instead perform E2EE/trusted-device checks during the auth-wait stage in `app/(app)/app/page.tsx` using `unlockAfterLogin`; when unlock is required an event and `sessionStorage` flag are set so UI can surface an unlock prompt. 
- Implemented an unlock dialog in the user profile (`components/app/profile/user-profile-button.tsx`) with a new menu item and a recovery-key unlock flow using `unlockWithRecoveryKey`, and added an event listener to auto-open this dialog when the auth-wait logic detects an unlock is needed. 
- Small cleanup: removed unused recovery-related imports and state (e.g., removed `Checkbox` UI usage and `generateRecoveryKey` from the sign-up form) and wired OAuth buttons to set the allow-init flag.

### Testing
- No automated test suite or linter was executed for this change per the requested constraint (no `eslint`/tests were run).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_699eb61f5c148332be97d7f10edfd81c)

## Summary by Sourcery

通过将恢复密钥处理移入专门的注册步骤，并将工作区解锁集中到用户资料页（而不是在主应用视图外层加限制），来优化 E2EE 的引导和解锁流程。

New Features:
- 引入专用的 `/sign-up/key` 页面，仅在有效的注册流程中显示或初始化 E2EE 恢复密钥，并阻止直接访问尝试。
- 新增以用户资料为入口的解锁对话框，允许已登录用户使用恢复密钥解锁其加密工作区，并响应应用范围的 “需要解锁” 事件。

Enhancements:
- 简化邮箱和 OAuth 注册表单，移除内联的恢复密钥生成/确认逻辑，并将注册成功后重定向到新的恢复密钥页面。
- 在主应用页面的 auth-wait 阶段执行 E2EE 解锁检查，当需要用户交互时发出信号，而不是用全局解锁门将日历整体包裹起来。
- 收紧 OAuth 注册过程中的密钥初始化路径，通过协调 `sessionStorage` 标记和重定向行为，确保恢复密钥只在受控流程中生成。

Tests:
- 说明：根据既定约束，本次变更未运行任何自动化测试或代码检查工具。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Refine the E2EE onboarding and unlock flows by moving recovery-key handling into a dedicated signup step and centralizing workspace unlock in the user profile instead of gating the main app view.

New Features:
- Introduce a dedicated /sign-up/key page that displays or initializes an E2EE recovery key only as part of a valid signup flow and blocks direct access attempts.
- Add a user-profile-driven unlock dialog that lets signed-in users unlock their encrypted workspace using a recovery key and reacts to an app-wide unlock-required event.

Enhancements:
- Simplify the email and OAuth signup forms by removing inline recovery-key generation/confirmation and redirecting successful signups through the new recovery-key page.
- Perform E2EE unlock checks during the auth-wait phase on the main app page, signaling when user interaction is required instead of wrapping the calendar in a global unlock gate.
- Tighten the OAuth signup key-init path by coordinating sessionStorage flags and redirect behavior so recovery keys are only generated in controlled flows.

Tests:
- Note: No automated tests or linters were run for this change per the stated constraints.

</details>