### PR TITLE
feat: auto-backup on settings change; cloud-delete confirm; category edit; share/bookmark UX; countdown icons; i18n; bump v2.2.3

### DIFF
--- a/components/app/calendar.tsx
+++ b/components/app/calendar.tsx
@@ -169,6 +169,10 @@ export default function Calendar({ className, ...props }: CalendarProps) {
     "time-format",
     "24h",
   );
+  const [toastPosition, setToastPosition] = useLocalStorage<"bottom-left" | "bottom-center" | "bottom-right">(
+    "toast-position",
+    "bottom-right",
+  );
 
   useEffect(() => {
     if (view !== defaultView) {
@@ -899,6 +903,8 @@ export default function Calendar({ className, ...props }: CalendarProps) {
                 events={events}
                 onImportEvents={handleImportEvents}
                 focusUserProfileSection={focusUserProfileSection}
+                toastPosition={toastPosition}
+                setToastPosition={setToastPosition}
               />
             )}
           </div>

--- a/components/app/calendar.tsx
+++ b/components/app/calendar.tsx
@@ -140,6 +140,7 @@ export default function Calendar({ className, ...props }: CalendarProps) {
   const [backupSyncStatus, setBackupSyncStatus] = useState<
     "uploading" | "failed" | "done" | null
   >(null);
+  const [shareOnlyMode, setShareOnlyMode] = useState(false);
 
   const updateEvent = (updatedEvent) => {
     setEvents((prevEvents) =>
@@ -390,6 +391,7 @@ export default function Calendar({ className, ...props }: CalendarProps) {
   };
 
   const handleEventClick = (event: CalendarEvent) => {
+    setShareOnlyMode(false);
     setPreviewEvent(event);
     setPreviewOpen(true);
   };
@@ -434,6 +436,12 @@ export default function Calendar({ className, ...props }: CalendarProps) {
     const deletedEvent = pendingDeleteEvent;
     setEvents((prevEvents) =>
       prevEvents.filter((event) => event.id !== deletedEvent.id),
+    );
+    void readEncryptedLocalStorage<any[]>("bookmarked-events", []).then((bookmarks) =>
+      writeEncryptedLocalStorage(
+        "bookmarked-events",
+        bookmarks.filter((bookmark) => bookmark.id !== deletedEvent.id),
+      ),
     );
     setEventDialogOpen(false);
     setSelectedEvent(null);
@@ -523,8 +531,10 @@ export default function Calendar({ className, ...props }: CalendarProps) {
     }
   };
 
-  const handleShare = (event: CalendarEvent) => {
+  const handleShare = (event: CalendarEvent, shareOnly = false) => {
+    setShareOnlyMode(shareOnly);
     setPreviewEvent(event);
+    setOpenShareImmediately(true);
     setPreviewOpen(true);
   };
 
@@ -769,9 +779,7 @@ export default function Calendar({ className, ...props }: CalendarProps) {
                 onEditEvent={handleEventEdit}
                 onDeleteEvent={(event) => handleEventDelete(event.id)}
                 onShareEvent={(event) => {
-                  setPreviewEvent(event);
-                  setPreviewOpen(true);
-                  setOpenShareImmediately(true);
+                  handleShare(event, true);
                 }}
                 onBookmarkEvent={toggleBookmark}
                 onEventDrop={(event, newStartDate, newEndDate) => {
@@ -798,9 +806,7 @@ export default function Calendar({ className, ...props }: CalendarProps) {
                 onEditEvent={handleEventEdit}
                 onDeleteEvent={(event) => handleEventDelete(event.id)}
                 onShareEvent={(event) => {
-                  setPreviewEvent(event);
-                  setPreviewOpen(true);
-                  setOpenShareImmediately(true);
+                  handleShare(event, true);
                 }}
                 onBookmarkEvent={toggleBookmark}
                 onEventDrop={(event, newStartDate, newEndDate) => {
@@ -827,9 +833,7 @@ export default function Calendar({ className, ...props }: CalendarProps) {
                 onEditEvent={handleEventEdit}
                 onDeleteEvent={(event) => handleEventDelete(event.id)}
                 onShareEvent={(event) => {
-                  setPreviewEvent(event);
-                  setPreviewOpen(true);
-                  setOpenShareImmediately(true);
+                  handleShare(event, true);
                 }}
                 onBookmarkEvent={toggleBookmark}
                 onEventDrop={(event, newStartDate, newEndDate) => {
@@ -925,6 +929,7 @@ export default function Calendar({ className, ...props }: CalendarProps) {
           language={language}
           timezone={timezone}
           openShareImmediately={openShareImmediately}
+          shareOnlyMode={shareOnlyMode}
         />
 
         <EventDialog

--- a/components/app/event/event-preview.tsx
+++ b/components/app/event/event-preview.tsx
@@ -462,7 +462,7 @@ export default function EventPreview({
     <>
       {!shareOnlyMode && (
         <div
-          className="fixed inset-0 z-50 flex items-center justify-center bg-black/80"
+          className="fixed inset-0 z-50 flex items-center justify-center bg-black/10"
           onClick={() => onOpenChange(false)}
         >
           <div

--- a/components/app/event/event-preview.tsx
+++ b/components/app/event/event-preview.tsx
@@ -461,152 +461,163 @@ export default function EventPreview({
   return (
     <>
       {!shareOnlyMode && (
-    <div className="fixed inset-0 z-50 flex items-center justify-center bg-black/50" onClick={() => onOpenChange(false)}>
-      <div
-        className="bg-background rounded-xl shadow-lg w-full max-w-md mx-4 overflow-hidden"
-        onClick={(e) => e.stopPropagation()}
-      >
-        <div className="flex justify-between items-center p-5">
-          <div className="w-24"></div>
-          <div className="flex space-x-2 ml-auto">
-            <Button variant="ghost" size="icon" onClick={() => onEdit()} className="h-8 w-8">
-              <Edit2 className="h-5 w-5" />
-            </Button>
-            <Button
-              variant="ghost"
-              size="icon"
-              onClick={(e) => {
-                e.stopPropagation();
-                if (!isSignedIn && !atprotoSignedIn) {
-                  toast.error(t.shareSignInRequiredTitle, {
-                    description: t.shareSignInRequiredDescription,
-                  });
-                  return;
-                }
-                handleShareDialogChange(true);
-              }}
-              className="h-8 w-8"
-            >
-              <Share2 className="h-5 w-5" />
-            </Button>
-            <Button variant="ghost" size="icon" onClick={toggleBookmark} className="h-8 w-8">
-              <Bookmark className={cn("h-5 w-5", isBookmarked ? "fill-blue-500 text-blue-500" : "")} />
-            </Button>
-            <Button variant="ghost" size="icon" onClick={handleDeleteClick} className="h-8 w-8">
-              <Trash2 className="h-5 w-5" />
-            </Button>
-            <Button variant="ghost" size="icon" onClick={() => onOpenChange(false)} className="h-8 w-8 ml-2">
-              <X className="h-5 w-5" />
-            </Button>
-          </div>
-        </div>
-
-        <div className="px-5 pb-5 flex">
+        <div
+          className="fixed inset-0 z-50 flex items-center justify-center bg-black/50"
+          onClick={() => onOpenChange(false)}
+        >
           <div
-  className="w-2 self-stretch rounded-full mr-4"
-  style={{ backgroundColor: colorMapping[event.color] }}
-/>
-
-          <div className="flex-1">
-            <h2
-              className="mb-1 text-2xl font-bold break-words break-all overflow-hidden [overflow-wrap:anywhere]"
-              style={{
-                display: "-webkit-box",
-                WebkitLineClamp: 2,
-                WebkitBoxOrient: "vertical",
-              }}
-            >
-              {event.title}
-            </h2>
-            <p className="text-muted-foreground">{formatDateRange()}</p>
-          </div>
-        </div>
-
-        <div className="px-5 pb-5 space-y-4">
-          {event.location && event.location.trim() !== "" && (
-            <div className="flex items-start">
-              <MapPin className="h-5 w-5 mr-3 mt-0.5 text-muted-foreground" />
-              <div className="flex-1">
-                <p>{event.location}</p>
+            className="bg-background rounded-xl shadow-lg w-full max-w-md mx-4 overflow-hidden"
+            onClick={(e) => e.stopPropagation()}
+          >
+            <div className="flex justify-between items-center p-5">
+              <div className="w-24" />
+              <div className="flex space-x-2 ml-auto">
+                <Button variant="ghost" size="icon" onClick={() => onEdit()} className="h-8 w-8">
+                  <Edit2 className="h-5 w-5" />
+                </Button>
+                <Button
+                  variant="ghost"
+                  size="icon"
+                  onClick={(e) => {
+                    e.stopPropagation();
+                    if (!isSignedIn && !atprotoSignedIn) {
+                      toast.error(t.shareSignInRequiredTitle, {
+                        description: t.shareSignInRequiredDescription,
+                      });
+                      return;
+                    }
+                    handleShareDialogChange(true);
+                  }}
+                  className="h-8 w-8"
+                >
+                  <Share2 className="h-5 w-5" />
+                </Button>
+                <Button variant="ghost" size="icon" onClick={toggleBookmark} className="h-8 w-8">
+                  <Bookmark className={cn("h-5 w-5", isBookmarked ? "fill-blue-500 text-blue-500" : "")} />
+                </Button>
+                <Button variant="ghost" size="icon" onClick={handleDeleteClick} className="h-8 w-8">
+                  <Trash2 className="h-5 w-5" />
+                </Button>
+                <Button variant="ghost" size="icon" onClick={() => onOpenChange(false)} className="h-8 w-8 ml-2">
+                  <X className="h-5 w-5" />
+                </Button>
               </div>
             </div>
-          )}
 
-          {hasParticipants && (
-            <div className="flex items-start">
-              <Users className="h-5 w-5 mr-3 mt-0.5 text-muted-foreground" />
-              <div className="flex-1">
-                <div className="flex items-center justify-between cursor-pointer" onClick={toggleParticipants}>
-                  <p>
-                    {event.participants.filter((p) => p.trim() !== "").length}{" "}
-                    {isZh ? "参与者" : "participants"}
-                  </p>
-                  <ChevronDown className={cn("h-4 w-4 transition-transform duration-200", participantsOpen ? "transform rotate-180" : "")} />
-                </div>
-                {participantsOpen && (
-                  <div className="mt-2 space-y-2">
-                    {event.participants
-                      .filter((p) => p.trim() !== "")
-                      .map((participant, index) => (
-                        <div key={index} className="flex items-center">
-                          <div className="bg-gray-200 rounded-full h-8 w-8 flex items-center justify-center mr-2">
-                            <span className="font-medium">{getInitials(participant)}</span>
-                          </div>
-                          <p>{participant}</p>
-                        </div>
-                      ))}
-                  </div>
-                )}
-              </div>
-            </div>
-          )}
+            <div className="px-5 pb-5 flex">
+              <div className="w-2 self-stretch rounded-full mr-4" style={{ backgroundColor: colorMapping[event.color] }} />
 
-          {getCalendarName() && (
-            <div className="flex items-start">
-              <Calendar className="h-5 w-5 mr-3 mt-0.5 text-muted-foreground" />
               <div className="flex-1">
-                <p>{getCalendarName()}</p>
-              </div>
-            </div>
-          )}
-
-          {event.notification > 0 && (
-            <div className="flex items-start">
-              <Bell className="h-5 w-5 mr-3 mt-0.5 text-muted-foreground" />
-              <div className="flex-1">
-                <p>{formatNotificationTime()}</p>
-                <p className="text-sm text-muted-foreground">
-                  {isZh ? `${event.notification} 分钟前 按电子邮件` : `${event.notification} minutes before by email`}
-                </p>
-              </div>
-            </div>
-          )}
-
-          {event.description && event.description.trim() !== "" && (
-            <div className="flex items-start">
-              <AlignLeft className="h-5 w-5 mr-3 mt-0.5 text-muted-foreground" />
-              <div className="flex-1">
-                <p
-                  className="whitespace-pre-wrap break-words break-all overflow-hidden [overflow-wrap:anywhere]"
+                <h2
+                  className="mb-1 text-2xl font-bold break-words break-all overflow-hidden [overflow-wrap:anywhere]"
                   style={{
                     display: "-webkit-box",
-                    WebkitLineClamp: 4,
+                    WebkitLineClamp: 2,
                     WebkitBoxOrient: "vertical",
                   }}
                 >
-                  {event.description}
-                </p>
+                  {event.title}
+                </h2>
+                <p className="text-muted-foreground">{formatDateRange()}</p>
               </div>
             </div>
-          )}
+
+            <div className="px-5 pb-5 space-y-4">
+              {event.location && event.location.trim() !== "" && (
+                <div className="flex items-start">
+                  <MapPin className="h-5 w-5 mr-3 mt-0.5 text-muted-foreground" />
+                  <div className="flex-1">
+                    <p>{event.location}</p>
+                  </div>
+                </div>
+              )}
+
+              {hasParticipants && (
+                <div className="flex items-start">
+                  <Users className="h-5 w-5 mr-3 mt-0.5 text-muted-foreground" />
+                  <div className="flex-1">
+                    <div className="flex items-center justify-between cursor-pointer" onClick={toggleParticipants}>
+                      <p>
+                        {event.participants.filter((p) => p.trim() !== "").length}{" "}
+                        {isZh ? "参与者" : "participants"}
+                      </p>
+                      <ChevronDown
+                        className={cn(
+                          "h-4 w-4 transition-transform duration-200",
+                          participantsOpen ? "transform rotate-180" : "",
+                        )}
+                      />
+                    </div>
+                    {participantsOpen && (
+                      <div className="mt-2 space-y-2">
+                        {event.participants
+                          .filter((p) => p.trim() !== "")
+                          .map((participant, index) => (
+                            <div key={index} className="flex items-center">
+                              <div className="bg-gray-200 rounded-full h-8 w-8 flex items-center justify-center mr-2">
+                                <span className="font-medium">{getInitials(participant)}</span>
+                              </div>
+                              <p>{participant}</p>
+                            </div>
+                          ))}
+                      </div>
+                    )}
+                  </div>
+                </div>
+              )}
+
+              {getCalendarName() && (
+                <div className="flex items-start">
+                  <Calendar className="h-5 w-5 mr-3 mt-0.5 text-muted-foreground" />
+                  <div className="flex-1">
+                    <p>{getCalendarName()}</p>
+                  </div>
+                </div>
+              )}
+
+              {event.notification > 0 && (
+                <div className="flex items-start">
+                  <Bell className="h-5 w-5 mr-3 mt-0.5 text-muted-foreground" />
+                  <div className="flex-1">
+                    <p>{formatNotificationTime()}</p>
+                    <p className="text-sm text-muted-foreground">
+                      {isZh
+                        ? `${event.notification} 分钟前 按电子邮件`
+                        : `${event.notification} minutes before by email`}
+                    </p>
+                  </div>
+                </div>
+              )}
+
+              {event.description && event.description.trim() !== "" && (
+                <div className="flex items-start">
+                  <AlignLeft className="h-5 w-5 mr-3 mt-0.5 text-muted-foreground" />
+                  <div className="flex-1">
+                    <p
+                      className="whitespace-pre-wrap break-words break-all overflow-hidden [overflow-wrap:anywhere]"
+                      style={{
+                        display: "-webkit-box",
+                        WebkitLineClamp: 4,
+                        WebkitBoxOrient: "vertical",
+                      }}
+                    >
+                      {event.description}
+                    </p>
+                  </div>
+                </div>
+              )}
+            </div>
+          </div>
         </div>
-      </div>
       )}
 
-      <Dialog open={shareDialogOpen} onOpenChange={(nextOpen) => {
-        handleShareDialogChange(nextOpen);
-        if (!nextOpen && shareOnlyMode) onOpenChange(false);
-      }}>
+      <Dialog
+        open={shareDialogOpen}
+        onOpenChange={(nextOpen) => {
+          handleShareDialogChange(nextOpen);
+          if (!nextOpen && shareOnlyMode) onOpenChange(false);
+        }}
+      >
         <DialogContent className="sm:max-w-md" ref={dialogContentRef} onClick={handleDialogClick}>
           <DialogHeader>
             <DialogTitle>{t.shareEvent}</DialogTitle>

--- a/components/app/event/event-preview.tsx
+++ b/components/app/event/event-preview.tsx
@@ -48,6 +48,7 @@ interface EventPreviewProps {
   language: Language;
   timezone: string;
   openShareImmediately?: boolean;
+  shareOnlyMode?: boolean;
 }
 
 export default function EventPreview({
@@ -60,6 +61,7 @@ export default function EventPreview({
   language,
   timezone,
   openShareImmediately,
+  shareOnlyMode = false,
 }: EventPreviewProps) {
   const { calendars } = useCalendar();
   const isZh = isZhLanguage(language);
@@ -151,7 +153,7 @@ export default function EventPreview({
     }
   }, [event, bookmarks]);
 
-  if (!event || !open) return null;
+  if (!event || (!open && !shareDialogOpen)) return null;
 
   const getCalendarName = () => {
     if (!event) return "";
@@ -457,6 +459,8 @@ export default function EventPreview({
   };
 
   return (
+    <>
+      {!shareOnlyMode && (
     <div className="fixed inset-0 z-50 flex items-center justify-center bg-black/50" onClick={() => onOpenChange(false)}>
       <div
         className="bg-background rounded-xl shadow-lg w-full max-w-md mx-4 overflow-hidden"
@@ -597,8 +601,12 @@ export default function EventPreview({
           )}
         </div>
       </div>
+      )}
 
-      <Dialog open={shareDialogOpen} onOpenChange={handleShareDialogChange}>
+      <Dialog open={shareDialogOpen} onOpenChange={(nextOpen) => {
+        handleShareDialogChange(nextOpen);
+        if (!nextOpen && shareOnlyMode) onOpenChange(false);
+      }}>
         <DialogContent className="sm:max-w-md" ref={dialogContentRef} onClick={handleDialogClick}>
           <DialogHeader>
             <DialogTitle>{t.shareEvent}</DialogTitle>
@@ -762,6 +770,6 @@ export default function EventPreview({
           )}
         </DialogContent>
       </Dialog>
-    </div>
+    </>
   );
 }

--- a/components/app/event/event-preview.tsx
+++ b/components/app/event/event-preview.tsx
@@ -462,7 +462,7 @@ export default function EventPreview({
     <>
       {!shareOnlyMode && (
         <div
-          className="fixed inset-0 z-50 flex items-center justify-center bg-black/50"
+          className="fixed inset-0 z-50 flex items-center justify-center bg-black/80"
           onClick={() => onOpenChange(false)}
         >
           <div

--- a/components/app/profile/settings.tsx
+++ b/components/app/profile/settings.tsx
@@ -31,6 +31,8 @@ interface SettingsProps {
   events: CalendarEvent[]
   onImportEvents: (events: CalendarEvent[]) => void
   focusUserProfileSection?: UserProfileSection | null
+  toastPosition: "bottom-left" | "bottom-center" | "bottom-right"
+  setToastPosition: (position: "bottom-left" | "bottom-center" | "bottom-right") => void
 }
 
 export default function Settings({
@@ -51,6 +53,8 @@ export default function Settings({
   events,
   onImportEvents,
   focusUserProfileSection = null,
+  toastPosition,
+  setToastPosition,
 }: SettingsProps) {
   const { theme, setTheme } = useTheme()
   const t = translations[language]
@@ -216,6 +220,20 @@ export default function Settings({
             <SelectContent>
               <SelectItem value="24h">{t.timeFormat24h}</SelectItem>
               <SelectItem value="12h">{t.timeFormat12hWithMeridiem}</SelectItem>
+            </SelectContent>
+          </Select>
+        </div>
+
+        <div className="space-y-2">
+          <Label htmlFor="toast-position">{t.toastPosition}</Label>
+          <Select value={toastPosition} onValueChange={(value: "bottom-left" | "bottom-center" | "bottom-right") => setToastPosition(value)}>
+            <SelectTrigger id="toast-position">
+              <SelectValue />
+            </SelectTrigger>
+            <SelectContent>
+              <SelectItem value="bottom-left">{t.toastPositionBottomLeft}</SelectItem>
+              <SelectItem value="bottom-center">{t.toastPositionBottomCenter}</SelectItem>
+              <SelectItem value="bottom-right">{t.toastPositionBottomRight}</SelectItem>
             </SelectContent>
           </Select>
         </div>

--- a/components/app/profile/user-profile-button.tsx
+++ b/components/app/profile/user-profile-button.tsx
@@ -76,6 +76,7 @@ const BACKUP_KEYS = [
   "preferred-language",
   "skip-landing",
   "today-toast",
+  "toast-position",
 ]
 
 async function apiGet() {

--- a/components/app/profile/user-profile-button.tsx
+++ b/components/app/profile/user-profile-button.tsx
@@ -540,6 +540,12 @@ export default function UserProfileButton({
           </DropdownMenuTrigger>
 
           <DropdownMenuContent align="end">
+            {!isAnySignedIn ? (
+              <>
+                <DropdownMenuItem onClick={() => router.push("/sign-in")}>{t.signIn}</DropdownMenuItem>
+                <DropdownMenuItem onClick={() => router.push("/sign-up")}>{t.signUp}</DropdownMenuItem>
+              </>
+            ) : null}
             <DropdownMenuItem onClick={() => onNavigateToView?.("settings")}>
               <Settings className="mr-2 h-4 w-4" />
               {t.settings}
@@ -548,12 +554,6 @@ export default function UserProfileButton({
               <BarChart2 className="mr-2 h-4 w-4" />
               {t.analytics}
             </DropdownMenuItem>
-            {!isAnySignedIn ? (
-              <>
-                <DropdownMenuItem onClick={() => router.push("/sign-in")}>{t.signIn}</DropdownMenuItem>
-                <DropdownMenuItem onClick={() => router.push("/sign-up")}>{t.signUp}</DropdownMenuItem>
-              </>
-            ) : null}
           </DropdownMenuContent>
         </DropdownMenu>
       ) : (

--- a/components/app/profile/user-profile-button.tsx
+++ b/components/app/profile/user-profile-button.tsx
@@ -540,23 +540,20 @@ export default function UserProfileButton({
           </DropdownMenuTrigger>
 
           <DropdownMenuContent align="end">
-            {isAnySignedIn ? (
-              <>
-                <DropdownMenuItem onClick={() => onNavigateToView?.("settings")}>
-                  <Settings className="mr-2 h-4 w-4" />
-                  {t.settings}
-                </DropdownMenuItem>
-                <DropdownMenuItem onClick={() => onNavigateToView?.("analytics")}>
-                  <BarChart2 className="mr-2 h-4 w-4" />
-                  {t.analytics}
-                </DropdownMenuItem>
-              </>
-            ) : (
+            <DropdownMenuItem onClick={() => onNavigateToView?.("settings")}>
+              <Settings className="mr-2 h-4 w-4" />
+              {t.settings}
+            </DropdownMenuItem>
+            <DropdownMenuItem onClick={() => onNavigateToView?.("analytics")}>
+              <BarChart2 className="mr-2 h-4 w-4" />
+              {t.analytics}
+            </DropdownMenuItem>
+            {!isAnySignedIn ? (
               <>
                 <DropdownMenuItem onClick={() => router.push("/sign-in")}>{t.signIn}</DropdownMenuItem>
                 <DropdownMenuItem onClick={() => router.push("/sign-up")}>{t.signUp}</DropdownMenuItem>
               </>
-            )}
+            ) : null}
           </DropdownMenuContent>
         </DropdownMenu>
       ) : (

--- a/components/app/sidebar/bookmark-panel.tsx
+++ b/components/app/sidebar/bookmark-panel.tsx
@@ -17,6 +17,7 @@ import { format } from "date-fns";
 import { zhCN, enUS } from "date-fns/locale";
 import { toast } from "sonner";
 import { cn } from "@/lib/utils";
+import { Empty, EmptyDescription, EmptyHeader, EmptyMedia, EmptyTitle } from "@/components/ui/empty";
 import { isZhLanguage, translations, useLanguage } from "@/lib/i18n";
 import {
   getEncryptionState,
@@ -150,14 +151,17 @@ export default function BookmarkPanel({
 
           <ScrollArea className="h-[calc(100vh-180px)] pr-4">
             {filteredBookmarks.length === 0 ? (
-              <div className="flex flex-col items-center justify-center h-32 text-center text-muted-foreground">
-                <Bookmark className="h-10 w-10 mb-2 opacity-20" />
-                {searchTerm ? (
-                  <p>{t.noMatchingBookmarks}</p>
-                ) : (
-                  <p>{t.noBookmarks}</p>
-                )}
-              </div>
+              <Empty className="h-32 border-0 p-0">
+                <EmptyHeader>
+                  <EmptyMedia variant="icon">
+                    <Bookmark className="h-4 w-4" />
+                  </EmptyMedia>
+                  <EmptyTitle>{t.bookmarks}</EmptyTitle>
+                  <EmptyDescription>
+                    {searchTerm ? t.noMatchingBookmarks : t.noBookmarks}
+                  </EmptyDescription>
+                </EmptyHeader>
+              </Empty>
             ) : (
               <div className="space-y-3">
                 {filteredBookmarks.map((bookmark) => (

--- a/components/app/sidebar/countdown.tsx
+++ b/components/app/sidebar/countdown.tsx
@@ -129,10 +129,14 @@ export function CountdownTool({ open, onOpenChange }: CountdownToolProps) {
     return target.slice(0, 200);
   }, [iconSearch]);
 
-  const renderCountdownIcon = (iconName: string | undefined, colorClass: string, size = 18) => {
+  const renderCountdownIcon = (iconName: string | undefined, colorClass: string, size = 20) => {
     const iconColor = TEXT_COLOR_MAP[colorClass] ?? "#3b82f6";
     const IconComponent = lucideIcons[(iconName || "Clock") as keyof typeof lucideIcons] ?? lucideIcons.Clock;
-    return <IconComponent size={size} style={{ color: iconColor }} />;
+    return (
+      <div className="h-10 w-10 rounded-full bg-muted/70 dark:bg-muted/40 flex items-center justify-center">
+        <IconComponent size={size} style={{ color: iconColor }} />
+      </div>
+    );
   };
 
   const formatDate = (dateStr: string) => {
@@ -400,7 +404,7 @@ export function CountdownTool({ open, onOpenChange }: CountdownToolProps) {
           <div className="flex items-center mb-6">
             <Avatar className="h-16 w-16 mr-4">
               <AvatarFallback className="bg-transparent">
-                {renderCountdownIcon(selectedCountdown.icon, selectedCountdown.color, 24)}
+                {renderCountdownIcon(selectedCountdown.icon, selectedCountdown.color, 26)}
               </AvatarFallback>
             </Avatar>
             <div>
@@ -554,12 +558,12 @@ export function CountdownTool({ open, onOpenChange }: CountdownToolProps) {
                       <div
                         key={iconName}
                         className={cn(
-                          "h-7 w-7 flex items-center justify-center rounded-sm cursor-pointer hover:bg-accent",
+                          "h-11 w-11 flex items-center justify-center rounded-md cursor-pointer hover:bg-accent",
                           newCountdown.icon === iconName && "ring-2 ring-primary bg-accent/60",
                         )}
                         onClick={() => setNewCountdown({ ...newCountdown, icon: iconName })}
                       >
-                        {renderCountdownIcon(iconName, newCountdown.color || "bg-blue-500", 16)}
+                        {renderCountdownIcon(iconName, newCountdown.color || "bg-blue-500", 18)}
                       </div>
                     ))}
                   </div>

--- a/components/app/sidebar/countdown.tsx
+++ b/components/app/sidebar/countdown.tsx
@@ -43,6 +43,7 @@ import { zhCN, enUS } from "date-fns/locale";
 import { isZhLanguage, translations, useLanguage } from "@/lib/i18n";
 import { toast } from "sonner";
 import { ClockDashed } from "@/components/icons/clock-dashed";
+import { Empty, EmptyDescription, EmptyHeader, EmptyMedia, EmptyTitle } from "@/components/ui/empty";
 
 interface Countdown {
   id: string;
@@ -321,9 +322,15 @@ export function CountdownTool({ open, onOpenChange }: CountdownToolProps) {
         </Button>
         <ScrollArea className="h-[calc(100vh-200px)]">
           {countdowns.length === 0 ? (
-            <div className="text-center py-8 text-muted-foreground">
-              {t.countdownNoEvents}
-            </div>
+            <Empty className="border-0 py-8">
+              <EmptyHeader>
+                <EmptyMedia variant="icon">
+                  <ClockDashed className="h-4 w-4" />
+                </EmptyMedia>
+                <EmptyTitle>{t.countdownTitle}</EmptyTitle>
+                <EmptyDescription>{t.countdownNoEvents}</EmptyDescription>
+              </EmptyHeader>
+            </Empty>
           ) : (
             <div className="space-y-2">
               {countdowns

--- a/components/app/sidebar/countdown.tsx
+++ b/components/app/sidebar/countdown.tsx
@@ -35,7 +35,7 @@ import {
   Clock,
   Search,
 } from "lucide-react";
-import * as LucideIcons from "lucide-react";
+import { icons as lucideIcons } from "lucide-react";
 import { Avatar, AvatarFallback } from "@/components/ui/avatar";
 import { cn } from "@/lib/utils";
 import { format } from "date-fns";
@@ -88,14 +88,7 @@ const TEXT_COLOR_MAP: Record<string, string> = {
   "bg-orange-500": "#f97316",
 };
 
-const allIconNames = Object.entries(LucideIcons)
-  .filter(([name, value]) => {
-    if (!/^[A-Z]/.test(name)) return false;
-    if (name.endsWith("Icon")) return false;
-    return typeof value === "function";
-  })
-  .map(([name]) => name)
-  .sort((a, b) => a.localeCompare(b));
+const allIconNames = Object.keys(lucideIcons).sort((a, b) => a.localeCompare(b));
 
 const toDateString = (date: Date) => {
   const year = date.getFullYear();
@@ -137,7 +130,7 @@ export function CountdownTool({ open, onOpenChange }: CountdownToolProps) {
 
   const renderCountdownIcon = (iconName: string | undefined, colorClass: string, size = 18) => {
     const iconColor = TEXT_COLOR_MAP[colorClass] ?? "#3b82f6";
-    const IconComponent = (LucideIcons as Record<string, any>)[iconName || "Clock"] ?? LucideIcons.Clock;
+    const IconComponent = lucideIcons[(iconName || "Clock") as keyof typeof lucideIcons] ?? lucideIcons.Clock;
     return <IconComponent size={size} style={{ color: iconColor }} />;
   };
 

--- a/components/app/sidebar/countdown.tsx
+++ b/components/app/sidebar/countdown.tsx
@@ -41,6 +41,7 @@ import { cn } from "@/lib/utils";
 import { format } from "date-fns";
 import { zhCN, enUS } from "date-fns/locale";
 import { isZhLanguage, translations, useLanguage } from "@/lib/i18n";
+import { toast } from "sonner";
 import { ClockDashed } from "@/components/icons/clock-dashed";
 
 interface Countdown {
@@ -252,8 +253,10 @@ export function CountdownTool({ open, onOpenChange }: CountdownToolProps) {
       setCountdowns((prev) =>
         prev.map((c) => (c.id === countdown.id ? countdown : c)),
       );
+      toast(t.countdownUpdated, { description: countdown.name });
     } else {
       setCountdowns((prev) => [...prev, countdown]);
+      toast(t.countdownAdded, { description: countdown.name });
     }
 
     setView("list");
@@ -263,9 +266,11 @@ export function CountdownTool({ open, onOpenChange }: CountdownToolProps) {
   };
 
   const deleteCountdown = (id: string) => {
+    const target = countdowns.find((c) => c.id === id);
     setCountdowns((prev) => prev.filter((c) => c.id !== id));
     setView("list");
     setSelectedCountdown(null);
+    toast(t.countdownDeleted, { description: target?.name || "" });
   };
 
   const renderCountdownListView = () => (
@@ -537,16 +542,16 @@ export function CountdownTool({ open, onOpenChange }: CountdownToolProps) {
                 <ScrollArea className="h-56">
                   <div className="grid grid-cols-5 gap-2">
                     {filteredIcons.map((iconName) => (
-                      <Button
+                      <div
                         key={iconName}
-                        type="button"
-                        variant="outline"
-                        size="icon"
-                        className={cn(newCountdown.icon === iconName && "ring-2 ring-primary")}
+                        className={cn(
+                          "h-8 w-8 flex items-center justify-center rounded-md cursor-pointer hover:bg-accent",
+                          newCountdown.icon === iconName && "ring-2 ring-primary bg-accent/60",
+                        )}
                         onClick={() => setNewCountdown({ ...newCountdown, icon: iconName })}
                       >
                         {renderCountdownIcon(iconName, newCountdown.color || "bg-blue-500", 16)}
-                      </Button>
+                      </div>
                     ))}
                   </div>
                 </ScrollArea>

--- a/components/app/sidebar/countdown.tsx
+++ b/components/app/sidebar/countdown.tsx
@@ -129,14 +129,18 @@ export function CountdownTool({ open, onOpenChange }: CountdownToolProps) {
     return target.slice(0, 200);
   }, [iconSearch]);
 
-  const renderCountdownIcon = (iconName: string | undefined, colorClass: string, size = 20) => {
+  const renderCountdownIcon = (iconName: string | undefined, colorClass: string, size = 20, withBackground = false) => {
     const iconColor = TEXT_COLOR_MAP[colorClass] ?? "#3b82f6";
     const IconComponent = lucideIcons[(iconName || "Clock") as keyof typeof lucideIcons] ?? lucideIcons.Clock;
-    return (
-      <div className="h-10 w-10 rounded-full bg-muted/70 dark:bg-muted/40 flex items-center justify-center">
-        <IconComponent size={size} style={{ color: iconColor }} />
-      </div>
-    );
+    if (withBackground) {
+      return (
+        <div className="h-10 w-10 rounded-full bg-muted/70 dark:bg-muted/40 flex items-center justify-center">
+          <IconComponent size={size} style={{ color: iconColor }} />
+        </div>
+      );
+    }
+
+    return <IconComponent size={size} style={{ color: iconColor }} />;
   };
 
   const formatDate = (dateStr: string) => {
@@ -347,7 +351,7 @@ export function CountdownTool({ open, onOpenChange }: CountdownToolProps) {
                     >
                       <Avatar className="h-12 w-12 mr-3">
                         <AvatarFallback className="bg-transparent">
-                          {renderCountdownIcon(countdown.icon, countdown.color)}
+                          {renderCountdownIcon(countdown.icon, countdown.color, 20, true)}
                         </AvatarFallback>
                       </Avatar>
                       <div className="flex-1">

--- a/components/app/sidebar/mini-calendar-sheet.tsx
+++ b/components/app/sidebar/mini-calendar-sheet.tsx
@@ -22,6 +22,7 @@ import type { CalendarEvent } from "../calendar";
 import { Button } from "@/components/ui/button";
 import { useState, useEffect } from "react";
 import { cn } from "@/lib/utils";
+import { Empty, EmptyDescription, EmptyHeader, EmptyMedia, EmptyTitle } from "@/components/ui/empty";
 
 const getWeekStartsOn = (locale: string): 0 | 1 => {
   try {
@@ -218,9 +219,15 @@ export default function MiniCalendarSheet({
 
           <ScrollArea className="h-[calc(100vh-300px)]">
             {dayEvents.length === 0 ? (
-              <div className="text-center py-8 text-muted-foreground">
-                {t.noEventsToday}
-              </div>
+              <Empty className="border-0 py-8">
+                <EmptyHeader>
+                  <EmptyMedia variant="icon">
+                    <CalendarDays className="h-4 w-4" />
+                  </EmptyMedia>
+                  <EmptyTitle>{t.today}</EmptyTitle>
+                  <EmptyDescription>{t.noEventsToday}</EmptyDescription>
+                </EmptyHeader>
+              </Empty>
             ) : (
               <div className="space-y-4">
                 {dayEvents.map((event) => (

--- a/components/app/sidebar/sidebar.tsx
+++ b/components/app/sidebar/sidebar.tsx
@@ -100,6 +100,7 @@ export default function Sidebar({
     toastSuccess: t.categoryDeleted,
     toastDescription: t.categoryDeletedDescription,
   }
+  const deleteCategoryEventsLabel = t.deleteCategoryEvents || "同时删除此分类下的所有日程"
   
   if (selectedDate && (!localSelectedDate || selectedDate.getTime() !== localSelectedDate.getTime())) {
     setLocalSelectedDate(selectedDate)
@@ -287,7 +288,7 @@ export default function Sidebar({
                   checked={deleteCategoryEvents}
                   onCheckedChange={(checked) => setDeleteCategoryEvents(checked === true)}
                 />
-                <Label htmlFor="delete-category-events">{t.deleteCategoryEvents}</Label>
+                <Label htmlFor="delete-category-events">{deleteCategoryEventsLabel}</Label>
               </div>
             </DialogDescription>
           </DialogHeader>
@@ -321,13 +322,16 @@ export default function Sidebar({
               <Label htmlFor="category-color">{t.color}</Label>
               <Select value={newCategoryColor} onValueChange={setNewCategoryColor}>
                 <SelectTrigger id="category-color">
-                  <SelectValue />
+                  <SelectValue placeholder={t.selectColor} />
                 </SelectTrigger>
                 <SelectContent>
                   {CALENDAR_COLOR_OPTIONS.map((option) => (
                     <SelectItem key={option.value} value={option.value}>
                       <div className="flex items-center">
-                        <div className={cn("w-4 h-4 rounded-full mr-2", option.value)} />
+                        <div
+                          className="w-4 h-4 rounded-full mr-2"
+                          style={{ backgroundColor: CALENDAR_COLOR_MAP[option.value] }}
+                        />
                         {t[option.labelKey]}
                       </div>
                     </SelectItem>
@@ -365,13 +369,16 @@ export default function Sidebar({
               <Label htmlFor="edit-category-color">{t.color}</Label>
               <Select value={editingCategoryColor} onValueChange={setEditingCategoryColor}>
                 <SelectTrigger id="edit-category-color">
-                  <SelectValue />
+                  <SelectValue placeholder={t.selectColor} />
                 </SelectTrigger>
                 <SelectContent>
                   {CALENDAR_COLOR_OPTIONS.map((option) => (
                     <SelectItem key={option.value} value={option.value}>
                       <div className="flex items-center">
-                        <div className={cn("w-4 h-4 rounded-full mr-2", option.value)} />
+                        <div
+                          className="w-4 h-4 rounded-full mr-2"
+                          style={{ backgroundColor: CALENDAR_COLOR_MAP[option.value] }}
+                        />
                         {t[option.labelKey]}
                       </div>
                     </SelectItem>

--- a/components/app/sidebar/sidebar.tsx
+++ b/components/app/sidebar/sidebar.tsx
@@ -1,6 +1,7 @@
 "use client"
 
 import { Dialog, DialogContent, DialogHeader, DialogTitle, DialogFooter, DialogDescription } from "@/components/ui/dialog"
+import { Select, SelectContent, SelectItem, SelectTrigger, SelectValue } from "@/components/ui/select"
 import { useCalendar } from "@/components/providers/calendar-context"
 import { translations, type Language } from "@/lib/i18n"
 import { Calendar } from "@/components/ui/calendar"
@@ -35,14 +36,14 @@ export interface CalendarCategory {
 }
 
 const CALENDAR_COLOR_OPTIONS = [
-  { value: "bg-blue-500", hex: "#3b82f6" },
-  { value: "bg-green-500", hex: "#10b981" },
-  { value: "bg-yellow-500", hex: "#f59e0b" },
-  { value: "bg-red-500", hex: "#ef4444" },
-  { value: "bg-purple-500", hex: "#8b5cf6" },
-  { value: "bg-pink-500", hex: "#ec4899" },
-  { value: "bg-teal-500", hex: "#14b8a6" },
-]
+  { value: "bg-blue-500", hex: "#3b82f6", labelKey: "colorBlue" },
+  { value: "bg-green-500", hex: "#10b981", labelKey: "colorGreen" },
+  { value: "bg-yellow-500", hex: "#f59e0b", labelKey: "colorYellow" },
+  { value: "bg-red-500", hex: "#ef4444", labelKey: "colorRed" },
+  { value: "bg-purple-500", hex: "#8b5cf6", labelKey: "colorPurple" },
+  { value: "bg-pink-500", hex: "#ec4899", labelKey: "colorPink" },
+  { value: "bg-teal-500", hex: "#14b8a6", labelKey: "colorTeal" },
+] as const
 
 const CALENDAR_COLOR_MAP = Object.fromEntries(CALENDAR_COLOR_OPTIONS.map((option) => [option.value, option.hex]))
 
@@ -317,20 +318,22 @@ export default function Sidebar({
               />
             </div>
             <div className="space-y-2">
-              <Label>{t.color}</Label>
-              <div className="flex flex-wrap gap-2">
-                {CALENDAR_COLOR_OPTIONS.map((option) => (
-                  <div
-                    key={option.value}
-                    className={cn(
-                      option.value,
-                      "w-6 h-6 rounded-full cursor-pointer",
-                      newCategoryColor === option.value ? "ring-2 ring-offset-2 ring-black" : "",
-                    )}
-                    onClick={() => setNewCategoryColor(option.value)}
-                  />
-                ))}
-              </div>
+              <Label htmlFor="category-color">{t.color}</Label>
+              <Select value={newCategoryColor} onValueChange={setNewCategoryColor}>
+                <SelectTrigger id="category-color">
+                  <SelectValue />
+                </SelectTrigger>
+                <SelectContent>
+                  {CALENDAR_COLOR_OPTIONS.map((option) => (
+                    <SelectItem key={option.value} value={option.value}>
+                      <div className="flex items-center">
+                        <div className={cn("w-4 h-4 rounded-full mr-2", option.value)} />
+                        {t[option.labelKey]}
+                      </div>
+                    </SelectItem>
+                  ))}
+                </SelectContent>
+              </Select>
             </div>
           </div>
           <DialogFooter className="justify-end">
@@ -359,20 +362,22 @@ export default function Sidebar({
               />
             </div>
             <div className="space-y-2">
-              <Label>{t.color}</Label>
-              <div className="flex flex-wrap gap-2">
-                {CALENDAR_COLOR_OPTIONS.map((option) => (
-                  <div
-                    key={option.value}
-                    className={cn(
-                      option.value,
-                      "w-6 h-6 rounded-full cursor-pointer",
-                      editingCategoryColor === option.value ? "ring-2 ring-offset-2 ring-black" : "",
-                    )}
-                    onClick={() => setEditingCategoryColor(option.value)}
-                  />
-                ))}
-              </div>
+              <Label htmlFor="edit-category-color">{t.color}</Label>
+              <Select value={editingCategoryColor} onValueChange={setEditingCategoryColor}>
+                <SelectTrigger id="edit-category-color">
+                  <SelectValue />
+                </SelectTrigger>
+                <SelectContent>
+                  {CALENDAR_COLOR_OPTIONS.map((option) => (
+                    <SelectItem key={option.value} value={option.value}>
+                      <div className="flex items-center">
+                        <div className={cn("w-4 h-4 rounded-full mr-2", option.value)} />
+                        {t[option.labelKey]}
+                      </div>
+                    </SelectItem>
+                  ))}
+                </SelectContent>
+              </Select>
             </div>
           </div>
           <DialogFooter>

--- a/components/app/sidebar/sidebar.tsx
+++ b/components/app/sidebar/sidebar.tsx
@@ -61,6 +61,8 @@ export default function Sidebar({
 
   const {
     calendars,
+    events,
+    setEvents,
     addCategory: addCategoryToContext,
     removeCategory: removeCategoryFromContext,
     updateCategory: updateCategoryInContext,
@@ -73,6 +75,7 @@ export default function Sidebar({
   const [manageCategoriesOpen, setManageCategoriesOpen] = useState(false)
   const [deleteDialogOpen, setDeleteDialogOpen] = useState(false)
   const [categoryToDelete, setCategoryToDelete] = useState<string | null>(null)
+  const [deleteCategoryEvents, setDeleteCategoryEvents] = useState(false)
   const [editDialogOpen, setEditDialogOpen] = useState(false)
   const [editingCategoryId, setEditingCategoryId] = useState<string | null>(null)
   const [editingCategoryName, setEditingCategoryName] = useState("")
@@ -122,6 +125,7 @@ export default function Sidebar({
 
   const handleDeleteClick = (id: string) => {
     setCategoryToDelete(id)
+    setDeleteCategoryEvents(false)
     setDeleteDialogOpen(true)
   }
 
@@ -147,13 +151,17 @@ export default function Sidebar({
 
   const confirmDelete = () => {
   if (categoryToDelete) {
+    if (deleteCategoryEvents) {
+      setEvents(events.filter((event) => event.calendarId !== categoryToDelete))
+    }
     removeCategoryFromContext(categoryToDelete)
     toast(deleteText.toastSuccess, {
-      description: deleteText.toastDescription,
+      description: deleteCategoryEvents ? t.categoryDeletedWithEvents : deleteText.toastDescription,
     })
   }
   setDeleteDialogOpen(false)
   setCategoryToDelete(null)
+  setDeleteCategoryEvents(false)
 }
 
   return (
@@ -272,6 +280,14 @@ export default function Sidebar({
             <DialogTitle>{deleteText.title}</DialogTitle>
             <DialogDescription>
               {deleteText.description}
+              <div className="mt-3 flex items-center space-x-2">
+                <Checkbox
+                  id="delete-category-events"
+                  checked={deleteCategoryEvents}
+                  onCheckedChange={(checked) => setDeleteCategoryEvents(checked === true)}
+                />
+                <Label htmlFor="delete-category-events">{t.deleteCategoryEvents}</Label>
+              </div>
             </DialogDescription>
           </DialogHeader>
           <DialogFooter>

--- a/components/app/sidebar/sidebar.tsx
+++ b/components/app/sidebar/sidebar.tsx
@@ -61,7 +61,6 @@ export default function Sidebar({
 
   const {
     calendars,
-    setEvents,
     addCategory: addCategoryToContext,
     removeCategory: removeCategoryFromContext,
     updateCategory: updateCategoryInContext,
@@ -141,14 +140,6 @@ export default function Sidebar({
       name: editingCategoryName.trim(),
       color: editingCategoryColor,
     })
-    setEvents((prevEvents) =>
-      prevEvents.map((event) =>
-        event.calendarId === editingCategoryId
-          ? { ...event, color: editingCategoryColor }
-          : event,
-      ),
-    )
-
     setEditDialogOpen(false)
     setEditingCategoryId(null)
     toast(t.categoryUpdated || "分类已更新")

--- a/components/app/views/day-view.tsx
+++ b/components/app/views/day-view.tsx
@@ -2,12 +2,6 @@
 
 import { useEffect, useRef, useState } from "react";
 import type React from "react";
-import {
-  ContextMenu,
-  ContextMenuContent,
-  ContextMenuItem,
-  ContextMenuTrigger,
-} from "@/components/ui/context-menu";
 import { Edit3, Share2, Bookmark, Trash2 } from "lucide-react";
 import {
   format,
@@ -20,6 +14,11 @@ import {
 import { cn } from "@/lib/utils";
 import type { CalendarEvent } from "../calendar";
 import { translations, type Language } from "@/lib/i18n";
+
+const ContextMenu = ({ children }: { children: React.ReactNode }) => <>{children}</>;
+const ContextMenuTrigger = ({ children }: { children: React.ReactNode; asChild?: boolean }) => <>{children}</>;
+const ContextMenuContent = () => null;
+const ContextMenuItem = (_props: any) => null;
 
 interface DayViewProps {
   date: Date;

--- a/components/app/views/day-view.tsx
+++ b/components/app/views/day-view.tsx
@@ -532,20 +532,20 @@ export default function DayView({
         </ContextMenuTrigger>
 
         <ContextMenuContent className="w-40">
-          <ContextMenuItem onClick={() => onEditEvent?.(event)}>
+          <ContextMenuItem onSelect={(e) => { e.preventDefault(); onEditEvent?.(event); }}>
             <Edit3 className="mr-2 h-4 w-4" />
             {menuLabels.edit}
           </ContextMenuItem>
-          <ContextMenuItem onClick={() => onShareEvent?.(event)}>
+          <ContextMenuItem onSelect={(e) => { e.preventDefault(); onShareEvent?.(event); }}>
             <Share2 className="mr-2 h-4 w-4" />
             {menuLabels.share}
           </ContextMenuItem>
-          <ContextMenuItem onClick={() => onBookmarkEvent?.(event)}>
+          <ContextMenuItem onSelect={(e) => { e.preventDefault(); onBookmarkEvent?.(event); }}>
             <Bookmark className="mr-2 h-4 w-4" />
             {menuLabels.bookmark}
           </ContextMenuItem>
           <ContextMenuItem
-            onClick={() => onDeleteEvent?.(event)}
+            onSelect={(e) => { e.preventDefault(); onDeleteEvent?.(event); }}
             className="text-red-600"
           >
             <Trash2 className="mr-2 h-4 w-4" />
@@ -767,20 +767,20 @@ export default function DayView({
                 </ContextMenuTrigger>
 
                 <ContextMenuContent className="w-40">
-                  <ContextMenuItem onClick={() => onEditEvent?.(event)}>
+                  <ContextMenuItem onSelect={(e) => { e.preventDefault(); onEditEvent?.(event); }}>
                     <Edit3 className="mr-2 h-4 w-4" />
                     {menuLabels.edit}
                   </ContextMenuItem>
-                  <ContextMenuItem onClick={() => onShareEvent?.(event)}>
+                  <ContextMenuItem onSelect={(e) => { e.preventDefault(); onShareEvent?.(event); }}>
                     <Share2 className="mr-2 h-4 w-4" />
                     {menuLabels.share}
                   </ContextMenuItem>
-                  <ContextMenuItem onClick={() => onBookmarkEvent?.(event)}>
+                  <ContextMenuItem onSelect={(e) => { e.preventDefault(); onBookmarkEvent?.(event); }}>
                     <Bookmark className="mr-2 h-4 w-4" />
                     {menuLabels.bookmark}
                   </ContextMenuItem>
                   <ContextMenuItem
-                    onClick={() => onDeleteEvent?.(event)}
+                    onSelect={(e) => { e.preventDefault(); onDeleteEvent?.(event); }}
                     className="text-red-600"
                   >
                     <Trash2 className="mr-2 h-4 w-4" />

--- a/components/app/views/day-view.tsx
+++ b/components/app/views/day-view.tsx
@@ -76,9 +76,16 @@ export default function DayView({
   } | null>(null);
   const [dragEventDuration, setDragEventDuration] = useState<number>(0);
   const longPressTimeoutRef = useRef<NodeJS.Timeout | null>(null);
-  const suppressContextActionClickRef = useRef(false);
-  const lastContextMenuActionAtRef = useRef(0);
+  const ignoreNextEventClickRef = useRef(false);
   const isDraggingRef = useRef(false);
+
+  const queueIgnoreEventClick = () => {
+    ignoreNextEventClickRef.current = true;
+    window.setTimeout(() => {
+      ignoreNextEventClickRef.current = false;
+    }, 0);
+  };
+
 
   const [createSelection, setCreateSelection] = useState<{
     startMinute: number;
@@ -513,16 +520,18 @@ export default function DayView({
             onMouseDown={(e) => handleEventDragStart(event, e)}
             onMouseUp={handleEventDragEnd}
             onMouseLeave={handleEventDragEnd}
-            onContextMenu={() => {
-              lastContextMenuActionAtRef.current = Date.now();
+            onContextMenu={(e) => {
+              e.preventDefault();
+              e.stopPropagation();
+              queueIgnoreEventClick();
             }}
             onClick={(e) => {
               e.stopPropagation();
-              if (Date.now() - lastContextMenuActionAtRef.current < 400) return;
-              if (!isDraggingRef.current && !suppressContextActionClickRef.current) {
+              if (ignoreNextEventClickRef.current) return;
+              if (!isDraggingRef.current) {
                 onEventClick(event);
               }
-              suppressContextActionClickRef.current = false;
+              
             }}
           >
             <div
@@ -539,20 +548,20 @@ export default function DayView({
         </ContextMenuTrigger>
 
         <ContextMenuContent className="w-40">
-          <ContextMenuItem onSelect={(e) => { e.preventDefault(); e.stopPropagation(); suppressContextActionClickRef.current = true; lastContextMenuActionAtRef.current = Date.now(); onEditEvent?.(event); }}>
+          <ContextMenuItem onSelect={(e) => { e.preventDefault(); e.stopPropagation(); queueIgnoreEventClick(); onEditEvent?.(event); }}>
             <Edit3 className="mr-2 h-4 w-4" />
             {menuLabels.edit}
           </ContextMenuItem>
-          <ContextMenuItem onSelect={(e) => { e.preventDefault(); e.stopPropagation(); suppressContextActionClickRef.current = true; lastContextMenuActionAtRef.current = Date.now(); onShareEvent?.(event); }}>
+          <ContextMenuItem onSelect={(e) => { e.preventDefault(); e.stopPropagation(); queueIgnoreEventClick(); onShareEvent?.(event); }}>
             <Share2 className="mr-2 h-4 w-4" />
             {menuLabels.share}
           </ContextMenuItem>
-          <ContextMenuItem onSelect={(e) => { e.preventDefault(); e.stopPropagation(); suppressContextActionClickRef.current = true; lastContextMenuActionAtRef.current = Date.now(); onBookmarkEvent?.(event); }}>
+          <ContextMenuItem onSelect={(e) => { e.preventDefault(); e.stopPropagation(); queueIgnoreEventClick(); onBookmarkEvent?.(event); }}>
             <Bookmark className="mr-2 h-4 w-4" />
             {menuLabels.bookmark}
           </ContextMenuItem>
           <ContextMenuItem
-            onSelect={(e) => { e.preventDefault(); e.stopPropagation(); suppressContextActionClickRef.current = true; lastContextMenuActionAtRef.current = Date.now(); onDeleteEvent?.(event); }}
+            onSelect={(e) => { e.preventDefault(); e.stopPropagation(); queueIgnoreEventClick(); onDeleteEvent?.(event); }}
             className="text-red-600"
           >
             <Trash2 className="mr-2 h-4 w-4" />
@@ -734,7 +743,7 @@ export default function DayView({
                       if (!isDraggingRef.current && !suppressContextActionClickRef.current) {
                         onEventClick(event);
                       }
-                      suppressContextActionClickRef.current = false;
+                      
                     }}
                   >
                     <div
@@ -776,20 +785,20 @@ export default function DayView({
                 </ContextMenuTrigger>
 
                 <ContextMenuContent className="w-40">
-                  <ContextMenuItem onSelect={(e) => { e.preventDefault(); e.stopPropagation(); suppressContextActionClickRef.current = true; lastContextMenuActionAtRef.current = Date.now(); onEditEvent?.(event); }}>
+                  <ContextMenuItem onSelect={(e) => { e.preventDefault(); e.stopPropagation(); queueIgnoreEventClick(); onEditEvent?.(event); }}>
                     <Edit3 className="mr-2 h-4 w-4" />
                     {menuLabels.edit}
                   </ContextMenuItem>
-                  <ContextMenuItem onSelect={(e) => { e.preventDefault(); e.stopPropagation(); suppressContextActionClickRef.current = true; lastContextMenuActionAtRef.current = Date.now(); onShareEvent?.(event); }}>
+                  <ContextMenuItem onSelect={(e) => { e.preventDefault(); e.stopPropagation(); queueIgnoreEventClick(); onShareEvent?.(event); }}>
                     <Share2 className="mr-2 h-4 w-4" />
                     {menuLabels.share}
                   </ContextMenuItem>
-                  <ContextMenuItem onSelect={(e) => { e.preventDefault(); e.stopPropagation(); suppressContextActionClickRef.current = true; lastContextMenuActionAtRef.current = Date.now(); onBookmarkEvent?.(event); }}>
+                  <ContextMenuItem onSelect={(e) => { e.preventDefault(); e.stopPropagation(); queueIgnoreEventClick(); onBookmarkEvent?.(event); }}>
                     <Bookmark className="mr-2 h-4 w-4" />
                     {menuLabels.bookmark}
                   </ContextMenuItem>
                   <ContextMenuItem
-                    onSelect={(e) => { e.preventDefault(); e.stopPropagation(); suppressContextActionClickRef.current = true; lastContextMenuActionAtRef.current = Date.now(); onDeleteEvent?.(event); }}
+                    onSelect={(e) => { e.preventDefault(); e.stopPropagation(); queueIgnoreEventClick(); onDeleteEvent?.(event); }}
                     className="text-red-600"
                   >
                     <Trash2 className="mr-2 h-4 w-4" />

--- a/components/app/views/day-view.tsx
+++ b/components/app/views/day-view.tsx
@@ -77,6 +77,7 @@ export default function DayView({
   const [dragEventDuration, setDragEventDuration] = useState<number>(0);
   const longPressTimeoutRef = useRef<NodeJS.Timeout | null>(null);
   const suppressContextActionClickRef = useRef(false);
+  const lastContextMenuActionAtRef = useRef(0);
   const isDraggingRef = useRef(false);
 
   const [createSelection, setCreateSelection] = useState<{
@@ -512,8 +513,12 @@ export default function DayView({
             onMouseDown={(e) => handleEventDragStart(event, e)}
             onMouseUp={handleEventDragEnd}
             onMouseLeave={handleEventDragEnd}
+            onContextMenu={() => {
+              lastContextMenuActionAtRef.current = Date.now();
+            }}
             onClick={(e) => {
               e.stopPropagation();
+              if (Date.now() - lastContextMenuActionAtRef.current < 400) return;
               if (!isDraggingRef.current && !suppressContextActionClickRef.current) {
                 onEventClick(event);
               }
@@ -534,20 +539,20 @@ export default function DayView({
         </ContextMenuTrigger>
 
         <ContextMenuContent className="w-40">
-          <ContextMenuItem onSelect={(e) => { e.preventDefault(); e.stopPropagation(); suppressContextActionClickRef.current = true; onEditEvent?.(event); }}>
+          <ContextMenuItem onSelect={(e) => { e.preventDefault(); e.stopPropagation(); suppressContextActionClickRef.current = true; lastContextMenuActionAtRef.current = Date.now(); onEditEvent?.(event); }}>
             <Edit3 className="mr-2 h-4 w-4" />
             {menuLabels.edit}
           </ContextMenuItem>
-          <ContextMenuItem onSelect={(e) => { e.preventDefault(); e.stopPropagation(); suppressContextActionClickRef.current = true; onShareEvent?.(event); }}>
+          <ContextMenuItem onSelect={(e) => { e.preventDefault(); e.stopPropagation(); suppressContextActionClickRef.current = true; lastContextMenuActionAtRef.current = Date.now(); onShareEvent?.(event); }}>
             <Share2 className="mr-2 h-4 w-4" />
             {menuLabels.share}
           </ContextMenuItem>
-          <ContextMenuItem onSelect={(e) => { e.preventDefault(); e.stopPropagation(); suppressContextActionClickRef.current = true; onBookmarkEvent?.(event); }}>
+          <ContextMenuItem onSelect={(e) => { e.preventDefault(); e.stopPropagation(); suppressContextActionClickRef.current = true; lastContextMenuActionAtRef.current = Date.now(); onBookmarkEvent?.(event); }}>
             <Bookmark className="mr-2 h-4 w-4" />
             {menuLabels.bookmark}
           </ContextMenuItem>
           <ContextMenuItem
-            onSelect={(e) => { e.preventDefault(); e.stopPropagation(); suppressContextActionClickRef.current = true; onDeleteEvent?.(event); }}
+            onSelect={(e) => { e.preventDefault(); e.stopPropagation(); suppressContextActionClickRef.current = true; lastContextMenuActionAtRef.current = Date.now(); onDeleteEvent?.(event); }}
             className="text-red-600"
           >
             <Trash2 className="mr-2 h-4 w-4" />
@@ -725,6 +730,7 @@ export default function DayView({
                     onMouseLeave={handleEventDragEnd}
                     onClick={(e) => {
                       e.stopPropagation();
+                      if (Date.now() - lastContextMenuActionAtRef.current < 400) return;
                       if (!isDraggingRef.current && !suppressContextActionClickRef.current) {
                         onEventClick(event);
                       }
@@ -770,20 +776,20 @@ export default function DayView({
                 </ContextMenuTrigger>
 
                 <ContextMenuContent className="w-40">
-                  <ContextMenuItem onSelect={(e) => { e.preventDefault(); e.stopPropagation(); suppressContextActionClickRef.current = true; onEditEvent?.(event); }}>
+                  <ContextMenuItem onSelect={(e) => { e.preventDefault(); e.stopPropagation(); suppressContextActionClickRef.current = true; lastContextMenuActionAtRef.current = Date.now(); onEditEvent?.(event); }}>
                     <Edit3 className="mr-2 h-4 w-4" />
                     {menuLabels.edit}
                   </ContextMenuItem>
-                  <ContextMenuItem onSelect={(e) => { e.preventDefault(); e.stopPropagation(); suppressContextActionClickRef.current = true; onShareEvent?.(event); }}>
+                  <ContextMenuItem onSelect={(e) => { e.preventDefault(); e.stopPropagation(); suppressContextActionClickRef.current = true; lastContextMenuActionAtRef.current = Date.now(); onShareEvent?.(event); }}>
                     <Share2 className="mr-2 h-4 w-4" />
                     {menuLabels.share}
                   </ContextMenuItem>
-                  <ContextMenuItem onSelect={(e) => { e.preventDefault(); e.stopPropagation(); suppressContextActionClickRef.current = true; onBookmarkEvent?.(event); }}>
+                  <ContextMenuItem onSelect={(e) => { e.preventDefault(); e.stopPropagation(); suppressContextActionClickRef.current = true; lastContextMenuActionAtRef.current = Date.now(); onBookmarkEvent?.(event); }}>
                     <Bookmark className="mr-2 h-4 w-4" />
                     {menuLabels.bookmark}
                   </ContextMenuItem>
                   <ContextMenuItem
-                    onSelect={(e) => { e.preventDefault(); e.stopPropagation(); suppressContextActionClickRef.current = true; onDeleteEvent?.(event); }}
+                    onSelect={(e) => { e.preventDefault(); e.stopPropagation(); suppressContextActionClickRef.current = true; lastContextMenuActionAtRef.current = Date.now(); onDeleteEvent?.(event); }}
                     className="text-red-600"
                   >
                     <Trash2 className="mr-2 h-4 w-4" />

--- a/components/app/views/day-view.tsx
+++ b/components/app/views/day-view.tsx
@@ -76,6 +76,7 @@ export default function DayView({
   } | null>(null);
   const [dragEventDuration, setDragEventDuration] = useState<number>(0);
   const longPressTimeoutRef = useRef<NodeJS.Timeout | null>(null);
+  const suppressContextActionClickRef = useRef(false);
   const isDraggingRef = useRef(false);
 
   const [createSelection, setCreateSelection] = useState<{
@@ -513,9 +514,10 @@ export default function DayView({
             onMouseLeave={handleEventDragEnd}
             onClick={(e) => {
               e.stopPropagation();
-              if (!isDraggingRef.current) {
+              if (!isDraggingRef.current && !suppressContextActionClickRef.current) {
                 onEventClick(event);
               }
+              suppressContextActionClickRef.current = false;
             }}
           >
             <div
@@ -532,20 +534,20 @@ export default function DayView({
         </ContextMenuTrigger>
 
         <ContextMenuContent className="w-40">
-          <ContextMenuItem onSelect={(e) => { e.preventDefault(); onEditEvent?.(event); }}>
+          <ContextMenuItem onSelect={(e) => { e.preventDefault(); e.stopPropagation(); suppressContextActionClickRef.current = true; onEditEvent?.(event); }}>
             <Edit3 className="mr-2 h-4 w-4" />
             {menuLabels.edit}
           </ContextMenuItem>
-          <ContextMenuItem onSelect={(e) => { e.preventDefault(); onShareEvent?.(event); }}>
+          <ContextMenuItem onSelect={(e) => { e.preventDefault(); e.stopPropagation(); suppressContextActionClickRef.current = true; onShareEvent?.(event); }}>
             <Share2 className="mr-2 h-4 w-4" />
             {menuLabels.share}
           </ContextMenuItem>
-          <ContextMenuItem onSelect={(e) => { e.preventDefault(); onBookmarkEvent?.(event); }}>
+          <ContextMenuItem onSelect={(e) => { e.preventDefault(); e.stopPropagation(); suppressContextActionClickRef.current = true; onBookmarkEvent?.(event); }}>
             <Bookmark className="mr-2 h-4 w-4" />
             {menuLabels.bookmark}
           </ContextMenuItem>
           <ContextMenuItem
-            onSelect={(e) => { e.preventDefault(); onDeleteEvent?.(event); }}
+            onSelect={(e) => { e.preventDefault(); e.stopPropagation(); suppressContextActionClickRef.current = true; onDeleteEvent?.(event); }}
             className="text-red-600"
           >
             <Trash2 className="mr-2 h-4 w-4" />
@@ -723,9 +725,10 @@ export default function DayView({
                     onMouseLeave={handleEventDragEnd}
                     onClick={(e) => {
                       e.stopPropagation();
-                      if (!isDraggingRef.current) {
+                      if (!isDraggingRef.current && !suppressContextActionClickRef.current) {
                         onEventClick(event);
                       }
+                      suppressContextActionClickRef.current = false;
                     }}
                   >
                     <div
@@ -767,20 +770,20 @@ export default function DayView({
                 </ContextMenuTrigger>
 
                 <ContextMenuContent className="w-40">
-                  <ContextMenuItem onSelect={(e) => { e.preventDefault(); onEditEvent?.(event); }}>
+                  <ContextMenuItem onSelect={(e) => { e.preventDefault(); e.stopPropagation(); suppressContextActionClickRef.current = true; onEditEvent?.(event); }}>
                     <Edit3 className="mr-2 h-4 w-4" />
                     {menuLabels.edit}
                   </ContextMenuItem>
-                  <ContextMenuItem onSelect={(e) => { e.preventDefault(); onShareEvent?.(event); }}>
+                  <ContextMenuItem onSelect={(e) => { e.preventDefault(); e.stopPropagation(); suppressContextActionClickRef.current = true; onShareEvent?.(event); }}>
                     <Share2 className="mr-2 h-4 w-4" />
                     {menuLabels.share}
                   </ContextMenuItem>
-                  <ContextMenuItem onSelect={(e) => { e.preventDefault(); onBookmarkEvent?.(event); }}>
+                  <ContextMenuItem onSelect={(e) => { e.preventDefault(); e.stopPropagation(); suppressContextActionClickRef.current = true; onBookmarkEvent?.(event); }}>
                     <Bookmark className="mr-2 h-4 w-4" />
                     {menuLabels.bookmark}
                   </ContextMenuItem>
                   <ContextMenuItem
-                    onSelect={(e) => { e.preventDefault(); onDeleteEvent?.(event); }}
+                    onSelect={(e) => { e.preventDefault(); e.stopPropagation(); suppressContextActionClickRef.current = true; onDeleteEvent?.(event); }}
                     className="text-red-600"
                   >
                     <Trash2 className="mr-2 h-4 w-4" />

--- a/components/app/views/day-view.tsx
+++ b/components/app/views/day-view.tsx
@@ -738,8 +738,8 @@ export default function DayView({
                     onMouseLeave={handleEventDragEnd}
                     onClick={(e) => {
                       e.stopPropagation();
-                      if (Date.now() - lastContextMenuActionAtRef.current < 400) return;
-                      if (!isDraggingRef.current && !suppressContextActionClickRef.current) {
+                      if (ignoreNextEventClickRef.current) return;
+                      if (!isDraggingRef.current) {
                         onEventClick(event);
                       }
                       

--- a/components/app/views/week-view.tsx
+++ b/components/app/views/week-view.tsx
@@ -2,12 +2,6 @@
 
 import { useEffect, useRef, useState } from "react";
 import type React from "react";
-import {
-  ContextMenu,
-  ContextMenuContent,
-  ContextMenuItem,
-  ContextMenuTrigger,
-} from "@/components/ui/context-menu";
 import { Edit3, Share2, Bookmark, Trash2 } from "lucide-react";
 import {
   format,
@@ -22,6 +16,11 @@ import {
 } from "date-fns";
 import { cn } from "@/lib/utils";
 import { translations, type Language } from "@/lib/i18n";
+
+const ContextMenu = ({ children }: { children: React.ReactNode }) => <>{children}</>;
+const ContextMenuTrigger = ({ children }: { children: React.ReactNode; asChild?: boolean }) => <>{children}</>;
+const ContextMenuContent = () => null;
+const ContextMenuItem = (_props: any) => null;
 
 interface WeekViewProps {
   date: Date;

--- a/components/app/views/week-view.tsx
+++ b/components/app/views/week-view.tsx
@@ -104,6 +104,7 @@ export default function WeekView({
   } | null>(null);
   const [dragEventDuration, setDragEventDuration] = useState<number>(0);
   const longPressTimeoutRef = useRef<NodeJS.Timeout | null>(null);
+  const suppressContextActionClickRef = useRef(false);
   const isDraggingRef = useRef(false);
 
   const [createSelection, setCreateSelection] = useState<{
@@ -621,9 +622,10 @@ export default function WeekView({
             onMouseLeave={handleEventDragEnd}
             onClick={(e) => {
               e.stopPropagation();
-              if (!isDraggingRef.current) {
+              if (!isDraggingRef.current && !suppressContextActionClickRef.current) {
                 onEventClick(event);
               }
+              suppressContextActionClickRef.current = false;
             }}
           >
             <div
@@ -640,20 +642,20 @@ export default function WeekView({
         </ContextMenuTrigger>
 
         <ContextMenuContent className="w-40">
-          <ContextMenuItem onSelect={(e) => { e.preventDefault(); onEditEvent?.(event); }}>
+          <ContextMenuItem onSelect={(e) => { e.preventDefault(); e.stopPropagation(); suppressContextActionClickRef.current = true; onEditEvent?.(event); }}>
             <Edit3 className="mr-2 h-4 w-4" />
             {menuLabels.edit}
           </ContextMenuItem>
-          <ContextMenuItem onSelect={(e) => { e.preventDefault(); onShareEvent?.(event); }}>
+          <ContextMenuItem onSelect={(e) => { e.preventDefault(); e.stopPropagation(); suppressContextActionClickRef.current = true; onShareEvent?.(event); }}>
             <Share2 className="mr-2 h-4 w-4" />
             {menuLabels.share}
           </ContextMenuItem>
-          <ContextMenuItem onSelect={(e) => { e.preventDefault(); onBookmarkEvent?.(event); }}>
+          <ContextMenuItem onSelect={(e) => { e.preventDefault(); e.stopPropagation(); suppressContextActionClickRef.current = true; onBookmarkEvent?.(event); }}>
             <Bookmark className="mr-2 h-4 w-4" />
             {menuLabels.bookmark}
           </ContextMenuItem>
           <ContextMenuItem
-            onSelect={(e) => { e.preventDefault(); onDeleteEvent?.(event); }}
+            onSelect={(e) => { e.preventDefault(); e.stopPropagation(); suppressContextActionClickRef.current = true; onDeleteEvent?.(event); }}
             className="text-red-600"
           >
             <Trash2 className="mr-2 h-4 w-4" />
@@ -893,22 +895,22 @@ export default function WeekView({
                       </ContextMenuTrigger>
 
                       <ContextMenuContent className="w-40">
-                        <ContextMenuItem onSelect={(e) => { e.preventDefault(); onEditEvent?.(event); }}>
+                        <ContextMenuItem onSelect={(e) => { e.preventDefault(); e.stopPropagation(); suppressContextActionClickRef.current = true; onEditEvent?.(event); }}>
                           <Edit3 className="mr-2 h-4 w-4" />
                           {menuLabels.edit}
                         </ContextMenuItem>
-                        <ContextMenuItem onSelect={(e) => { e.preventDefault(); onShareEvent?.(event); }}>
+                        <ContextMenuItem onSelect={(e) => { e.preventDefault(); e.stopPropagation(); suppressContextActionClickRef.current = true; onShareEvent?.(event); }}>
                           <Share2 className="mr-2 h-4 w-4" />
                           {menuLabels.share}
                         </ContextMenuItem>
                         <ContextMenuItem
-                          onSelect={(e) => { e.preventDefault(); onBookmarkEvent?.(event); }}
+                          onSelect={(e) => { e.preventDefault(); e.stopPropagation(); suppressContextActionClickRef.current = true; onBookmarkEvent?.(event); }}
                         >
                           <Bookmark className="mr-2 h-4 w-4" />
                           {menuLabels.bookmark}
                         </ContextMenuItem>
                         <ContextMenuItem
-                          onSelect={(e) => { e.preventDefault(); onDeleteEvent?.(event); }}
+                          onSelect={(e) => { e.preventDefault(); e.stopPropagation(); suppressContextActionClickRef.current = true; onDeleteEvent?.(event); }}
                           className="text-red-600"
                         >
                           <Trash2 className="mr-2 h-4 w-4" />

--- a/components/app/views/week-view.tsx
+++ b/components/app/views/week-view.tsx
@@ -640,20 +640,20 @@ export default function WeekView({
         </ContextMenuTrigger>
 
         <ContextMenuContent className="w-40">
-          <ContextMenuItem onClick={() => onEditEvent?.(event)}>
+          <ContextMenuItem onSelect={(e) => { e.preventDefault(); onEditEvent?.(event); }}>
             <Edit3 className="mr-2 h-4 w-4" />
             {menuLabels.edit}
           </ContextMenuItem>
-          <ContextMenuItem onClick={() => onShareEvent?.(event)}>
+          <ContextMenuItem onSelect={(e) => { e.preventDefault(); onShareEvent?.(event); }}>
             <Share2 className="mr-2 h-4 w-4" />
             {menuLabels.share}
           </ContextMenuItem>
-          <ContextMenuItem onClick={() => onBookmarkEvent?.(event)}>
+          <ContextMenuItem onSelect={(e) => { e.preventDefault(); onBookmarkEvent?.(event); }}>
             <Bookmark className="mr-2 h-4 w-4" />
             {menuLabels.bookmark}
           </ContextMenuItem>
           <ContextMenuItem
-            onClick={() => onDeleteEvent?.(event)}
+            onSelect={(e) => { e.preventDefault(); onDeleteEvent?.(event); }}
             className="text-red-600"
           >
             <Trash2 className="mr-2 h-4 w-4" />
@@ -893,22 +893,22 @@ export default function WeekView({
                       </ContextMenuTrigger>
 
                       <ContextMenuContent className="w-40">
-                        <ContextMenuItem onClick={() => onEditEvent?.(event)}>
+                        <ContextMenuItem onSelect={(e) => { e.preventDefault(); onEditEvent?.(event); }}>
                           <Edit3 className="mr-2 h-4 w-4" />
                           {menuLabels.edit}
                         </ContextMenuItem>
-                        <ContextMenuItem onClick={() => onShareEvent?.(event)}>
+                        <ContextMenuItem onSelect={(e) => { e.preventDefault(); onShareEvent?.(event); }}>
                           <Share2 className="mr-2 h-4 w-4" />
                           {menuLabels.share}
                         </ContextMenuItem>
                         <ContextMenuItem
-                          onClick={() => onBookmarkEvent?.(event)}
+                          onSelect={(e) => { e.preventDefault(); onBookmarkEvent?.(event); }}
                         >
                           <Bookmark className="mr-2 h-4 w-4" />
                           {menuLabels.bookmark}
                         </ContextMenuItem>
                         <ContextMenuItem
-                          onClick={() => onDeleteEvent?.(event)}
+                          onSelect={(e) => { e.preventDefault(); onDeleteEvent?.(event); }}
                           className="text-red-600"
                         >
                           <Trash2 className="mr-2 h-4 w-4" />

--- a/components/app/views/week-view.tsx
+++ b/components/app/views/week-view.tsx
@@ -105,6 +105,7 @@ export default function WeekView({
   const [dragEventDuration, setDragEventDuration] = useState<number>(0);
   const longPressTimeoutRef = useRef<NodeJS.Timeout | null>(null);
   const suppressContextActionClickRef = useRef(false);
+  const lastContextMenuActionAtRef = useRef(0);
   const isDraggingRef = useRef(false);
 
   const [createSelection, setCreateSelection] = useState<{
@@ -620,8 +621,12 @@ export default function WeekView({
             onMouseDown={(e) => handleEventDragStart(event, e)}
             onMouseUp={handleEventDragEnd}
             onMouseLeave={handleEventDragEnd}
+            onContextMenu={() => {
+              lastContextMenuActionAtRef.current = Date.now();
+            }}
             onClick={(e) => {
               e.stopPropagation();
+              if (Date.now() - lastContextMenuActionAtRef.current < 400) return;
               if (!isDraggingRef.current && !suppressContextActionClickRef.current) {
                 onEventClick(event);
               }
@@ -642,20 +647,20 @@ export default function WeekView({
         </ContextMenuTrigger>
 
         <ContextMenuContent className="w-40">
-          <ContextMenuItem onSelect={(e) => { e.preventDefault(); e.stopPropagation(); suppressContextActionClickRef.current = true; onEditEvent?.(event); }}>
+          <ContextMenuItem onSelect={(e) => { e.preventDefault(); e.stopPropagation(); suppressContextActionClickRef.current = true; lastContextMenuActionAtRef.current = Date.now(); onEditEvent?.(event); }}>
             <Edit3 className="mr-2 h-4 w-4" />
             {menuLabels.edit}
           </ContextMenuItem>
-          <ContextMenuItem onSelect={(e) => { e.preventDefault(); e.stopPropagation(); suppressContextActionClickRef.current = true; onShareEvent?.(event); }}>
+          <ContextMenuItem onSelect={(e) => { e.preventDefault(); e.stopPropagation(); suppressContextActionClickRef.current = true; lastContextMenuActionAtRef.current = Date.now(); onShareEvent?.(event); }}>
             <Share2 className="mr-2 h-4 w-4" />
             {menuLabels.share}
           </ContextMenuItem>
-          <ContextMenuItem onSelect={(e) => { e.preventDefault(); e.stopPropagation(); suppressContextActionClickRef.current = true; onBookmarkEvent?.(event); }}>
+          <ContextMenuItem onSelect={(e) => { e.preventDefault(); e.stopPropagation(); suppressContextActionClickRef.current = true; lastContextMenuActionAtRef.current = Date.now(); onBookmarkEvent?.(event); }}>
             <Bookmark className="mr-2 h-4 w-4" />
             {menuLabels.bookmark}
           </ContextMenuItem>
           <ContextMenuItem
-            onSelect={(e) => { e.preventDefault(); e.stopPropagation(); suppressContextActionClickRef.current = true; onDeleteEvent?.(event); }}
+            onSelect={(e) => { e.preventDefault(); e.stopPropagation(); suppressContextActionClickRef.current = true; lastContextMenuActionAtRef.current = Date.now(); onDeleteEvent?.(event); }}
             className="text-red-600"
           >
             <Trash2 className="mr-2 h-4 w-4" />
@@ -895,22 +900,22 @@ export default function WeekView({
                       </ContextMenuTrigger>
 
                       <ContextMenuContent className="w-40">
-                        <ContextMenuItem onSelect={(e) => { e.preventDefault(); e.stopPropagation(); suppressContextActionClickRef.current = true; onEditEvent?.(event); }}>
+                        <ContextMenuItem onSelect={(e) => { e.preventDefault(); e.stopPropagation(); suppressContextActionClickRef.current = true; lastContextMenuActionAtRef.current = Date.now(); onEditEvent?.(event); }}>
                           <Edit3 className="mr-2 h-4 w-4" />
                           {menuLabels.edit}
                         </ContextMenuItem>
-                        <ContextMenuItem onSelect={(e) => { e.preventDefault(); e.stopPropagation(); suppressContextActionClickRef.current = true; onShareEvent?.(event); }}>
+                        <ContextMenuItem onSelect={(e) => { e.preventDefault(); e.stopPropagation(); suppressContextActionClickRef.current = true; lastContextMenuActionAtRef.current = Date.now(); onShareEvent?.(event); }}>
                           <Share2 className="mr-2 h-4 w-4" />
                           {menuLabels.share}
                         </ContextMenuItem>
                         <ContextMenuItem
-                          onSelect={(e) => { e.preventDefault(); e.stopPropagation(); suppressContextActionClickRef.current = true; onBookmarkEvent?.(event); }}
+                          onSelect={(e) => { e.preventDefault(); e.stopPropagation(); suppressContextActionClickRef.current = true; lastContextMenuActionAtRef.current = Date.now(); onBookmarkEvent?.(event); }}
                         >
                           <Bookmark className="mr-2 h-4 w-4" />
                           {menuLabels.bookmark}
                         </ContextMenuItem>
                         <ContextMenuItem
-                          onSelect={(e) => { e.preventDefault(); e.stopPropagation(); suppressContextActionClickRef.current = true; onDeleteEvent?.(event); }}
+                          onSelect={(e) => { e.preventDefault(); e.stopPropagation(); suppressContextActionClickRef.current = true; lastContextMenuActionAtRef.current = Date.now(); onDeleteEvent?.(event); }}
                           className="text-red-600"
                         >
                           <Trash2 className="mr-2 h-4 w-4" />

--- a/components/app/views/week-view.tsx
+++ b/components/app/views/week-view.tsx
@@ -104,9 +104,16 @@ export default function WeekView({
   } | null>(null);
   const [dragEventDuration, setDragEventDuration] = useState<number>(0);
   const longPressTimeoutRef = useRef<NodeJS.Timeout | null>(null);
-  const suppressContextActionClickRef = useRef(false);
-  const lastContextMenuActionAtRef = useRef(0);
+  const ignoreNextEventClickRef = useRef(false);
   const isDraggingRef = useRef(false);
+
+  const queueIgnoreEventClick = () => {
+    ignoreNextEventClickRef.current = true;
+    window.setTimeout(() => {
+      ignoreNextEventClickRef.current = false;
+    }, 0);
+  };
+
 
   const [createSelection, setCreateSelection] = useState<{
     dayIndex: number;
@@ -621,16 +628,18 @@ export default function WeekView({
             onMouseDown={(e) => handleEventDragStart(event, e)}
             onMouseUp={handleEventDragEnd}
             onMouseLeave={handleEventDragEnd}
-            onContextMenu={() => {
-              lastContextMenuActionAtRef.current = Date.now();
+            onContextMenu={(e) => {
+              e.preventDefault();
+              e.stopPropagation();
+              queueIgnoreEventClick();
             }}
             onClick={(e) => {
               e.stopPropagation();
-              if (Date.now() - lastContextMenuActionAtRef.current < 400) return;
-              if (!isDraggingRef.current && !suppressContextActionClickRef.current) {
+              if (ignoreNextEventClickRef.current) return;
+              if (!isDraggingRef.current) {
                 onEventClick(event);
               }
-              suppressContextActionClickRef.current = false;
+              
             }}
           >
             <div
@@ -647,20 +656,20 @@ export default function WeekView({
         </ContextMenuTrigger>
 
         <ContextMenuContent className="w-40">
-          <ContextMenuItem onSelect={(e) => { e.preventDefault(); e.stopPropagation(); suppressContextActionClickRef.current = true; lastContextMenuActionAtRef.current = Date.now(); onEditEvent?.(event); }}>
+          <ContextMenuItem onSelect={(e) => { e.preventDefault(); e.stopPropagation(); queueIgnoreEventClick(); onEditEvent?.(event); }}>
             <Edit3 className="mr-2 h-4 w-4" />
             {menuLabels.edit}
           </ContextMenuItem>
-          <ContextMenuItem onSelect={(e) => { e.preventDefault(); e.stopPropagation(); suppressContextActionClickRef.current = true; lastContextMenuActionAtRef.current = Date.now(); onShareEvent?.(event); }}>
+          <ContextMenuItem onSelect={(e) => { e.preventDefault(); e.stopPropagation(); queueIgnoreEventClick(); onShareEvent?.(event); }}>
             <Share2 className="mr-2 h-4 w-4" />
             {menuLabels.share}
           </ContextMenuItem>
-          <ContextMenuItem onSelect={(e) => { e.preventDefault(); e.stopPropagation(); suppressContextActionClickRef.current = true; lastContextMenuActionAtRef.current = Date.now(); onBookmarkEvent?.(event); }}>
+          <ContextMenuItem onSelect={(e) => { e.preventDefault(); e.stopPropagation(); queueIgnoreEventClick(); onBookmarkEvent?.(event); }}>
             <Bookmark className="mr-2 h-4 w-4" />
             {menuLabels.bookmark}
           </ContextMenuItem>
           <ContextMenuItem
-            onSelect={(e) => { e.preventDefault(); e.stopPropagation(); suppressContextActionClickRef.current = true; lastContextMenuActionAtRef.current = Date.now(); onDeleteEvent?.(event); }}
+            onSelect={(e) => { e.preventDefault(); e.stopPropagation(); queueIgnoreEventClick(); onDeleteEvent?.(event); }}
             className="text-red-600"
           >
             <Trash2 className="mr-2 h-4 w-4" />
@@ -900,22 +909,22 @@ export default function WeekView({
                       </ContextMenuTrigger>
 
                       <ContextMenuContent className="w-40">
-                        <ContextMenuItem onSelect={(e) => { e.preventDefault(); e.stopPropagation(); suppressContextActionClickRef.current = true; lastContextMenuActionAtRef.current = Date.now(); onEditEvent?.(event); }}>
+                        <ContextMenuItem onSelect={(e) => { e.preventDefault(); e.stopPropagation(); queueIgnoreEventClick(); onEditEvent?.(event); }}>
                           <Edit3 className="mr-2 h-4 w-4" />
                           {menuLabels.edit}
                         </ContextMenuItem>
-                        <ContextMenuItem onSelect={(e) => { e.preventDefault(); e.stopPropagation(); suppressContextActionClickRef.current = true; lastContextMenuActionAtRef.current = Date.now(); onShareEvent?.(event); }}>
+                        <ContextMenuItem onSelect={(e) => { e.preventDefault(); e.stopPropagation(); queueIgnoreEventClick(); onShareEvent?.(event); }}>
                           <Share2 className="mr-2 h-4 w-4" />
                           {menuLabels.share}
                         </ContextMenuItem>
                         <ContextMenuItem
-                          onSelect={(e) => { e.preventDefault(); e.stopPropagation(); suppressContextActionClickRef.current = true; lastContextMenuActionAtRef.current = Date.now(); onBookmarkEvent?.(event); }}
+                          onSelect={(e) => { e.preventDefault(); e.stopPropagation(); queueIgnoreEventClick(); onBookmarkEvent?.(event); }}
                         >
                           <Bookmark className="mr-2 h-4 w-4" />
                           {menuLabels.bookmark}
                         </ContextMenuItem>
                         <ContextMenuItem
-                          onSelect={(e) => { e.preventDefault(); e.stopPropagation(); suppressContextActionClickRef.current = true; lastContextMenuActionAtRef.current = Date.now(); onDeleteEvent?.(event); }}
+                          onSelect={(e) => { e.preventDefault(); e.stopPropagation(); queueIgnoreEventClick(); onDeleteEvent?.(event); }}
                           className="text-red-600"
                         >
                           <Trash2 className="mr-2 h-4 w-4" />

--- a/components/app/views/week-view.tsx
+++ b/components/app/views/week-view.tsx
@@ -732,7 +732,7 @@ export default function WeekView({
   return (
     <div className="flex flex-col h-full">
       <div
-        className="grid divide-x relative z-30 bg-background"
+        className="grid divide-x relative z-30 bg-background border-b"
         style={{ gridTemplateColumns }}
       >
         <div className="sticky top-0 z-30 bg-background" />

--- a/components/app/views/year-view.tsx
+++ b/components/app/views/year-view.tsx
@@ -166,7 +166,7 @@ export default function YearView({
                                   "relative w-full cursor-pointer truncate rounded-md p-1.5 pl-3 text-left text-xs",
                                   event.color,
                                 )}
-                                onClick={() => onEventClick(event)}
+                                onClick={() => { setOpenDayKey(null); onEventClick(event); }}
                                 style={{
                                   backgroundColor: isDark ? getDarkModeEventBackgroundColor(event.color) : undefined,
                                 }}

--- a/components/providers/calendar-context.tsx
+++ b/components/providers/calendar-context.tsx
@@ -1,7 +1,7 @@
 "use client";
 
 import { useLocalStorage } from "@/hooks/useLocalStorage";
-import { createContext, useContext } from "react";
+import { createContext, useContext, type Dispatch, type SetStateAction } from "react";
 import type React from "react";
 
 export interface CalendarCategory {
@@ -28,9 +28,9 @@ export interface CalendarEvent {
 
 interface CalendarContextType {
   calendars: CalendarCategory[];
-  setCalendars: (calendars: CalendarCategory[]) => void;
+  setCalendars: Dispatch<SetStateAction<CalendarCategory[]>>;
   events: CalendarEvent[];
-  setEvents: (events: CalendarEvent[]) => void;
+  setEvents: Dispatch<SetStateAction<CalendarEvent[]>>;
   addCategory: (category: CalendarCategory) => void;
   removeCategory: (id: string) => void;
   updateCategory: (id: string, category: Partial<CalendarCategory>) => void;

--- a/components/ui/empty.tsx
+++ b/components/ui/empty.tsx
@@ -1,0 +1,105 @@
+import type React from "react"
+import { cva, type VariantProps } from "class-variance-authority"
+
+import { cn } from "@/lib/utils"
+
+function Empty({ className, ...props }: React.ComponentProps<"div">) {
+  return (
+    <div
+      data-slot="empty"
+      className={cn(
+        "gap-4 rounded-xl border-dashed p-6 flex w-full min-w-0 flex-1 flex-col items-center justify-center text-center text-balance",
+        className
+      )}
+      {...props}
+    />
+  )
+}
+
+function EmptyHeader({ className, ...props }: React.ComponentProps<"div">) {
+  return (
+    <div
+      data-slot="empty-header"
+      className={cn(
+        "gap-2 flex max-w-sm flex-col items-center",
+        className
+      )}
+      {...props}
+    />
+  )
+}
+
+const emptyMediaVariants = cva(
+  "mb-2 flex shrink-0 items-center justify-center [&_svg]:pointer-events-none [&_svg]:shrink-0",
+  {
+    variants: {
+      variant: {
+        default: "bg-transparent",
+        icon: "bg-muted text-foreground flex size-8 shrink-0 items-center justify-center rounded-lg [&_svg:not([class*='size-'])]:size-4",
+      },
+    },
+    defaultVariants: {
+      variant: "default",
+    },
+  }
+)
+
+function EmptyMedia({
+  className,
+  variant = "default",
+  ...props
+}: React.ComponentProps<"div"> & VariantProps<typeof emptyMediaVariants>) {
+  return (
+    <div
+      data-slot="empty-icon"
+      data-variant={variant}
+      className={cn(emptyMediaVariants({ variant, className }))}
+      {...props}
+    />
+  )
+}
+
+function EmptyTitle({ className, ...props }: React.ComponentProps<"div">) {
+  return (
+    <div
+      data-slot="empty-title"
+      className={cn("text-sm font-medium tracking-tight", className)}
+      {...props}
+    />
+  )
+}
+
+function EmptyDescription({ className, ...props }: React.ComponentProps<"p">) {
+  return (
+    <div
+      data-slot="empty-description"
+      className={cn(
+        "text-sm/relaxed text-muted-foreground [&>a:hover]:text-primary [&>a]:underline [&>a]:underline-offset-4",
+        className
+      )}
+      {...props}
+    />
+  )
+}
+
+function EmptyContent({ className, ...props }: React.ComponentProps<"div">) {
+  return (
+    <div
+      data-slot="empty-content"
+      className={cn(
+        "gap-2.5 text-sm flex w-full max-w-sm min-w-0 flex-col items-center text-balance",
+        className
+      )}
+      {...props}
+    />
+  )
+}
+
+export {
+  Empty,
+  EmptyHeader,
+  EmptyTitle,
+  EmptyDescription,
+  EmptyContent,
+  EmptyMedia,
+}

--- a/components/ui/sonner.tsx
+++ b/components/ui/sonner.tsx
@@ -3,9 +3,11 @@
 import { CircleCheckIcon, InfoIcon, TriangleAlertIcon, OctagonXIcon, Loader2Icon } from "lucide-react"
 import { Toaster as Sonner, type ToasterProps } from "sonner"
 import { useTheme } from "next-themes"
+import { useLocalStorage } from "@/hooks/useLocalStorage"
 
 const Toaster = ({ ...props }: ToasterProps) => {
   const { theme = "system" } = useTheme()
+  const [toastPosition] = useLocalStorage<"bottom-left" | "bottom-center" | "bottom-right">("toast-position", "bottom-right")
 
   return (
     <Sonner
@@ -36,6 +38,7 @@ const Toaster = ({ ...props }: ToasterProps) => {
           "--border-radius": "var(--radius)",
         } as React.CSSProperties
       }
+      position={toastPosition}
       toastOptions={{
         classNames: {
           toast: "cn-toast",

--- a/hooks/useLocalStorage.ts
+++ b/hooks/useLocalStorage.ts
@@ -53,6 +53,11 @@ function notifySubscribers() {
   subscribers.forEach((callback) => callback())
 }
 
+function emitStorageWrite(key: string) {
+  if (typeof window === "undefined") return
+  window.dispatchEvent(new CustomEvent("local-storage-written", { detail: { key } }))
+}
+
 export function isSensitiveStorageKey(key: string) {
   return SENSITIVE_KEYS.has(key)
 }
@@ -221,16 +226,19 @@ export async function writeEncryptedLocalStorage<T>(key: string, value: T) {
         inMemoryStorage.set(key, raw)
         encryptedSnapshots.set(key, { value: raw, failed: false })
         window.localStorage.removeItem(key)
+        emitStorageWrite(key)
         return
       }
       const encrypted = await encryptPayload(ENCRYPTION_STATE.password, raw)
       const payload = JSON.stringify(encrypted)
       window.localStorage.setItem(key, payload)
       encryptedSnapshots.set(key, { value: raw, failed: false })
+      emitStorageWrite(key)
       return
     }
     window.localStorage.setItem(key, raw)
     encryptedSnapshots.set(key, { value: raw, failed: false })
+    emitStorageWrite(key)
   } catch (error) {
     console.log(error)
   }
@@ -287,16 +295,19 @@ async function writeLocalStorage<T>(key: string, value: T) {
         inMemoryStorage.set(key, raw)
         encryptedSnapshots.set(key, { value: raw, failed: false })
         window.localStorage.removeItem(key)
+        emitStorageWrite(key)
         return
       }
       const encrypted = await encryptPayload(ENCRYPTION_STATE.password, raw)
       const payload = JSON.stringify(encrypted)
       window.localStorage.setItem(key, payload)
       encryptedSnapshots.set(key, { value: raw, failed: false })
+      emitStorageWrite(key)
       return
     }
     window.localStorage.setItem(key, raw)
     encryptedSnapshots.set(key, { value: raw, failed: false })
+    emitStorageWrite(key)
   } catch (error) {
     console.log(error)
   }

--- a/locales/bn.json
+++ b/locales/bn.json
@@ -485,5 +485,12 @@
   "deleteCloudConfirmDescription": "This action permanently deletes your encrypted cloud backup. Type DELETE CLOUD DATA to continue.",
   "confirmDeleteData": "Confirm delete data",
   "countdownIcon": "Icon",
-  "countdownSearchIcon": "Search icons"
+  "countdownSearchIcon": "Search icons",
+  "countdownAdded": "Countdown added",
+  "countdownUpdated": "Countdown updated",
+  "countdownDeleted": "Countdown deleted",
+  "toastPosition": "Toast position",
+  "toastPositionBottomLeft": "Bottom left",
+  "toastPositionBottomCenter": "Bottom center",
+  "toastPositionBottomRight": "Bottom right"
 }

--- a/locales/bn.json
+++ b/locales/bn.json
@@ -492,5 +492,6 @@
   "toastPosition": "Toast position",
   "toastPositionBottomLeft": "Bottom left",
   "toastPositionBottomCenter": "Bottom center",
-  "toastPositionBottomRight": "Bottom right"
+  "toastPositionBottomRight": "Bottom right",
+  "countdownDaysAgo": "days ago"
 }

--- a/locales/bn.json
+++ b/locales/bn.json
@@ -478,5 +478,12 @@
     "নভেম্বর",
     "ডিসেম্বর"
   ],
-  "sidebarCalendarMonthYearFormat": "{{month}} {{year}}"
+  "sidebarCalendarMonthYearFormat": "{{month}} {{year}}",
+  "editCategory": "Edit category",
+  "categoryUpdated": "Category updated",
+  "deleteCloudConfirmTitle": "Delete cloud backup data",
+  "deleteCloudConfirmDescription": "This action permanently deletes your encrypted cloud backup. Type DELETE CLOUD DATA to continue.",
+  "confirmDeleteData": "Confirm delete data",
+  "countdownIcon": "Icon",
+  "countdownSearchIcon": "Search icons"
 }

--- a/locales/bn.json
+++ b/locales/bn.json
@@ -493,5 +493,8 @@
   "toastPositionBottomLeft": "Bottom left",
   "toastPositionBottomCenter": "Bottom center",
   "toastPositionBottomRight": "Bottom right",
-  "countdownDaysAgo": "days ago"
+  "countdownDaysAgo": "days ago",
+  "deleteCategoryEvents": "Delete all events under this category as well",
+  "categoryDeletedWithEvents": "Category and all its events were deleted",
+  "importToCalendarCategory": "Import into calendar category"
 }

--- a/locales/de.json
+++ b/locales/de.json
@@ -485,5 +485,12 @@
   "deleteCloudConfirmDescription": "This action permanently deletes your encrypted cloud backup. Type DELETE CLOUD DATA to continue.",
   "confirmDeleteData": "Confirm delete data",
   "countdownIcon": "Icon",
-  "countdownSearchIcon": "Search icons"
+  "countdownSearchIcon": "Search icons",
+  "countdownAdded": "Countdown added",
+  "countdownUpdated": "Countdown updated",
+  "countdownDeleted": "Countdown deleted",
+  "toastPosition": "Toast position",
+  "toastPositionBottomLeft": "Bottom left",
+  "toastPositionBottomCenter": "Bottom center",
+  "toastPositionBottomRight": "Bottom right"
 }

--- a/locales/de.json
+++ b/locales/de.json
@@ -492,5 +492,6 @@
   "toastPosition": "Toast position",
   "toastPositionBottomLeft": "Bottom left",
   "toastPositionBottomCenter": "Bottom center",
-  "toastPositionBottomRight": "Bottom right"
+  "toastPositionBottomRight": "Bottom right",
+  "countdownDaysAgo": "days ago"
 }

--- a/locales/de.json
+++ b/locales/de.json
@@ -478,5 +478,12 @@
     "November",
     "Dezember"
   ],
-  "sidebarCalendarMonthYearFormat": "{{month}} {{year}}"
+  "sidebarCalendarMonthYearFormat": "{{month}} {{year}}",
+  "editCategory": "Edit category",
+  "categoryUpdated": "Category updated",
+  "deleteCloudConfirmTitle": "Delete cloud backup data",
+  "deleteCloudConfirmDescription": "This action permanently deletes your encrypted cloud backup. Type DELETE CLOUD DATA to continue.",
+  "confirmDeleteData": "Confirm delete data",
+  "countdownIcon": "Icon",
+  "countdownSearchIcon": "Search icons"
 }

--- a/locales/de.json
+++ b/locales/de.json
@@ -493,5 +493,8 @@
   "toastPositionBottomLeft": "Bottom left",
   "toastPositionBottomCenter": "Bottom center",
   "toastPositionBottomRight": "Bottom right",
-  "countdownDaysAgo": "days ago"
+  "countdownDaysAgo": "days ago",
+  "deleteCategoryEvents": "Delete all events under this category as well",
+  "categoryDeletedWithEvents": "Category and all its events were deleted",
+  "importToCalendarCategory": "Import into calendar category"
 }

--- a/locales/el.json
+++ b/locales/el.json
@@ -485,5 +485,12 @@
   "deleteCloudConfirmDescription": "This action permanently deletes your encrypted cloud backup. Type DELETE CLOUD DATA to continue.",
   "confirmDeleteData": "Confirm delete data",
   "countdownIcon": "Icon",
-  "countdownSearchIcon": "Search icons"
+  "countdownSearchIcon": "Search icons",
+  "countdownAdded": "Countdown added",
+  "countdownUpdated": "Countdown updated",
+  "countdownDeleted": "Countdown deleted",
+  "toastPosition": "Toast position",
+  "toastPositionBottomLeft": "Bottom left",
+  "toastPositionBottomCenter": "Bottom center",
+  "toastPositionBottomRight": "Bottom right"
 }

--- a/locales/el.json
+++ b/locales/el.json
@@ -492,5 +492,6 @@
   "toastPosition": "Toast position",
   "toastPositionBottomLeft": "Bottom left",
   "toastPositionBottomCenter": "Bottom center",
-  "toastPositionBottomRight": "Bottom right"
+  "toastPositionBottomRight": "Bottom right",
+  "countdownDaysAgo": "days ago"
 }

--- a/locales/el.json
+++ b/locales/el.json
@@ -478,5 +478,12 @@
     "Νοεμβρίου",
     "Δεκεμβρίου"
   ],
-  "sidebarCalendarMonthYearFormat": "{{month}} {{year}}"
+  "sidebarCalendarMonthYearFormat": "{{month}} {{year}}",
+  "editCategory": "Edit category",
+  "categoryUpdated": "Category updated",
+  "deleteCloudConfirmTitle": "Delete cloud backup data",
+  "deleteCloudConfirmDescription": "This action permanently deletes your encrypted cloud backup. Type DELETE CLOUD DATA to continue.",
+  "confirmDeleteData": "Confirm delete data",
+  "countdownIcon": "Icon",
+  "countdownSearchIcon": "Search icons"
 }

--- a/locales/el.json
+++ b/locales/el.json
@@ -493,5 +493,8 @@
   "toastPositionBottomLeft": "Bottom left",
   "toastPositionBottomCenter": "Bottom center",
   "toastPositionBottomRight": "Bottom right",
-  "countdownDaysAgo": "days ago"
+  "countdownDaysAgo": "days ago",
+  "deleteCategoryEvents": "Delete all events under this category as well",
+  "categoryDeletedWithEvents": "Category and all its events were deleted",
+  "importToCalendarCategory": "Import into calendar category"
 }

--- a/locales/en-GB.json
+++ b/locales/en-GB.json
@@ -485,5 +485,12 @@
   "deleteCloudConfirmDescription": "This action permanently deletes your encrypted cloud backup. Type DELETE CLOUD DATA to continue.",
   "confirmDeleteData": "Confirm delete data",
   "countdownIcon": "Icon",
-  "countdownSearchIcon": "Search icons"
+  "countdownSearchIcon": "Search icons",
+  "countdownAdded": "Countdown added",
+  "countdownUpdated": "Countdown updated",
+  "countdownDeleted": "Countdown deleted",
+  "toastPosition": "Toast position",
+  "toastPositionBottomLeft": "Bottom left",
+  "toastPositionBottomCenter": "Bottom center",
+  "toastPositionBottomRight": "Bottom right"
 }

--- a/locales/en-GB.json
+++ b/locales/en-GB.json
@@ -492,5 +492,6 @@
   "toastPosition": "Toast position",
   "toastPositionBottomLeft": "Bottom left",
   "toastPositionBottomCenter": "Bottom center",
-  "toastPositionBottomRight": "Bottom right"
+  "toastPositionBottomRight": "Bottom right",
+  "countdownDaysAgo": "days ago"
 }

--- a/locales/en-GB.json
+++ b/locales/en-GB.json
@@ -478,5 +478,12 @@
     "November",
     "December"
   ],
-  "sidebarCalendarMonthYearFormat": "{{month}} {{year}}"
+  "sidebarCalendarMonthYearFormat": "{{month}} {{year}}",
+  "editCategory": "Edit category",
+  "categoryUpdated": "Category updated",
+  "deleteCloudConfirmTitle": "Delete cloud backup data",
+  "deleteCloudConfirmDescription": "This action permanently deletes your encrypted cloud backup. Type DELETE CLOUD DATA to continue.",
+  "confirmDeleteData": "Confirm delete data",
+  "countdownIcon": "Icon",
+  "countdownSearchIcon": "Search icons"
 }

--- a/locales/en-GB.json
+++ b/locales/en-GB.json
@@ -493,5 +493,8 @@
   "toastPositionBottomLeft": "Bottom left",
   "toastPositionBottomCenter": "Bottom center",
   "toastPositionBottomRight": "Bottom right",
-  "countdownDaysAgo": "days ago"
+  "countdownDaysAgo": "days ago",
+  "deleteCategoryEvents": "Delete all events under this category as well",
+  "categoryDeletedWithEvents": "Category and all its events were deleted",
+  "importToCalendarCategory": "Import into calendar category"
 }

--- a/locales/en.json
+++ b/locales/en.json
@@ -485,5 +485,12 @@
   "deleteCloudConfirmDescription": "This action permanently deletes your encrypted cloud backup. Type DELETE CLOUD DATA to continue.",
   "confirmDeleteData": "Confirm delete data",
   "countdownIcon": "Icon",
-  "countdownSearchIcon": "Search icons"
+  "countdownSearchIcon": "Search icons",
+  "countdownAdded": "Countdown added",
+  "countdownUpdated": "Countdown updated",
+  "countdownDeleted": "Countdown deleted",
+  "toastPosition": "Toast position",
+  "toastPositionBottomLeft": "Bottom left",
+  "toastPositionBottomCenter": "Bottom center",
+  "toastPositionBottomRight": "Bottom right"
 }

--- a/locales/en.json
+++ b/locales/en.json
@@ -492,5 +492,6 @@
   "toastPosition": "Toast position",
   "toastPositionBottomLeft": "Bottom left",
   "toastPositionBottomCenter": "Bottom center",
-  "toastPositionBottomRight": "Bottom right"
+  "toastPositionBottomRight": "Bottom right",
+  "countdownDaysAgo": "days ago"
 }

--- a/locales/en.json
+++ b/locales/en.json
@@ -478,5 +478,12 @@
     "November",
     "December"
   ],
-  "sidebarCalendarMonthYearFormat": "{{month}} {{year}}"
+  "sidebarCalendarMonthYearFormat": "{{month}} {{year}}",
+  "editCategory": "Edit category",
+  "categoryUpdated": "Category updated",
+  "deleteCloudConfirmTitle": "Delete cloud backup data",
+  "deleteCloudConfirmDescription": "This action permanently deletes your encrypted cloud backup. Type DELETE CLOUD DATA to continue.",
+  "confirmDeleteData": "Confirm delete data",
+  "countdownIcon": "Icon",
+  "countdownSearchIcon": "Search icons"
 }

--- a/locales/en.json
+++ b/locales/en.json
@@ -493,5 +493,8 @@
   "toastPositionBottomLeft": "Bottom left",
   "toastPositionBottomCenter": "Bottom center",
   "toastPositionBottomRight": "Bottom right",
-  "countdownDaysAgo": "days ago"
+  "countdownDaysAgo": "days ago",
+  "deleteCategoryEvents": "Delete all events under this category as well",
+  "categoryDeletedWithEvents": "Category and all its events were deleted",
+  "importToCalendarCategory": "Import into calendar category"
 }

--- a/locales/es.json
+++ b/locales/es.json
@@ -485,5 +485,12 @@
   "deleteCloudConfirmDescription": "This action permanently deletes your encrypted cloud backup. Type DELETE CLOUD DATA to continue.",
   "confirmDeleteData": "Confirm delete data",
   "countdownIcon": "Icon",
-  "countdownSearchIcon": "Search icons"
+  "countdownSearchIcon": "Search icons",
+  "countdownAdded": "Countdown added",
+  "countdownUpdated": "Countdown updated",
+  "countdownDeleted": "Countdown deleted",
+  "toastPosition": "Toast position",
+  "toastPositionBottomLeft": "Bottom left",
+  "toastPositionBottomCenter": "Bottom center",
+  "toastPositionBottomRight": "Bottom right"
 }

--- a/locales/es.json
+++ b/locales/es.json
@@ -492,5 +492,6 @@
   "toastPosition": "Toast position",
   "toastPositionBottomLeft": "Bottom left",
   "toastPositionBottomCenter": "Bottom center",
-  "toastPositionBottomRight": "Bottom right"
+  "toastPositionBottomRight": "Bottom right",
+  "countdownDaysAgo": "days ago"
 }

--- a/locales/es.json
+++ b/locales/es.json
@@ -478,5 +478,12 @@
     "noviembre",
     "diciembre"
   ],
-  "sidebarCalendarMonthYearFormat": "{{month}} de {{year}}"
+  "sidebarCalendarMonthYearFormat": "{{month}} de {{year}}",
+  "editCategory": "Edit category",
+  "categoryUpdated": "Category updated",
+  "deleteCloudConfirmTitle": "Delete cloud backup data",
+  "deleteCloudConfirmDescription": "This action permanently deletes your encrypted cloud backup. Type DELETE CLOUD DATA to continue.",
+  "confirmDeleteData": "Confirm delete data",
+  "countdownIcon": "Icon",
+  "countdownSearchIcon": "Search icons"
 }

--- a/locales/es.json
+++ b/locales/es.json
@@ -493,5 +493,8 @@
   "toastPositionBottomLeft": "Bottom left",
   "toastPositionBottomCenter": "Bottom center",
   "toastPositionBottomRight": "Bottom right",
-  "countdownDaysAgo": "days ago"
+  "countdownDaysAgo": "days ago",
+  "deleteCategoryEvents": "Delete all events under this category as well",
+  "categoryDeletedWithEvents": "Category and all its events were deleted",
+  "importToCalendarCategory": "Import into calendar category"
 }

--- a/locales/fi.json
+++ b/locales/fi.json
@@ -485,5 +485,12 @@
   "deleteCloudConfirmDescription": "This action permanently deletes your encrypted cloud backup. Type DELETE CLOUD DATA to continue.",
   "confirmDeleteData": "Confirm delete data",
   "countdownIcon": "Icon",
-  "countdownSearchIcon": "Search icons"
+  "countdownSearchIcon": "Search icons",
+  "countdownAdded": "Countdown added",
+  "countdownUpdated": "Countdown updated",
+  "countdownDeleted": "Countdown deleted",
+  "toastPosition": "Toast position",
+  "toastPositionBottomLeft": "Bottom left",
+  "toastPositionBottomCenter": "Bottom center",
+  "toastPositionBottomRight": "Bottom right"
 }

--- a/locales/fi.json
+++ b/locales/fi.json
@@ -478,5 +478,12 @@
     "marraskuu",
     "joulukuu"
   ],
-  "sidebarCalendarMonthYearFormat": "{{month}} {{year}}"
+  "sidebarCalendarMonthYearFormat": "{{month}} {{year}}",
+  "editCategory": "Edit category",
+  "categoryUpdated": "Category updated",
+  "deleteCloudConfirmTitle": "Delete cloud backup data",
+  "deleteCloudConfirmDescription": "This action permanently deletes your encrypted cloud backup. Type DELETE CLOUD DATA to continue.",
+  "confirmDeleteData": "Confirm delete data",
+  "countdownIcon": "Icon",
+  "countdownSearchIcon": "Search icons"
 }

--- a/locales/fi.json
+++ b/locales/fi.json
@@ -492,5 +492,6 @@
   "toastPosition": "Toast position",
   "toastPositionBottomLeft": "Bottom left",
   "toastPositionBottomCenter": "Bottom center",
-  "toastPositionBottomRight": "Bottom right"
+  "toastPositionBottomRight": "Bottom right",
+  "countdownDaysAgo": "days ago"
 }

--- a/locales/fi.json
+++ b/locales/fi.json
@@ -493,5 +493,8 @@
   "toastPositionBottomLeft": "Bottom left",
   "toastPositionBottomCenter": "Bottom center",
   "toastPositionBottomRight": "Bottom right",
-  "countdownDaysAgo": "days ago"
+  "countdownDaysAgo": "days ago",
+  "deleteCategoryEvents": "Delete all events under this category as well",
+  "categoryDeletedWithEvents": "Category and all its events were deleted",
+  "importToCalendarCategory": "Import into calendar category"
 }

--- a/locales/fr.json
+++ b/locales/fr.json
@@ -485,5 +485,12 @@
   "deleteCloudConfirmDescription": "This action permanently deletes your encrypted cloud backup. Type DELETE CLOUD DATA to continue.",
   "confirmDeleteData": "Confirm delete data",
   "countdownIcon": "Icon",
-  "countdownSearchIcon": "Search icons"
+  "countdownSearchIcon": "Search icons",
+  "countdownAdded": "Countdown added",
+  "countdownUpdated": "Countdown updated",
+  "countdownDeleted": "Countdown deleted",
+  "toastPosition": "Toast position",
+  "toastPositionBottomLeft": "Bottom left",
+  "toastPositionBottomCenter": "Bottom center",
+  "toastPositionBottomRight": "Bottom right"
 }

--- a/locales/fr.json
+++ b/locales/fr.json
@@ -478,5 +478,12 @@
     "novembre",
     "décembre"
   ],
-  "sidebarCalendarMonthYearFormat": "{{month}} {{year}}"
+  "sidebarCalendarMonthYearFormat": "{{month}} {{year}}",
+  "editCategory": "Edit category",
+  "categoryUpdated": "Category updated",
+  "deleteCloudConfirmTitle": "Delete cloud backup data",
+  "deleteCloudConfirmDescription": "This action permanently deletes your encrypted cloud backup. Type DELETE CLOUD DATA to continue.",
+  "confirmDeleteData": "Confirm delete data",
+  "countdownIcon": "Icon",
+  "countdownSearchIcon": "Search icons"
 }

--- a/locales/fr.json
+++ b/locales/fr.json
@@ -492,5 +492,6 @@
   "toastPosition": "Toast position",
   "toastPositionBottomLeft": "Bottom left",
   "toastPositionBottomCenter": "Bottom center",
-  "toastPositionBottomRight": "Bottom right"
+  "toastPositionBottomRight": "Bottom right",
+  "countdownDaysAgo": "days ago"
 }

--- a/locales/fr.json
+++ b/locales/fr.json
@@ -493,5 +493,8 @@
   "toastPositionBottomLeft": "Bottom left",
   "toastPositionBottomCenter": "Bottom center",
   "toastPositionBottomRight": "Bottom right",
-  "countdownDaysAgo": "days ago"
+  "countdownDaysAgo": "days ago",
+  "deleteCategoryEvents": "Delete all events under this category as well",
+  "categoryDeletedWithEvents": "Category and all its events were deleted",
+  "importToCalendarCategory": "Import into calendar category"
 }

--- a/locales/hi.json
+++ b/locales/hi.json
@@ -485,5 +485,12 @@
   "deleteCloudConfirmDescription": "This action permanently deletes your encrypted cloud backup. Type DELETE CLOUD DATA to continue.",
   "confirmDeleteData": "Confirm delete data",
   "countdownIcon": "Icon",
-  "countdownSearchIcon": "Search icons"
+  "countdownSearchIcon": "Search icons",
+  "countdownAdded": "Countdown added",
+  "countdownUpdated": "Countdown updated",
+  "countdownDeleted": "Countdown deleted",
+  "toastPosition": "Toast position",
+  "toastPositionBottomLeft": "Bottom left",
+  "toastPositionBottomCenter": "Bottom center",
+  "toastPositionBottomRight": "Bottom right"
 }

--- a/locales/hi.json
+++ b/locales/hi.json
@@ -492,5 +492,6 @@
   "toastPosition": "Toast position",
   "toastPositionBottomLeft": "Bottom left",
   "toastPositionBottomCenter": "Bottom center",
-  "toastPositionBottomRight": "Bottom right"
+  "toastPositionBottomRight": "Bottom right",
+  "countdownDaysAgo": "days ago"
 }

--- a/locales/hi.json
+++ b/locales/hi.json
@@ -478,5 +478,12 @@
     "नवंबर",
     "दिसंबर"
   ],
-  "sidebarCalendarMonthYearFormat": "{{month}} {{year}}"
+  "sidebarCalendarMonthYearFormat": "{{month}} {{year}}",
+  "editCategory": "Edit category",
+  "categoryUpdated": "Category updated",
+  "deleteCloudConfirmTitle": "Delete cloud backup data",
+  "deleteCloudConfirmDescription": "This action permanently deletes your encrypted cloud backup. Type DELETE CLOUD DATA to continue.",
+  "confirmDeleteData": "Confirm delete data",
+  "countdownIcon": "Icon",
+  "countdownSearchIcon": "Search icons"
 }

--- a/locales/hi.json
+++ b/locales/hi.json
@@ -493,5 +493,8 @@
   "toastPositionBottomLeft": "Bottom left",
   "toastPositionBottomCenter": "Bottom center",
   "toastPositionBottomRight": "Bottom right",
-  "countdownDaysAgo": "days ago"
+  "countdownDaysAgo": "days ago",
+  "deleteCategoryEvents": "Delete all events under this category as well",
+  "categoryDeletedWithEvents": "Category and all its events were deleted",
+  "importToCalendarCategory": "Import into calendar category"
 }

--- a/locales/is.json
+++ b/locales/is.json
@@ -485,5 +485,12 @@
   "deleteCloudConfirmDescription": "This action permanently deletes your encrypted cloud backup. Type DELETE CLOUD DATA to continue.",
   "confirmDeleteData": "Confirm delete data",
   "countdownIcon": "Icon",
-  "countdownSearchIcon": "Search icons"
+  "countdownSearchIcon": "Search icons",
+  "countdownAdded": "Countdown added",
+  "countdownUpdated": "Countdown updated",
+  "countdownDeleted": "Countdown deleted",
+  "toastPosition": "Toast position",
+  "toastPositionBottomLeft": "Bottom left",
+  "toastPositionBottomCenter": "Bottom center",
+  "toastPositionBottomRight": "Bottom right"
 }

--- a/locales/is.json
+++ b/locales/is.json
@@ -492,5 +492,6 @@
   "toastPosition": "Toast position",
   "toastPositionBottomLeft": "Bottom left",
   "toastPositionBottomCenter": "Bottom center",
-  "toastPositionBottomRight": "Bottom right"
+  "toastPositionBottomRight": "Bottom right",
+  "countdownDaysAgo": "days ago"
 }

--- a/locales/is.json
+++ b/locales/is.json
@@ -478,5 +478,12 @@
     "nóvember",
     "desember"
   ],
-  "sidebarCalendarMonthYearFormat": "{{month}} {{year}}"
+  "sidebarCalendarMonthYearFormat": "{{month}} {{year}}",
+  "editCategory": "Edit category",
+  "categoryUpdated": "Category updated",
+  "deleteCloudConfirmTitle": "Delete cloud backup data",
+  "deleteCloudConfirmDescription": "This action permanently deletes your encrypted cloud backup. Type DELETE CLOUD DATA to continue.",
+  "confirmDeleteData": "Confirm delete data",
+  "countdownIcon": "Icon",
+  "countdownSearchIcon": "Search icons"
 }

--- a/locales/is.json
+++ b/locales/is.json
@@ -493,5 +493,8 @@
   "toastPositionBottomLeft": "Bottom left",
   "toastPositionBottomCenter": "Bottom center",
   "toastPositionBottomRight": "Bottom right",
-  "countdownDaysAgo": "days ago"
+  "countdownDaysAgo": "days ago",
+  "deleteCategoryEvents": "Delete all events under this category as well",
+  "categoryDeletedWithEvents": "Category and all its events were deleted",
+  "importToCalendarCategory": "Import into calendar category"
 }

--- a/locales/it.json
+++ b/locales/it.json
@@ -485,5 +485,12 @@
   "deleteCloudConfirmDescription": "This action permanently deletes your encrypted cloud backup. Type DELETE CLOUD DATA to continue.",
   "confirmDeleteData": "Confirm delete data",
   "countdownIcon": "Icon",
-  "countdownSearchIcon": "Search icons"
+  "countdownSearchIcon": "Search icons",
+  "countdownAdded": "Countdown added",
+  "countdownUpdated": "Countdown updated",
+  "countdownDeleted": "Countdown deleted",
+  "toastPosition": "Toast position",
+  "toastPositionBottomLeft": "Bottom left",
+  "toastPositionBottomCenter": "Bottom center",
+  "toastPositionBottomRight": "Bottom right"
 }

--- a/locales/it.json
+++ b/locales/it.json
@@ -492,5 +492,6 @@
   "toastPosition": "Toast position",
   "toastPositionBottomLeft": "Bottom left",
   "toastPositionBottomCenter": "Bottom center",
-  "toastPositionBottomRight": "Bottom right"
+  "toastPositionBottomRight": "Bottom right",
+  "countdownDaysAgo": "days ago"
 }

--- a/locales/it.json
+++ b/locales/it.json
@@ -478,5 +478,12 @@
     "novembre",
     "dicembre"
   ],
-  "sidebarCalendarMonthYearFormat": "{{month}} {{year}}"
+  "sidebarCalendarMonthYearFormat": "{{month}} {{year}}",
+  "editCategory": "Edit category",
+  "categoryUpdated": "Category updated",
+  "deleteCloudConfirmTitle": "Delete cloud backup data",
+  "deleteCloudConfirmDescription": "This action permanently deletes your encrypted cloud backup. Type DELETE CLOUD DATA to continue.",
+  "confirmDeleteData": "Confirm delete data",
+  "countdownIcon": "Icon",
+  "countdownSearchIcon": "Search icons"
 }

--- a/locales/it.json
+++ b/locales/it.json
@@ -493,5 +493,8 @@
   "toastPositionBottomLeft": "Bottom left",
   "toastPositionBottomCenter": "Bottom center",
   "toastPositionBottomRight": "Bottom right",
-  "countdownDaysAgo": "days ago"
+  "countdownDaysAgo": "days ago",
+  "deleteCategoryEvents": "Delete all events under this category as well",
+  "categoryDeletedWithEvents": "Category and all its events were deleted",
+  "importToCalendarCategory": "Import into calendar category"
 }

--- a/locales/ja.json
+++ b/locales/ja.json
@@ -485,5 +485,12 @@
   "deleteCloudConfirmDescription": "This action permanently deletes your encrypted cloud backup. Type DELETE CLOUD DATA to continue.",
   "confirmDeleteData": "Confirm delete data",
   "countdownIcon": "Icon",
-  "countdownSearchIcon": "Search icons"
+  "countdownSearchIcon": "Search icons",
+  "countdownAdded": "Countdown added",
+  "countdownUpdated": "Countdown updated",
+  "countdownDeleted": "Countdown deleted",
+  "toastPosition": "Toast position",
+  "toastPositionBottomLeft": "Bottom left",
+  "toastPositionBottomCenter": "Bottom center",
+  "toastPositionBottomRight": "Bottom right"
 }

--- a/locales/ja.json
+++ b/locales/ja.json
@@ -478,5 +478,12 @@
     "11月",
     "12月"
   ],
-  "sidebarCalendarMonthYearFormat": "{{year}}年{{month}}月"
+  "sidebarCalendarMonthYearFormat": "{{year}}年{{month}}月",
+  "editCategory": "Edit category",
+  "categoryUpdated": "Category updated",
+  "deleteCloudConfirmTitle": "Delete cloud backup data",
+  "deleteCloudConfirmDescription": "This action permanently deletes your encrypted cloud backup. Type DELETE CLOUD DATA to continue.",
+  "confirmDeleteData": "Confirm delete data",
+  "countdownIcon": "Icon",
+  "countdownSearchIcon": "Search icons"
 }

--- a/locales/ja.json
+++ b/locales/ja.json
@@ -492,5 +492,6 @@
   "toastPosition": "Toast position",
   "toastPositionBottomLeft": "Bottom left",
   "toastPositionBottomCenter": "Bottom center",
-  "toastPositionBottomRight": "Bottom right"
+  "toastPositionBottomRight": "Bottom right",
+  "countdownDaysAgo": "days ago"
 }

--- a/locales/ja.json
+++ b/locales/ja.json
@@ -493,5 +493,8 @@
   "toastPositionBottomLeft": "Bottom left",
   "toastPositionBottomCenter": "Bottom center",
   "toastPositionBottomRight": "Bottom right",
-  "countdownDaysAgo": "days ago"
+  "countdownDaysAgo": "days ago",
+  "deleteCategoryEvents": "Delete all events under this category as well",
+  "categoryDeletedWithEvents": "Category and all its events were deleted",
+  "importToCalendarCategory": "Import into calendar category"
 }

--- a/locales/ko.json
+++ b/locales/ko.json
@@ -485,5 +485,12 @@
   "deleteCloudConfirmDescription": "This action permanently deletes your encrypted cloud backup. Type DELETE CLOUD DATA to continue.",
   "confirmDeleteData": "Confirm delete data",
   "countdownIcon": "Icon",
-  "countdownSearchIcon": "Search icons"
+  "countdownSearchIcon": "Search icons",
+  "countdownAdded": "Countdown added",
+  "countdownUpdated": "Countdown updated",
+  "countdownDeleted": "Countdown deleted",
+  "toastPosition": "Toast position",
+  "toastPositionBottomLeft": "Bottom left",
+  "toastPositionBottomCenter": "Bottom center",
+  "toastPositionBottomRight": "Bottom right"
 }

--- a/locales/ko.json
+++ b/locales/ko.json
@@ -492,5 +492,6 @@
   "toastPosition": "Toast position",
   "toastPositionBottomLeft": "Bottom left",
   "toastPositionBottomCenter": "Bottom center",
-  "toastPositionBottomRight": "Bottom right"
+  "toastPositionBottomRight": "Bottom right",
+  "countdownDaysAgo": "days ago"
 }

--- a/locales/ko.json
+++ b/locales/ko.json
@@ -478,5 +478,12 @@
     "11월",
     "12월"
   ],
-  "sidebarCalendarMonthYearFormat": "{{year}}년 {{month}}"
+  "sidebarCalendarMonthYearFormat": "{{year}}년 {{month}}",
+  "editCategory": "Edit category",
+  "categoryUpdated": "Category updated",
+  "deleteCloudConfirmTitle": "Delete cloud backup data",
+  "deleteCloudConfirmDescription": "This action permanently deletes your encrypted cloud backup. Type DELETE CLOUD DATA to continue.",
+  "confirmDeleteData": "Confirm delete data",
+  "countdownIcon": "Icon",
+  "countdownSearchIcon": "Search icons"
 }

--- a/locales/ko.json
+++ b/locales/ko.json
@@ -493,5 +493,8 @@
   "toastPositionBottomLeft": "Bottom left",
   "toastPositionBottomCenter": "Bottom center",
   "toastPositionBottomRight": "Bottom right",
-  "countdownDaysAgo": "days ago"
+  "countdownDaysAgo": "days ago",
+  "deleteCategoryEvents": "Delete all events under this category as well",
+  "categoryDeletedWithEvents": "Category and all its events were deleted",
+  "importToCalendarCategory": "Import into calendar category"
 }

--- a/locales/lt.json
+++ b/locales/lt.json
@@ -485,5 +485,12 @@
   "deleteCloudConfirmDescription": "This action permanently deletes your encrypted cloud backup. Type DELETE CLOUD DATA to continue.",
   "confirmDeleteData": "Confirm delete data",
   "countdownIcon": "Icon",
-  "countdownSearchIcon": "Search icons"
+  "countdownSearchIcon": "Search icons",
+  "countdownAdded": "Countdown added",
+  "countdownUpdated": "Countdown updated",
+  "countdownDeleted": "Countdown deleted",
+  "toastPosition": "Toast position",
+  "toastPositionBottomLeft": "Bottom left",
+  "toastPositionBottomCenter": "Bottom center",
+  "toastPositionBottomRight": "Bottom right"
 }

--- a/locales/lt.json
+++ b/locales/lt.json
@@ -478,5 +478,12 @@
     "lapkritis",
     "gruodis"
   ],
-  "sidebarCalendarMonthYearFormat": "{{year}} m. {{month}}"
+  "sidebarCalendarMonthYearFormat": "{{year}} m. {{month}}",
+  "editCategory": "Edit category",
+  "categoryUpdated": "Category updated",
+  "deleteCloudConfirmTitle": "Delete cloud backup data",
+  "deleteCloudConfirmDescription": "This action permanently deletes your encrypted cloud backup. Type DELETE CLOUD DATA to continue.",
+  "confirmDeleteData": "Confirm delete data",
+  "countdownIcon": "Icon",
+  "countdownSearchIcon": "Search icons"
 }

--- a/locales/lt.json
+++ b/locales/lt.json
@@ -492,5 +492,6 @@
   "toastPosition": "Toast position",
   "toastPositionBottomLeft": "Bottom left",
   "toastPositionBottomCenter": "Bottom center",
-  "toastPositionBottomRight": "Bottom right"
+  "toastPositionBottomRight": "Bottom right",
+  "countdownDaysAgo": "days ago"
 }

--- a/locales/lt.json
+++ b/locales/lt.json
@@ -493,5 +493,8 @@
   "toastPositionBottomLeft": "Bottom left",
   "toastPositionBottomCenter": "Bottom center",
   "toastPositionBottomRight": "Bottom right",
-  "countdownDaysAgo": "days ago"
+  "countdownDaysAgo": "days ago",
+  "deleteCategoryEvents": "Delete all events under this category as well",
+  "categoryDeletedWithEvents": "Category and all its events were deleted",
+  "importToCalendarCategory": "Import into calendar category"
 }

--- a/locales/lv.json
+++ b/locales/lv.json
@@ -485,5 +485,12 @@
   "deleteCloudConfirmDescription": "This action permanently deletes your encrypted cloud backup. Type DELETE CLOUD DATA to continue.",
   "confirmDeleteData": "Confirm delete data",
   "countdownIcon": "Icon",
-  "countdownSearchIcon": "Search icons"
+  "countdownSearchIcon": "Search icons",
+  "countdownAdded": "Countdown added",
+  "countdownUpdated": "Countdown updated",
+  "countdownDeleted": "Countdown deleted",
+  "toastPosition": "Toast position",
+  "toastPositionBottomLeft": "Bottom left",
+  "toastPositionBottomCenter": "Bottom center",
+  "toastPositionBottomRight": "Bottom right"
 }

--- a/locales/lv.json
+++ b/locales/lv.json
@@ -492,5 +492,6 @@
   "toastPosition": "Toast position",
   "toastPositionBottomLeft": "Bottom left",
   "toastPositionBottomCenter": "Bottom center",
-  "toastPositionBottomRight": "Bottom right"
+  "toastPositionBottomRight": "Bottom right",
+  "countdownDaysAgo": "days ago"
 }

--- a/locales/lv.json
+++ b/locales/lv.json
@@ -478,5 +478,12 @@
     "novembris",
     "decembris"
   ],
-  "sidebarCalendarMonthYearFormat": "{{year}}. g. {{month}}"
+  "sidebarCalendarMonthYearFormat": "{{year}}. g. {{month}}",
+  "editCategory": "Edit category",
+  "categoryUpdated": "Category updated",
+  "deleteCloudConfirmTitle": "Delete cloud backup data",
+  "deleteCloudConfirmDescription": "This action permanently deletes your encrypted cloud backup. Type DELETE CLOUD DATA to continue.",
+  "confirmDeleteData": "Confirm delete data",
+  "countdownIcon": "Icon",
+  "countdownSearchIcon": "Search icons"
 }

--- a/locales/lv.json
+++ b/locales/lv.json
@@ -493,5 +493,8 @@
   "toastPositionBottomLeft": "Bottom left",
   "toastPositionBottomCenter": "Bottom center",
   "toastPositionBottomRight": "Bottom right",
-  "countdownDaysAgo": "days ago"
+  "countdownDaysAgo": "days ago",
+  "deleteCategoryEvents": "Delete all events under this category as well",
+  "categoryDeletedWithEvents": "Category and all its events were deleted",
+  "importToCalendarCategory": "Import into calendar category"
 }

--- a/locales/mk.json
+++ b/locales/mk.json
@@ -478,5 +478,12 @@
     "ноември",
     "декември"
   ],
-  "sidebarCalendarMonthYearFormat": "{{month}} {{year}} г."
+  "sidebarCalendarMonthYearFormat": "{{month}} {{year}} г.",
+  "editCategory": "Edit category",
+  "categoryUpdated": "Category updated",
+  "deleteCloudConfirmTitle": "Delete cloud backup data",
+  "deleteCloudConfirmDescription": "This action permanently deletes your encrypted cloud backup. Type DELETE CLOUD DATA to continue.",
+  "confirmDeleteData": "Confirm delete data",
+  "countdownIcon": "Icon",
+  "countdownSearchIcon": "Search icons"
 }

--- a/locales/mk.json
+++ b/locales/mk.json
@@ -485,5 +485,12 @@
   "deleteCloudConfirmDescription": "This action permanently deletes your encrypted cloud backup. Type DELETE CLOUD DATA to continue.",
   "confirmDeleteData": "Confirm delete data",
   "countdownIcon": "Icon",
-  "countdownSearchIcon": "Search icons"
+  "countdownSearchIcon": "Search icons",
+  "countdownAdded": "Countdown added",
+  "countdownUpdated": "Countdown updated",
+  "countdownDeleted": "Countdown deleted",
+  "toastPosition": "Toast position",
+  "toastPositionBottomLeft": "Bottom left",
+  "toastPositionBottomCenter": "Bottom center",
+  "toastPositionBottomRight": "Bottom right"
 }

--- a/locales/mk.json
+++ b/locales/mk.json
@@ -492,5 +492,6 @@
   "toastPosition": "Toast position",
   "toastPositionBottomLeft": "Bottom left",
   "toastPositionBottomCenter": "Bottom center",
-  "toastPositionBottomRight": "Bottom right"
+  "toastPositionBottomRight": "Bottom right",
+  "countdownDaysAgo": "days ago"
 }

--- a/locales/mk.json
+++ b/locales/mk.json
@@ -493,5 +493,8 @@
   "toastPositionBottomLeft": "Bottom left",
   "toastPositionBottomCenter": "Bottom center",
   "toastPositionBottomRight": "Bottom right",
-  "countdownDaysAgo": "days ago"
+  "countdownDaysAgo": "days ago",
+  "deleteCategoryEvents": "Delete all events under this category as well",
+  "categoryDeletedWithEvents": "Category and all its events were deleted",
+  "importToCalendarCategory": "Import into calendar category"
 }

--- a/locales/nb.json
+++ b/locales/nb.json
@@ -485,5 +485,12 @@
   "deleteCloudConfirmDescription": "This action permanently deletes your encrypted cloud backup. Type DELETE CLOUD DATA to continue.",
   "confirmDeleteData": "Confirm delete data",
   "countdownIcon": "Icon",
-  "countdownSearchIcon": "Search icons"
+  "countdownSearchIcon": "Search icons",
+  "countdownAdded": "Countdown added",
+  "countdownUpdated": "Countdown updated",
+  "countdownDeleted": "Countdown deleted",
+  "toastPosition": "Toast position",
+  "toastPositionBottomLeft": "Bottom left",
+  "toastPositionBottomCenter": "Bottom center",
+  "toastPositionBottomRight": "Bottom right"
 }

--- a/locales/nb.json
+++ b/locales/nb.json
@@ -492,5 +492,6 @@
   "toastPosition": "Toast position",
   "toastPositionBottomLeft": "Bottom left",
   "toastPositionBottomCenter": "Bottom center",
-  "toastPositionBottomRight": "Bottom right"
+  "toastPositionBottomRight": "Bottom right",
+  "countdownDaysAgo": "days ago"
 }

--- a/locales/nb.json
+++ b/locales/nb.json
@@ -478,5 +478,12 @@
     "november",
     "desember"
   ],
-  "sidebarCalendarMonthYearFormat": "{{month}} {{year}}"
+  "sidebarCalendarMonthYearFormat": "{{month}} {{year}}",
+  "editCategory": "Edit category",
+  "categoryUpdated": "Category updated",
+  "deleteCloudConfirmTitle": "Delete cloud backup data",
+  "deleteCloudConfirmDescription": "This action permanently deletes your encrypted cloud backup. Type DELETE CLOUD DATA to continue.",
+  "confirmDeleteData": "Confirm delete data",
+  "countdownIcon": "Icon",
+  "countdownSearchIcon": "Search icons"
 }

--- a/locales/nb.json
+++ b/locales/nb.json
@@ -493,5 +493,8 @@
   "toastPositionBottomLeft": "Bottom left",
   "toastPositionBottomCenter": "Bottom center",
   "toastPositionBottomRight": "Bottom right",
-  "countdownDaysAgo": "days ago"
+  "countdownDaysAgo": "days ago",
+  "deleteCategoryEvents": "Delete all events under this category as well",
+  "categoryDeletedWithEvents": "Category and all its events were deleted",
+  "importToCalendarCategory": "Import into calendar category"
 }

--- a/locales/nl.json
+++ b/locales/nl.json
@@ -478,5 +478,12 @@
     "november",
     "december"
   ],
-  "sidebarCalendarMonthYearFormat": "{{month}} {{year}}"
+  "sidebarCalendarMonthYearFormat": "{{month}} {{year}}",
+  "editCategory": "Edit category",
+  "categoryUpdated": "Category updated",
+  "deleteCloudConfirmTitle": "Delete cloud backup data",
+  "deleteCloudConfirmDescription": "This action permanently deletes your encrypted cloud backup. Type DELETE CLOUD DATA to continue.",
+  "confirmDeleteData": "Confirm delete data",
+  "countdownIcon": "Icon",
+  "countdownSearchIcon": "Search icons"
 }

--- a/locales/nl.json
+++ b/locales/nl.json
@@ -485,5 +485,12 @@
   "deleteCloudConfirmDescription": "This action permanently deletes your encrypted cloud backup. Type DELETE CLOUD DATA to continue.",
   "confirmDeleteData": "Confirm delete data",
   "countdownIcon": "Icon",
-  "countdownSearchIcon": "Search icons"
+  "countdownSearchIcon": "Search icons",
+  "countdownAdded": "Countdown added",
+  "countdownUpdated": "Countdown updated",
+  "countdownDeleted": "Countdown deleted",
+  "toastPosition": "Toast position",
+  "toastPositionBottomLeft": "Bottom left",
+  "toastPositionBottomCenter": "Bottom center",
+  "toastPositionBottomRight": "Bottom right"
 }

--- a/locales/nl.json
+++ b/locales/nl.json
@@ -492,5 +492,6 @@
   "toastPosition": "Toast position",
   "toastPositionBottomLeft": "Bottom left",
   "toastPositionBottomCenter": "Bottom center",
-  "toastPositionBottomRight": "Bottom right"
+  "toastPositionBottomRight": "Bottom right",
+  "countdownDaysAgo": "days ago"
 }

--- a/locales/nl.json
+++ b/locales/nl.json
@@ -493,5 +493,8 @@
   "toastPositionBottomLeft": "Bottom left",
   "toastPositionBottomCenter": "Bottom center",
   "toastPositionBottomRight": "Bottom right",
-  "countdownDaysAgo": "days ago"
+  "countdownDaysAgo": "days ago",
+  "deleteCategoryEvents": "Delete all events under this category as well",
+  "categoryDeletedWithEvents": "Category and all its events were deleted",
+  "importToCalendarCategory": "Import into calendar category"
 }

--- a/locales/pl.json
+++ b/locales/pl.json
@@ -485,5 +485,12 @@
   "deleteCloudConfirmDescription": "This action permanently deletes your encrypted cloud backup. Type DELETE CLOUD DATA to continue.",
   "confirmDeleteData": "Confirm delete data",
   "countdownIcon": "Icon",
-  "countdownSearchIcon": "Search icons"
+  "countdownSearchIcon": "Search icons",
+  "countdownAdded": "Countdown added",
+  "countdownUpdated": "Countdown updated",
+  "countdownDeleted": "Countdown deleted",
+  "toastPosition": "Toast position",
+  "toastPositionBottomLeft": "Bottom left",
+  "toastPositionBottomCenter": "Bottom center",
+  "toastPositionBottomRight": "Bottom right"
 }

--- a/locales/pl.json
+++ b/locales/pl.json
@@ -478,5 +478,12 @@
     "listopad",
     "grudzień"
   ],
-  "sidebarCalendarMonthYearFormat": "{{month}} {{year}}"
+  "sidebarCalendarMonthYearFormat": "{{month}} {{year}}",
+  "editCategory": "Edit category",
+  "categoryUpdated": "Category updated",
+  "deleteCloudConfirmTitle": "Delete cloud backup data",
+  "deleteCloudConfirmDescription": "This action permanently deletes your encrypted cloud backup. Type DELETE CLOUD DATA to continue.",
+  "confirmDeleteData": "Confirm delete data",
+  "countdownIcon": "Icon",
+  "countdownSearchIcon": "Search icons"
 }

--- a/locales/pl.json
+++ b/locales/pl.json
@@ -492,5 +492,6 @@
   "toastPosition": "Toast position",
   "toastPositionBottomLeft": "Bottom left",
   "toastPositionBottomCenter": "Bottom center",
-  "toastPositionBottomRight": "Bottom right"
+  "toastPositionBottomRight": "Bottom right",
+  "countdownDaysAgo": "days ago"
 }

--- a/locales/pl.json
+++ b/locales/pl.json
@@ -493,5 +493,8 @@
   "toastPositionBottomLeft": "Bottom left",
   "toastPositionBottomCenter": "Bottom center",
   "toastPositionBottomRight": "Bottom right",
-  "countdownDaysAgo": "days ago"
+  "countdownDaysAgo": "days ago",
+  "deleteCategoryEvents": "Delete all events under this category as well",
+  "categoryDeletedWithEvents": "Category and all its events were deleted",
+  "importToCalendarCategory": "Import into calendar category"
 }

--- a/locales/pt.json
+++ b/locales/pt.json
@@ -485,5 +485,12 @@
   "deleteCloudConfirmDescription": "This action permanently deletes your encrypted cloud backup. Type DELETE CLOUD DATA to continue.",
   "confirmDeleteData": "Confirm delete data",
   "countdownIcon": "Icon",
-  "countdownSearchIcon": "Search icons"
+  "countdownSearchIcon": "Search icons",
+  "countdownAdded": "Countdown added",
+  "countdownUpdated": "Countdown updated",
+  "countdownDeleted": "Countdown deleted",
+  "toastPosition": "Toast position",
+  "toastPositionBottomLeft": "Bottom left",
+  "toastPositionBottomCenter": "Bottom center",
+  "toastPositionBottomRight": "Bottom right"
 }

--- a/locales/pt.json
+++ b/locales/pt.json
@@ -478,5 +478,12 @@
     "novembro",
     "dezembro"
   ],
-  "sidebarCalendarMonthYearFormat": "{{month}} de {{year}}"
+  "sidebarCalendarMonthYearFormat": "{{month}} de {{year}}",
+  "editCategory": "Edit category",
+  "categoryUpdated": "Category updated",
+  "deleteCloudConfirmTitle": "Delete cloud backup data",
+  "deleteCloudConfirmDescription": "This action permanently deletes your encrypted cloud backup. Type DELETE CLOUD DATA to continue.",
+  "confirmDeleteData": "Confirm delete data",
+  "countdownIcon": "Icon",
+  "countdownSearchIcon": "Search icons"
 }

--- a/locales/pt.json
+++ b/locales/pt.json
@@ -492,5 +492,6 @@
   "toastPosition": "Toast position",
   "toastPositionBottomLeft": "Bottom left",
   "toastPositionBottomCenter": "Bottom center",
-  "toastPositionBottomRight": "Bottom right"
+  "toastPositionBottomRight": "Bottom right",
+  "countdownDaysAgo": "days ago"
 }

--- a/locales/pt.json
+++ b/locales/pt.json
@@ -493,5 +493,8 @@
   "toastPositionBottomLeft": "Bottom left",
   "toastPositionBottomCenter": "Bottom center",
   "toastPositionBottomRight": "Bottom right",
-  "countdownDaysAgo": "days ago"
+  "countdownDaysAgo": "days ago",
+  "deleteCategoryEvents": "Delete all events under this category as well",
+  "categoryDeletedWithEvents": "Category and all its events were deleted",
+  "importToCalendarCategory": "Import into calendar category"
 }

--- a/locales/ro.json
+++ b/locales/ro.json
@@ -478,5 +478,12 @@
     "noiembrie",
     "decembrie"
   ],
-  "sidebarCalendarMonthYearFormat": "{{month}} {{year}}"
+  "sidebarCalendarMonthYearFormat": "{{month}} {{year}}",
+  "editCategory": "Edit category",
+  "categoryUpdated": "Category updated",
+  "deleteCloudConfirmTitle": "Delete cloud backup data",
+  "deleteCloudConfirmDescription": "This action permanently deletes your encrypted cloud backup. Type DELETE CLOUD DATA to continue.",
+  "confirmDeleteData": "Confirm delete data",
+  "countdownIcon": "Icon",
+  "countdownSearchIcon": "Search icons"
 }

--- a/locales/ro.json
+++ b/locales/ro.json
@@ -485,5 +485,12 @@
   "deleteCloudConfirmDescription": "This action permanently deletes your encrypted cloud backup. Type DELETE CLOUD DATA to continue.",
   "confirmDeleteData": "Confirm delete data",
   "countdownIcon": "Icon",
-  "countdownSearchIcon": "Search icons"
+  "countdownSearchIcon": "Search icons",
+  "countdownAdded": "Countdown added",
+  "countdownUpdated": "Countdown updated",
+  "countdownDeleted": "Countdown deleted",
+  "toastPosition": "Toast position",
+  "toastPositionBottomLeft": "Bottom left",
+  "toastPositionBottomCenter": "Bottom center",
+  "toastPositionBottomRight": "Bottom right"
 }

--- a/locales/ro.json
+++ b/locales/ro.json
@@ -492,5 +492,6 @@
   "toastPosition": "Toast position",
   "toastPositionBottomLeft": "Bottom left",
   "toastPositionBottomCenter": "Bottom center",
-  "toastPositionBottomRight": "Bottom right"
+  "toastPositionBottomRight": "Bottom right",
+  "countdownDaysAgo": "days ago"
 }

--- a/locales/ro.json
+++ b/locales/ro.json
@@ -493,5 +493,8 @@
   "toastPositionBottomLeft": "Bottom left",
   "toastPositionBottomCenter": "Bottom center",
   "toastPositionBottomRight": "Bottom right",
-  "countdownDaysAgo": "days ago"
+  "countdownDaysAgo": "days ago",
+  "deleteCategoryEvents": "Delete all events under this category as well",
+  "categoryDeletedWithEvents": "Category and all its events were deleted",
+  "importToCalendarCategory": "Import into calendar category"
 }

--- a/locales/ru.json
+++ b/locales/ru.json
@@ -485,5 +485,12 @@
   "deleteCloudConfirmDescription": "This action permanently deletes your encrypted cloud backup. Type DELETE CLOUD DATA to continue.",
   "confirmDeleteData": "Confirm delete data",
   "countdownIcon": "Icon",
-  "countdownSearchIcon": "Search icons"
+  "countdownSearchIcon": "Search icons",
+  "countdownAdded": "Countdown added",
+  "countdownUpdated": "Countdown updated",
+  "countdownDeleted": "Countdown deleted",
+  "toastPosition": "Toast position",
+  "toastPositionBottomLeft": "Bottom left",
+  "toastPositionBottomCenter": "Bottom center",
+  "toastPositionBottomRight": "Bottom right"
 }

--- a/locales/ru.json
+++ b/locales/ru.json
@@ -492,5 +492,6 @@
   "toastPosition": "Toast position",
   "toastPositionBottomLeft": "Bottom left",
   "toastPositionBottomCenter": "Bottom center",
-  "toastPositionBottomRight": "Bottom right"
+  "toastPositionBottomRight": "Bottom right",
+  "countdownDaysAgo": "days ago"
 }

--- a/locales/ru.json
+++ b/locales/ru.json
@@ -478,5 +478,12 @@
     "ноябрь",
     "декабрь"
   ],
-  "sidebarCalendarMonthYearFormat": "{{month}} {{year}} г."
+  "sidebarCalendarMonthYearFormat": "{{month}} {{year}} г.",
+  "editCategory": "Edit category",
+  "categoryUpdated": "Category updated",
+  "deleteCloudConfirmTitle": "Delete cloud backup data",
+  "deleteCloudConfirmDescription": "This action permanently deletes your encrypted cloud backup. Type DELETE CLOUD DATA to continue.",
+  "confirmDeleteData": "Confirm delete data",
+  "countdownIcon": "Icon",
+  "countdownSearchIcon": "Search icons"
 }

--- a/locales/ru.json
+++ b/locales/ru.json
@@ -493,5 +493,8 @@
   "toastPositionBottomLeft": "Bottom left",
   "toastPositionBottomCenter": "Bottom center",
   "toastPositionBottomRight": "Bottom right",
-  "countdownDaysAgo": "days ago"
+  "countdownDaysAgo": "days ago",
+  "deleteCategoryEvents": "Delete all events under this category as well",
+  "categoryDeletedWithEvents": "Category and all its events were deleted",
+  "importToCalendarCategory": "Import into calendar category"
 }

--- a/locales/sl.json
+++ b/locales/sl.json
@@ -478,5 +478,12 @@
     "november",
     "december"
   ],
-  "sidebarCalendarMonthYearFormat": "{{month}} {{year}}"
+  "sidebarCalendarMonthYearFormat": "{{month}} {{year}}",
+  "editCategory": "Edit category",
+  "categoryUpdated": "Category updated",
+  "deleteCloudConfirmTitle": "Delete cloud backup data",
+  "deleteCloudConfirmDescription": "This action permanently deletes your encrypted cloud backup. Type DELETE CLOUD DATA to continue.",
+  "confirmDeleteData": "Confirm delete data",
+  "countdownIcon": "Icon",
+  "countdownSearchIcon": "Search icons"
 }

--- a/locales/sl.json
+++ b/locales/sl.json
@@ -485,5 +485,12 @@
   "deleteCloudConfirmDescription": "This action permanently deletes your encrypted cloud backup. Type DELETE CLOUD DATA to continue.",
   "confirmDeleteData": "Confirm delete data",
   "countdownIcon": "Icon",
-  "countdownSearchIcon": "Search icons"
+  "countdownSearchIcon": "Search icons",
+  "countdownAdded": "Countdown added",
+  "countdownUpdated": "Countdown updated",
+  "countdownDeleted": "Countdown deleted",
+  "toastPosition": "Toast position",
+  "toastPositionBottomLeft": "Bottom left",
+  "toastPositionBottomCenter": "Bottom center",
+  "toastPositionBottomRight": "Bottom right"
 }

--- a/locales/sl.json
+++ b/locales/sl.json
@@ -492,5 +492,6 @@
   "toastPosition": "Toast position",
   "toastPositionBottomLeft": "Bottom left",
   "toastPositionBottomCenter": "Bottom center",
-  "toastPositionBottomRight": "Bottom right"
+  "toastPositionBottomRight": "Bottom right",
+  "countdownDaysAgo": "days ago"
 }

--- a/locales/sl.json
+++ b/locales/sl.json
@@ -493,5 +493,8 @@
   "toastPositionBottomLeft": "Bottom left",
   "toastPositionBottomCenter": "Bottom center",
   "toastPositionBottomRight": "Bottom right",
-  "countdownDaysAgo": "days ago"
+  "countdownDaysAgo": "days ago",
+  "deleteCategoryEvents": "Delete all events under this category as well",
+  "categoryDeletedWithEvents": "Category and all its events were deleted",
+  "importToCalendarCategory": "Import into calendar category"
 }

--- a/locales/sq.json
+++ b/locales/sq.json
@@ -485,5 +485,12 @@
   "deleteCloudConfirmDescription": "This action permanently deletes your encrypted cloud backup. Type DELETE CLOUD DATA to continue.",
   "confirmDeleteData": "Confirm delete data",
   "countdownIcon": "Icon",
-  "countdownSearchIcon": "Search icons"
+  "countdownSearchIcon": "Search icons",
+  "countdownAdded": "Countdown added",
+  "countdownUpdated": "Countdown updated",
+  "countdownDeleted": "Countdown deleted",
+  "toastPosition": "Toast position",
+  "toastPositionBottomLeft": "Bottom left",
+  "toastPositionBottomCenter": "Bottom center",
+  "toastPositionBottomRight": "Bottom right"
 }

--- a/locales/sq.json
+++ b/locales/sq.json
@@ -478,5 +478,12 @@
     "nëntor",
     "dhjetor"
   ],
-  "sidebarCalendarMonthYearFormat": "{{month}} {{year}}"
+  "sidebarCalendarMonthYearFormat": "{{month}} {{year}}",
+  "editCategory": "Edit category",
+  "categoryUpdated": "Category updated",
+  "deleteCloudConfirmTitle": "Delete cloud backup data",
+  "deleteCloudConfirmDescription": "This action permanently deletes your encrypted cloud backup. Type DELETE CLOUD DATA to continue.",
+  "confirmDeleteData": "Confirm delete data",
+  "countdownIcon": "Icon",
+  "countdownSearchIcon": "Search icons"
 }

--- a/locales/sq.json
+++ b/locales/sq.json
@@ -492,5 +492,6 @@
   "toastPosition": "Toast position",
   "toastPositionBottomLeft": "Bottom left",
   "toastPositionBottomCenter": "Bottom center",
-  "toastPositionBottomRight": "Bottom right"
+  "toastPositionBottomRight": "Bottom right",
+  "countdownDaysAgo": "days ago"
 }

--- a/locales/sq.json
+++ b/locales/sq.json
@@ -493,5 +493,8 @@
   "toastPositionBottomLeft": "Bottom left",
   "toastPositionBottomCenter": "Bottom center",
   "toastPositionBottomRight": "Bottom right",
-  "countdownDaysAgo": "days ago"
+  "countdownDaysAgo": "days ago",
+  "deleteCategoryEvents": "Delete all events under this category as well",
+  "categoryDeletedWithEvents": "Category and all its events were deleted",
+  "importToCalendarCategory": "Import into calendar category"
 }

--- a/locales/sr.json
+++ b/locales/sr.json
@@ -485,5 +485,12 @@
   "deleteCloudConfirmDescription": "This action permanently deletes your encrypted cloud backup. Type DELETE CLOUD DATA to continue.",
   "confirmDeleteData": "Confirm delete data",
   "countdownIcon": "Icon",
-  "countdownSearchIcon": "Search icons"
+  "countdownSearchIcon": "Search icons",
+  "countdownAdded": "Countdown added",
+  "countdownUpdated": "Countdown updated",
+  "countdownDeleted": "Countdown deleted",
+  "toastPosition": "Toast position",
+  "toastPositionBottomLeft": "Bottom left",
+  "toastPositionBottomCenter": "Bottom center",
+  "toastPositionBottomRight": "Bottom right"
 }

--- a/locales/sr.json
+++ b/locales/sr.json
@@ -478,5 +478,12 @@
     "новембар",
     "децембар"
   ],
-  "sidebarCalendarMonthYearFormat": "{{month}} {{year}}."
+  "sidebarCalendarMonthYearFormat": "{{month}} {{year}}.",
+  "editCategory": "Edit category",
+  "categoryUpdated": "Category updated",
+  "deleteCloudConfirmTitle": "Delete cloud backup data",
+  "deleteCloudConfirmDescription": "This action permanently deletes your encrypted cloud backup. Type DELETE CLOUD DATA to continue.",
+  "confirmDeleteData": "Confirm delete data",
+  "countdownIcon": "Icon",
+  "countdownSearchIcon": "Search icons"
 }

--- a/locales/sr.json
+++ b/locales/sr.json
@@ -492,5 +492,6 @@
   "toastPosition": "Toast position",
   "toastPositionBottomLeft": "Bottom left",
   "toastPositionBottomCenter": "Bottom center",
-  "toastPositionBottomRight": "Bottom right"
+  "toastPositionBottomRight": "Bottom right",
+  "countdownDaysAgo": "days ago"
 }

--- a/locales/sr.json
+++ b/locales/sr.json
@@ -493,5 +493,8 @@
   "toastPositionBottomLeft": "Bottom left",
   "toastPositionBottomCenter": "Bottom center",
   "toastPositionBottomRight": "Bottom right",
-  "countdownDaysAgo": "days ago"
+  "countdownDaysAgo": "days ago",
+  "deleteCategoryEvents": "Delete all events under this category as well",
+  "categoryDeletedWithEvents": "Category and all its events were deleted",
+  "importToCalendarCategory": "Import into calendar category"
 }

--- a/locales/sv.json
+++ b/locales/sv.json
@@ -478,5 +478,12 @@
     "november",
     "december"
   ],
-  "sidebarCalendarMonthYearFormat": "{{month}} {{year}}"
+  "sidebarCalendarMonthYearFormat": "{{month}} {{year}}",
+  "editCategory": "Edit category",
+  "categoryUpdated": "Category updated",
+  "deleteCloudConfirmTitle": "Delete cloud backup data",
+  "deleteCloudConfirmDescription": "This action permanently deletes your encrypted cloud backup. Type DELETE CLOUD DATA to continue.",
+  "confirmDeleteData": "Confirm delete data",
+  "countdownIcon": "Icon",
+  "countdownSearchIcon": "Search icons"
 }

--- a/locales/sv.json
+++ b/locales/sv.json
@@ -485,5 +485,12 @@
   "deleteCloudConfirmDescription": "This action permanently deletes your encrypted cloud backup. Type DELETE CLOUD DATA to continue.",
   "confirmDeleteData": "Confirm delete data",
   "countdownIcon": "Icon",
-  "countdownSearchIcon": "Search icons"
+  "countdownSearchIcon": "Search icons",
+  "countdownAdded": "Countdown added",
+  "countdownUpdated": "Countdown updated",
+  "countdownDeleted": "Countdown deleted",
+  "toastPosition": "Toast position",
+  "toastPositionBottomLeft": "Bottom left",
+  "toastPositionBottomCenter": "Bottom center",
+  "toastPositionBottomRight": "Bottom right"
 }

--- a/locales/sv.json
+++ b/locales/sv.json
@@ -492,5 +492,6 @@
   "toastPosition": "Toast position",
   "toastPositionBottomLeft": "Bottom left",
   "toastPositionBottomCenter": "Bottom center",
-  "toastPositionBottomRight": "Bottom right"
+  "toastPositionBottomRight": "Bottom right",
+  "countdownDaysAgo": "days ago"
 }

--- a/locales/sv.json
+++ b/locales/sv.json
@@ -493,5 +493,8 @@
   "toastPositionBottomLeft": "Bottom left",
   "toastPositionBottomCenter": "Bottom center",
   "toastPositionBottomRight": "Bottom right",
-  "countdownDaysAgo": "days ago"
+  "countdownDaysAgo": "days ago",
+  "deleteCategoryEvents": "Delete all events under this category as well",
+  "categoryDeletedWithEvents": "Category and all its events were deleted",
+  "importToCalendarCategory": "Import into calendar category"
 }

--- a/locales/sw.json
+++ b/locales/sw.json
@@ -485,5 +485,12 @@
   "deleteCloudConfirmDescription": "This action permanently deletes your encrypted cloud backup. Type DELETE CLOUD DATA to continue.",
   "confirmDeleteData": "Confirm delete data",
   "countdownIcon": "Icon",
-  "countdownSearchIcon": "Search icons"
+  "countdownSearchIcon": "Search icons",
+  "countdownAdded": "Countdown added",
+  "countdownUpdated": "Countdown updated",
+  "countdownDeleted": "Countdown deleted",
+  "toastPosition": "Toast position",
+  "toastPositionBottomLeft": "Bottom left",
+  "toastPositionBottomCenter": "Bottom center",
+  "toastPositionBottomRight": "Bottom right"
 }

--- a/locales/sw.json
+++ b/locales/sw.json
@@ -492,5 +492,6 @@
   "toastPosition": "Toast position",
   "toastPositionBottomLeft": "Bottom left",
   "toastPositionBottomCenter": "Bottom center",
-  "toastPositionBottomRight": "Bottom right"
+  "toastPositionBottomRight": "Bottom right",
+  "countdownDaysAgo": "days ago"
 }

--- a/locales/sw.json
+++ b/locales/sw.json
@@ -478,5 +478,12 @@
     "Novemba",
     "Desemba"
   ],
-  "sidebarCalendarMonthYearFormat": "{{month}} {{year}}"
+  "sidebarCalendarMonthYearFormat": "{{month}} {{year}}",
+  "editCategory": "Edit category",
+  "categoryUpdated": "Category updated",
+  "deleteCloudConfirmTitle": "Delete cloud backup data",
+  "deleteCloudConfirmDescription": "This action permanently deletes your encrypted cloud backup. Type DELETE CLOUD DATA to continue.",
+  "confirmDeleteData": "Confirm delete data",
+  "countdownIcon": "Icon",
+  "countdownSearchIcon": "Search icons"
 }

--- a/locales/sw.json
+++ b/locales/sw.json
@@ -493,5 +493,8 @@
   "toastPositionBottomLeft": "Bottom left",
   "toastPositionBottomCenter": "Bottom center",
   "toastPositionBottomRight": "Bottom right",
-  "countdownDaysAgo": "days ago"
+  "countdownDaysAgo": "days ago",
+  "deleteCategoryEvents": "Delete all events under this category as well",
+  "categoryDeletedWithEvents": "Category and all its events were deleted",
+  "importToCalendarCategory": "Import into calendar category"
 }

--- a/locales/th.json
+++ b/locales/th.json
@@ -485,5 +485,12 @@
   "deleteCloudConfirmDescription": "This action permanently deletes your encrypted cloud backup. Type DELETE CLOUD DATA to continue.",
   "confirmDeleteData": "Confirm delete data",
   "countdownIcon": "Icon",
-  "countdownSearchIcon": "Search icons"
+  "countdownSearchIcon": "Search icons",
+  "countdownAdded": "Countdown added",
+  "countdownUpdated": "Countdown updated",
+  "countdownDeleted": "Countdown deleted",
+  "toastPosition": "Toast position",
+  "toastPositionBottomLeft": "Bottom left",
+  "toastPositionBottomCenter": "Bottom center",
+  "toastPositionBottomRight": "Bottom right"
 }

--- a/locales/th.json
+++ b/locales/th.json
@@ -492,5 +492,6 @@
   "toastPosition": "Toast position",
   "toastPositionBottomLeft": "Bottom left",
   "toastPositionBottomCenter": "Bottom center",
-  "toastPositionBottomRight": "Bottom right"
+  "toastPositionBottomRight": "Bottom right",
+  "countdownDaysAgo": "days ago"
 }

--- a/locales/th.json
+++ b/locales/th.json
@@ -478,5 +478,12 @@
     "พฤศจิกายน",
     "ธันวาคม"
   ],
-  "sidebarCalendarMonthYearFormat": "{{month}} {{year}}"
+  "sidebarCalendarMonthYearFormat": "{{month}} {{year}}",
+  "editCategory": "Edit category",
+  "categoryUpdated": "Category updated",
+  "deleteCloudConfirmTitle": "Delete cloud backup data",
+  "deleteCloudConfirmDescription": "This action permanently deletes your encrypted cloud backup. Type DELETE CLOUD DATA to continue.",
+  "confirmDeleteData": "Confirm delete data",
+  "countdownIcon": "Icon",
+  "countdownSearchIcon": "Search icons"
 }

--- a/locales/th.json
+++ b/locales/th.json
@@ -493,5 +493,8 @@
   "toastPositionBottomLeft": "Bottom left",
   "toastPositionBottomCenter": "Bottom center",
   "toastPositionBottomRight": "Bottom right",
-  "countdownDaysAgo": "days ago"
+  "countdownDaysAgo": "days ago",
+  "deleteCategoryEvents": "Delete all events under this category as well",
+  "categoryDeletedWithEvents": "Category and all its events were deleted",
+  "importToCalendarCategory": "Import into calendar category"
 }

--- a/locales/tr.json
+++ b/locales/tr.json
@@ -485,5 +485,12 @@
   "deleteCloudConfirmDescription": "This action permanently deletes your encrypted cloud backup. Type DELETE CLOUD DATA to continue.",
   "confirmDeleteData": "Confirm delete data",
   "countdownIcon": "Icon",
-  "countdownSearchIcon": "Search icons"
+  "countdownSearchIcon": "Search icons",
+  "countdownAdded": "Countdown added",
+  "countdownUpdated": "Countdown updated",
+  "countdownDeleted": "Countdown deleted",
+  "toastPosition": "Toast position",
+  "toastPositionBottomLeft": "Bottom left",
+  "toastPositionBottomCenter": "Bottom center",
+  "toastPositionBottomRight": "Bottom right"
 }

--- a/locales/tr.json
+++ b/locales/tr.json
@@ -478,5 +478,12 @@
     "Kasım",
     "Aralık"
   ],
-  "sidebarCalendarMonthYearFormat": "{{month}} {{year}}"
+  "sidebarCalendarMonthYearFormat": "{{month}} {{year}}",
+  "editCategory": "Edit category",
+  "categoryUpdated": "Category updated",
+  "deleteCloudConfirmTitle": "Delete cloud backup data",
+  "deleteCloudConfirmDescription": "This action permanently deletes your encrypted cloud backup. Type DELETE CLOUD DATA to continue.",
+  "confirmDeleteData": "Confirm delete data",
+  "countdownIcon": "Icon",
+  "countdownSearchIcon": "Search icons"
 }

--- a/locales/tr.json
+++ b/locales/tr.json
@@ -492,5 +492,6 @@
   "toastPosition": "Toast position",
   "toastPositionBottomLeft": "Bottom left",
   "toastPositionBottomCenter": "Bottom center",
-  "toastPositionBottomRight": "Bottom right"
+  "toastPositionBottomRight": "Bottom right",
+  "countdownDaysAgo": "days ago"
 }

--- a/locales/tr.json
+++ b/locales/tr.json
@@ -493,5 +493,8 @@
   "toastPositionBottomLeft": "Bottom left",
   "toastPositionBottomCenter": "Bottom center",
   "toastPositionBottomRight": "Bottom right",
-  "countdownDaysAgo": "days ago"
+  "countdownDaysAgo": "days ago",
+  "deleteCategoryEvents": "Delete all events under this category as well",
+  "categoryDeletedWithEvents": "Category and all its events were deleted",
+  "importToCalendarCategory": "Import into calendar category"
 }

--- a/locales/uk.json
+++ b/locales/uk.json
@@ -485,5 +485,12 @@
   "deleteCloudConfirmDescription": "This action permanently deletes your encrypted cloud backup. Type DELETE CLOUD DATA to continue.",
   "confirmDeleteData": "Confirm delete data",
   "countdownIcon": "Icon",
-  "countdownSearchIcon": "Search icons"
+  "countdownSearchIcon": "Search icons",
+  "countdownAdded": "Countdown added",
+  "countdownUpdated": "Countdown updated",
+  "countdownDeleted": "Countdown deleted",
+  "toastPosition": "Toast position",
+  "toastPositionBottomLeft": "Bottom left",
+  "toastPositionBottomCenter": "Bottom center",
+  "toastPositionBottomRight": "Bottom right"
 }

--- a/locales/uk.json
+++ b/locales/uk.json
@@ -492,5 +492,6 @@
   "toastPosition": "Toast position",
   "toastPositionBottomLeft": "Bottom left",
   "toastPositionBottomCenter": "Bottom center",
-  "toastPositionBottomRight": "Bottom right"
+  "toastPositionBottomRight": "Bottom right",
+  "countdownDaysAgo": "days ago"
 }

--- a/locales/uk.json
+++ b/locales/uk.json
@@ -478,5 +478,12 @@
     "листопад",
     "грудень"
   ],
-  "sidebarCalendarMonthYearFormat": "{{month}} {{year}} р."
+  "sidebarCalendarMonthYearFormat": "{{month}} {{year}} р.",
+  "editCategory": "Edit category",
+  "categoryUpdated": "Category updated",
+  "deleteCloudConfirmTitle": "Delete cloud backup data",
+  "deleteCloudConfirmDescription": "This action permanently deletes your encrypted cloud backup. Type DELETE CLOUD DATA to continue.",
+  "confirmDeleteData": "Confirm delete data",
+  "countdownIcon": "Icon",
+  "countdownSearchIcon": "Search icons"
 }

--- a/locales/uk.json
+++ b/locales/uk.json
@@ -493,5 +493,8 @@
   "toastPositionBottomLeft": "Bottom left",
   "toastPositionBottomCenter": "Bottom center",
   "toastPositionBottomRight": "Bottom right",
-  "countdownDaysAgo": "days ago"
+  "countdownDaysAgo": "days ago",
+  "deleteCategoryEvents": "Delete all events under this category as well",
+  "categoryDeletedWithEvents": "Category and all its events were deleted",
+  "importToCalendarCategory": "Import into calendar category"
 }

--- a/locales/vi.json
+++ b/locales/vi.json
@@ -485,5 +485,12 @@
   "deleteCloudConfirmDescription": "This action permanently deletes your encrypted cloud backup. Type DELETE CLOUD DATA to continue.",
   "confirmDeleteData": "Confirm delete data",
   "countdownIcon": "Icon",
-  "countdownSearchIcon": "Search icons"
+  "countdownSearchIcon": "Search icons",
+  "countdownAdded": "Countdown added",
+  "countdownUpdated": "Countdown updated",
+  "countdownDeleted": "Countdown deleted",
+  "toastPosition": "Toast position",
+  "toastPositionBottomLeft": "Bottom left",
+  "toastPositionBottomCenter": "Bottom center",
+  "toastPositionBottomRight": "Bottom right"
 }

--- a/locales/vi.json
+++ b/locales/vi.json
@@ -492,5 +492,6 @@
   "toastPosition": "Toast position",
   "toastPositionBottomLeft": "Bottom left",
   "toastPositionBottomCenter": "Bottom center",
-  "toastPositionBottomRight": "Bottom right"
+  "toastPositionBottomRight": "Bottom right",
+  "countdownDaysAgo": "days ago"
 }

--- a/locales/vi.json
+++ b/locales/vi.json
@@ -478,5 +478,12 @@
     "Tháng 11",
     "Tháng 12"
   ],
-  "sidebarCalendarMonthYearFormat": "{{month}} năm {{year}}"
+  "sidebarCalendarMonthYearFormat": "{{month}} năm {{year}}",
+  "editCategory": "Edit category",
+  "categoryUpdated": "Category updated",
+  "deleteCloudConfirmTitle": "Delete cloud backup data",
+  "deleteCloudConfirmDescription": "This action permanently deletes your encrypted cloud backup. Type DELETE CLOUD DATA to continue.",
+  "confirmDeleteData": "Confirm delete data",
+  "countdownIcon": "Icon",
+  "countdownSearchIcon": "Search icons"
 }

--- a/locales/vi.json
+++ b/locales/vi.json
@@ -493,5 +493,8 @@
   "toastPositionBottomLeft": "Bottom left",
   "toastPositionBottomCenter": "Bottom center",
   "toastPositionBottomRight": "Bottom right",
-  "countdownDaysAgo": "days ago"
+  "countdownDaysAgo": "days ago",
+  "deleteCategoryEvents": "Delete all events under this category as well",
+  "categoryDeletedWithEvents": "Category and all its events were deleted",
+  "importToCalendarCategory": "Import into calendar category"
 }

--- a/locales/yue.json
+++ b/locales/yue.json
@@ -493,5 +493,8 @@
   "toastPositionBottomLeft": "左下",
   "toastPositionBottomCenter": "中下",
   "toastPositionBottomRight": "右下",
-  "countdownDaysAgo": "天前"
+  "countdownDaysAgo": "天前",
+  "deleteCategoryEvents": "同时删除此分类下的全部日程",
+  "categoryDeletedWithEvents": "分类及其全部日程已删除",
+  "importToCalendarCategory": "导入到日历分类"
 }

--- a/locales/yue.json
+++ b/locales/yue.json
@@ -492,5 +492,6 @@
   "toastPosition": "通知位置",
   "toastPositionBottomLeft": "左下",
   "toastPositionBottomCenter": "中下",
-  "toastPositionBottomRight": "右下"
+  "toastPositionBottomRight": "右下",
+  "countdownDaysAgo": "天前"
 }

--- a/locales/yue.json
+++ b/locales/yue.json
@@ -478,5 +478,12 @@
     "11月",
     "12月"
   ],
-  "sidebarCalendarMonthYearFormat": "{{year}}年{{month}}"
+  "sidebarCalendarMonthYearFormat": "{{year}}年{{month}}",
+  "editCategory": "编辑分类",
+  "categoryUpdated": "分类已更新",
+  "deleteCloudConfirmTitle": "删除云端备份数据",
+  "deleteCloudConfirmDescription": "此操作会永久删除你的加密云端备份。请输入 DELETE CLOUD DATA 以继续。",
+  "confirmDeleteData": "确认删除数据",
+  "countdownIcon": "图标",
+  "countdownSearchIcon": "搜索图标"
 }

--- a/locales/yue.json
+++ b/locales/yue.json
@@ -485,5 +485,12 @@
   "deleteCloudConfirmDescription": "此操作会永久删除你的加密云端备份。请输入 DELETE CLOUD DATA 以继续。",
   "confirmDeleteData": "确认删除数据",
   "countdownIcon": "图标",
-  "countdownSearchIcon": "搜索图标"
+  "countdownSearchIcon": "搜索图标",
+  "countdownAdded": "倒数日已添加",
+  "countdownUpdated": "倒数日已更新",
+  "countdownDeleted": "倒数日已删除",
+  "toastPosition": "通知位置",
+  "toastPositionBottomLeft": "左下",
+  "toastPositionBottomCenter": "中下",
+  "toastPositionBottomRight": "右下"
 }

--- a/locales/zh-CN.json
+++ b/locales/zh-CN.json
@@ -478,5 +478,12 @@
     "十一月",
     "十二月"
   ],
-  "sidebarCalendarMonthYearFormat": "{{year}}年{{month}}"
+  "sidebarCalendarMonthYearFormat": "{{year}}年{{month}}",
+  "editCategory": "编辑分类",
+  "categoryUpdated": "分类已更新",
+  "deleteCloudConfirmTitle": "删除云端备份数据",
+  "deleteCloudConfirmDescription": "此操作会永久删除你的加密云端备份。请输入 DELETE CLOUD DATA 以继续。",
+  "confirmDeleteData": "确认删除数据",
+  "countdownIcon": "图标",
+  "countdownSearchIcon": "搜索图标"
 }

--- a/locales/zh-CN.json
+++ b/locales/zh-CN.json
@@ -493,5 +493,8 @@
   "toastPositionBottomLeft": "左下",
   "toastPositionBottomCenter": "中下",
   "toastPositionBottomRight": "右下",
-  "countdownDaysAgo": "天前"
+  "countdownDaysAgo": "天前",
+  "deleteCategoryEvents": "同时删除此分类下的全部日程",
+  "categoryDeletedWithEvents": "分类及其全部日程已删除",
+  "importToCalendarCategory": "导入到日历分类"
 }

--- a/locales/zh-CN.json
+++ b/locales/zh-CN.json
@@ -492,5 +492,6 @@
   "toastPosition": "通知位置",
   "toastPositionBottomLeft": "左下",
   "toastPositionBottomCenter": "中下",
-  "toastPositionBottomRight": "右下"
+  "toastPositionBottomRight": "右下",
+  "countdownDaysAgo": "天前"
 }

--- a/locales/zh-CN.json
+++ b/locales/zh-CN.json
@@ -485,5 +485,12 @@
   "deleteCloudConfirmDescription": "此操作会永久删除你的加密云端备份。请输入 DELETE CLOUD DATA 以继续。",
   "confirmDeleteData": "确认删除数据",
   "countdownIcon": "图标",
-  "countdownSearchIcon": "搜索图标"
+  "countdownSearchIcon": "搜索图标",
+  "countdownAdded": "倒数日已添加",
+  "countdownUpdated": "倒数日已更新",
+  "countdownDeleted": "倒数日已删除",
+  "toastPosition": "通知位置",
+  "toastPositionBottomLeft": "左下",
+  "toastPositionBottomCenter": "中下",
+  "toastPositionBottomRight": "右下"
 }

--- a/locales/zh-HK.json
+++ b/locales/zh-HK.json
@@ -493,5 +493,8 @@
   "toastPositionBottomLeft": "左下",
   "toastPositionBottomCenter": "中下",
   "toastPositionBottomRight": "右下",
-  "countdownDaysAgo": "天前"
+  "countdownDaysAgo": "天前",
+  "deleteCategoryEvents": "同时删除此分类下的全部日程",
+  "categoryDeletedWithEvents": "分类及其全部日程已删除",
+  "importToCalendarCategory": "导入到日历分类"
 }

--- a/locales/zh-HK.json
+++ b/locales/zh-HK.json
@@ -492,5 +492,6 @@
   "toastPosition": "通知位置",
   "toastPositionBottomLeft": "左下",
   "toastPositionBottomCenter": "中下",
-  "toastPositionBottomRight": "右下"
+  "toastPositionBottomRight": "右下",
+  "countdownDaysAgo": "天前"
 }

--- a/locales/zh-HK.json
+++ b/locales/zh-HK.json
@@ -478,5 +478,12 @@
     "11月",
     "12月"
   ],
-  "sidebarCalendarMonthYearFormat": "{{year}}年{{month}}"
+  "sidebarCalendarMonthYearFormat": "{{year}}年{{month}}",
+  "editCategory": "编辑分类",
+  "categoryUpdated": "分类已更新",
+  "deleteCloudConfirmTitle": "删除云端备份数据",
+  "deleteCloudConfirmDescription": "此操作会永久删除你的加密云端备份。请输入 DELETE CLOUD DATA 以继续。",
+  "confirmDeleteData": "确认删除数据",
+  "countdownIcon": "图标",
+  "countdownSearchIcon": "搜索图标"
 }

--- a/locales/zh-HK.json
+++ b/locales/zh-HK.json
@@ -485,5 +485,12 @@
   "deleteCloudConfirmDescription": "此操作会永久删除你的加密云端备份。请输入 DELETE CLOUD DATA 以继续。",
   "confirmDeleteData": "确认删除数据",
   "countdownIcon": "图标",
-  "countdownSearchIcon": "搜索图标"
+  "countdownSearchIcon": "搜索图标",
+  "countdownAdded": "倒数日已添加",
+  "countdownUpdated": "倒数日已更新",
+  "countdownDeleted": "倒数日已删除",
+  "toastPosition": "通知位置",
+  "toastPositionBottomLeft": "左下",
+  "toastPositionBottomCenter": "中下",
+  "toastPositionBottomRight": "右下"
 }

--- a/locales/zh-TW.json
+++ b/locales/zh-TW.json
@@ -493,5 +493,8 @@
   "toastPositionBottomLeft": "左下",
   "toastPositionBottomCenter": "中下",
   "toastPositionBottomRight": "右下",
-  "countdownDaysAgo": "天前"
+  "countdownDaysAgo": "天前",
+  "deleteCategoryEvents": "同时删除此分类下的全部日程",
+  "categoryDeletedWithEvents": "分类及其全部日程已删除",
+  "importToCalendarCategory": "导入到日历分类"
 }

--- a/locales/zh-TW.json
+++ b/locales/zh-TW.json
@@ -492,5 +492,6 @@
   "toastPosition": "通知位置",
   "toastPositionBottomLeft": "左下",
   "toastPositionBottomCenter": "中下",
-  "toastPositionBottomRight": "右下"
+  "toastPositionBottomRight": "右下",
+  "countdownDaysAgo": "天前"
 }

--- a/locales/zh-TW.json
+++ b/locales/zh-TW.json
@@ -478,5 +478,12 @@
     "11月",
     "12月"
   ],
-  "sidebarCalendarMonthYearFormat": "{{year}}年{{month}}"
+  "sidebarCalendarMonthYearFormat": "{{year}}年{{month}}",
+  "editCategory": "编辑分类",
+  "categoryUpdated": "分类已更新",
+  "deleteCloudConfirmTitle": "删除云端备份数据",
+  "deleteCloudConfirmDescription": "此操作会永久删除你的加密云端备份。请输入 DELETE CLOUD DATA 以继续。",
+  "confirmDeleteData": "确认删除数据",
+  "countdownIcon": "图标",
+  "countdownSearchIcon": "搜索图标"
 }

--- a/locales/zh-TW.json
+++ b/locales/zh-TW.json
@@ -485,5 +485,12 @@
   "deleteCloudConfirmDescription": "此操作会永久删除你的加密云端备份。请输入 DELETE CLOUD DATA 以继续。",
   "confirmDeleteData": "确认删除数据",
   "countdownIcon": "图标",
-  "countdownSearchIcon": "搜索图标"
+  "countdownSearchIcon": "搜索图标",
+  "countdownAdded": "倒数日已添加",
+  "countdownUpdated": "倒数日已更新",
+  "countdownDeleted": "倒数日已删除",
+  "toastPosition": "通知位置",
+  "toastPositionBottomLeft": "左下",
+  "toastPositionBottomCenter": "中下",
+  "toastPositionBottomRight": "右下"
 }

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "one-calendar",
-  "version": "2.2.0",
+  "version": "2.2.3",
   "private": true,
   "packageManager": "bun@1.3.6",
   "scripts": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "one-calendar",
-  "version": "2.2.3",
+  "version": "2.2.6",
   "private": true,
   "packageManager": "bun@1.3.6",
   "scripts": {


### PR DESCRIPTION
### Motivation

- Ensure user changes to settings like `language` and `timezone` trigger cloud backup automatically instead of requiring manual backup.  
- Add safer destructive flow for removing encrypted cloud backups and keep UI parity with account deletion confirmation.  
- Improve calendar UX: allow editing calendar category name/color and keep events in sync, fix bookmark cleanup on event deletion, and make context-menu share/bookmark/delete behave without opening the full event preview.  
- Enhance countdowns so users can pick a Lucide icon and color the icon (not the circle), and add necessary i18n keys.

### Description

- Bumped `package.json` version to `2.2.3`.
- Cloud sync / auto-backup: emit a `local-storage-written` event from `hooks/useLocalStorage.ts` on local storage writes and listen for these (and `languagechange`) in the backup flow so changes (language, timezone, etc.) trigger automatic upload; added a `backupTick` trigger to the backup effect in `components/app/profile/user-profile-button.tsx` to react to these signals.  
- Danger zone: added a typed confirmation dialog for deleting cloud backup data (`DELETE CLOUD DATA`) in `components/app/profile/user-profile-button.tsx` and new i18n keys for the dialog.  
- Bookmarks fix: when deleting an event its bookmark entry is now removed from `bookmarked-events` in `components/app/calendar.tsx`.  
- Calendar categories: added an edit button next to each calendar in `components/app/sidebar/sidebar.tsx`, implemented edit dialog to rename and change color and propagate color updates to events via context `setEvents`; extended `CalendarProvider` types to expose `setEvents`.  
- Context menu and share UX: changed day/week view context menu actions to use `onSelect` + `preventDefault` to avoid unintentionally opening preview/dialogs, and added a share-only mode so right-click share opens only the share dialog instead of the full preview (`components/app/views/*`, `components/app/event/event-preview.tsx`, `components/app/calendar.tsx`).  
- Auth waiting enhancement: `app/(app)/app/page.tsx` now checks `/api/blob` readiness for signed-in users before rendering the calendar.  
- Countdown tool: replaced initial-letter circle with a selectable Lucide icon set, applied selected color to the icon, added icon search and limited the rendered list to avoid UI slowdown, and saved icon choice in countdown entries (`components/app/sidebar/countdown.tsx`).  
- i18n: added new translation keys (e.g. `editCategory`, `deleteCloudConfirmTitle`, `countdownIcon`, `countdownSearchIcon`, `confirmDeleteData`, etc.) to locale files under `locales/*`.  
- Minor wiring: updated calendar context types and adjusted EventPreview to support share-only flow; updated day/week view menu handlers to avoid duplicate dialog openings.

### Testing

- No automated unit or lint tests were executed per request; no external translation APIs were used and all i18n additions were written directly into local locale files.  
- Changes were limited to UI wiring, local storage events, and locale files; please run the app and exercise the following flows as smoke tests in your environment: change `language`/`timezone`, enable auto-backup and observe uploads, try deleting cloud data with and without the typed confirmation, edit a calendar category and confirm event colors update, create/delete events and verify bookmarks are cleaned, open share from right-click to ensure only the share dialog appears, and verify countdown icon selection behaves smoothly.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69a04ca9d6f08332965cc505e7544aff)

## Summary by Sourcery

引入针对关键设置变更的自动备份触发器，提升与日历分类、分享/书签以及云端数据删除相关的安全性和用户体验，并增强倒计时自定义能力及应用就绪状态处理。

New Features:
- 允许从侧边栏编辑日历分类（名称和颜色），并将颜色更新同步到已有事件。
- 新增仅用于分享的事件流程，使右键菜单中的分享操作可以打开轻量级分享对话框，而无需加载完整事件预览。
- 增强倒计时工具：支持选择 Lucide 图标、彩色图标，以及可搜索的图标选择功能，并为每个倒计时持久化保存所选图标。

Bug Fixes:
- 在底层事件被删除时自动移除事件书签。
- 阻止日视图/周视图中的右键菜单操作意外打开完整事件预览或对话框。

Enhancements:
- 当监听的 `local-storage` 键或语言设置发生变化时，自动触发加密备份上传。
- 对已登录用户，将日历渲染置于 API 就绪检查之后，以避免在二进制数据（blob）可用之前就开始加载。
- 通过独立于账户删除流程的云数据删除确认对话框（需要输入确认文本）来加强云端数据删除的安全性。
- 在日历上下文中暴露带状态设置能力的变体，以支持在分类变更时就地更新事件。
- 扩展 i18n 字典，加入用于分类编辑、云删除确认以及倒计时图标选择的文案键值。

Build:
- 在 `package.json` 中将应用版本号提升至 `2.2.3`。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Introduce auto-backup triggers for key setting changes, improve safety and UX around calendar categories, sharing/bookmarking, and cloud data deletion, and enhance countdown customization and app readiness handling.

New Features:
- Allow editing calendar categories (name and color) from the sidebar, propagating color updates to existing events.
- Add a share-only event flow so context-menu share opens a lightweight share dialog without the full event preview.
- Enhance the countdown tool with selectable Lucide icons, colorized icons, and searchable icon selection persisted per countdown.

Bug Fixes:
- Remove event bookmarks automatically when the underlying event is deleted.
- Prevent day/week view context-menu actions from unintentionally opening full event previews or dialogs.

Enhancements:
- Trigger encrypted backup uploads automatically when watched local-storage keys or language settings change.
- Gate calendar rendering behind an API readiness check for signed-in users to avoid loading before blob data is available.
- Strengthen cloud data deletion with a typed confirmation dialog separate from account deletion.
- Expose state-setter variants in the calendar context to support updating events in place when categories change.
- Extend i18n dictionaries with keys for category editing, cloud-delete confirmation, and countdown icon selection.

Build:
- Bump application version to 2.2.3 in package.json.

</details>