### PR TITLE
Add top-bar help dropdown and move status/legal links from profile menu

### DIFF
--- a/components/app/calendar.tsx
+++ b/components/app/calendar.tsx
@@ -22,6 +22,11 @@ import {
   CheckCircle2,
   AlertCircle,
   Loader2,
+  CircleHelp,
+  ShieldCheck,
+  MessageSquare,
+  FileText,
+  ScrollText,
 } from "lucide-react";
 import dynamic from "next/dynamic";
 import {
@@ -46,6 +51,12 @@ import { Button } from "@/components/ui/button";
 import { Input } from "@/components/ui/input";
 import { cn } from "@/lib/utils";
 import { toast } from "sonner";
+import {
+  DropdownMenu,
+  DropdownMenuContent,
+  DropdownMenuItem,
+  DropdownMenuTrigger,
+} from "@/components/ui/dropdown-menu";
 import {
   AlertDialog,
   AlertDialogAction,
@@ -762,6 +773,38 @@ export default function Calendar({ className, ...props }: CalendarProps) {
                   {backupStatusIcon ?? <CloudUpload className="h-4 w-4" />}
                 </div>
               ) : null}
+              <DropdownMenu>
+                <DropdownMenuTrigger asChild>
+                  <Button
+                    variant="outline"
+                    size="icon"
+                    className="rounded-full h-8 w-8"
+                    aria-label="Help"
+                  >
+                    <CircleHelp className="h-4 w-4" />
+                  </Button>
+                </DropdownMenuTrigger>
+                <DropdownMenuContent align="end">
+                  <DropdownMenuItem onClick={() => window.open("https://calendarstatus.xyehr.cn", "_blank", "noopener,noreferrer")}>
+                    <ShieldCheck className="mr-2 h-4 w-4" />
+                    {t.status}
+                  </DropdownMenuItem>
+                  <DropdownMenuItem onClick={() => {
+                    window.location.href = "mailto:evan.huang000@proton.me";
+                  }}>
+                    <MessageSquare className="mr-2 h-4 w-4" />
+                    {t.feedback}
+                  </DropdownMenuItem>
+                  <DropdownMenuItem onClick={() => router.push("/privacy")}>
+                    <FileText className="mr-2 h-4 w-4" />
+                    {t.privacy}
+                  </DropdownMenuItem>
+                  <DropdownMenuItem onClick={() => router.push("/terms")}>
+                    <ScrollText className="mr-2 h-4 w-4" />
+                    {t.tos}
+                  </DropdownMenuItem>
+                </DropdownMenuContent>
+              </DropdownMenu>
               <UserProfileButton
                 variant="outline"
                 className="rounded-full h-8 w-8"

--- a/components/app/profile/user-profile-button.tsx
+++ b/components/app/profile/user-profile-button.tsx
@@ -14,10 +14,6 @@ import {
   Camera,
   BarChart2,
   Settings,
-  ShieldCheck,
-  MessageSquare,
-  FileText,
-  ScrollText,
 } from "lucide-react"
 import { Button } from "@/components/ui/button"
 import {
@@ -557,22 +553,6 @@ export default function UserProfileButton({
             <DropdownMenuItem onClick={() => onNavigateToView?.("analytics")}>
               <BarChart2 className="mr-2 h-4 w-4" />
               {t.analytics}
-            </DropdownMenuItem>
-            <DropdownMenuItem onClick={() => window.open("https://calendarstatus.xyehr.cn", "_blank", "noopener,noreferrer")}>
-              <ShieldCheck className="mr-2 h-4 w-4" />
-              {t.status}
-            </DropdownMenuItem>
-            <DropdownMenuItem onClick={() => window.location.href = "mailto:evan.huang000@proton.me"}>
-              <MessageSquare className="mr-2 h-4 w-4" />
-              {t.feedback}
-            </DropdownMenuItem>
-            <DropdownMenuItem onClick={() => router.push("/privacy")}>
-              <FileText className="mr-2 h-4 w-4" />
-              {t.privacy}
-            </DropdownMenuItem>
-            <DropdownMenuItem onClick={() => router.push("/terms")}>
-              <ScrollText className="mr-2 h-4 w-4" />
-              {t.tos}
             </DropdownMenuItem>
           </DropdownMenuContent>
         </DropdownMenu>


### PR DESCRIPTION
### Motivation
- Provide a dedicated help/utility control in the top bar for status, feedback, privacy and terms links instead of crowding the user profile menu.
- Make the top-bar UI consistent with existing circular icon buttons and improve discoverability for support/legal actions.

### Description
- Added a circular help button with a question-mark icon (`CircleHelp`) next to the backup status indicator in `components/app/calendar.tsx` and implemented a `DropdownMenu` for it that contains `Status`, `Feedback`, `Privacy` and `Terms of Service` actions.
- Imported needed icons (`CircleHelp`, `ShieldCheck`, `MessageSquare`, `FileText`, `ScrollText`) and the dropdown primitives from `@/components/ui/dropdown-menu` in `calendar.tsx`.
- Removed the duplicate `Status`, `Feedback`, `Privacy` and `Terms` entries from the user profile dropdown in `components/app/profile/user-profile-button.tsx` so those actions are only available in the new help menu.
- Kept existing navigation behaviors (external status link, mailto feedback, router pushes to `/privacy` and `/terms`).

### Testing
- Attempted to start the dev server with `bun run dev` to verify visually, but it failed with `next: command not found` so the app could not be launched in this environment (run failed).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69a122f75e1c8332b7d811dd002fec46)

## Summary by Sourcery

在顶部栏中新增专用的帮助下拉菜单，并将状态、反馈、隐私和条款相关操作从用户资料菜单移至该新控件中。

新功能：
- 在日历顶部栏中添加圆形帮助按钮，点击后打开下拉菜单，包含状态、反馈、隐私和条款等操作。

优化改进：
- 精简用户资料下拉菜单，移除已可通过新帮助菜单访问的支持和法律相关链接。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Add a dedicated help dropdown in the top bar and relocate status, feedback, privacy, and terms actions from the user profile menu to this new control.

New Features:
- Introduce a circular help button in the calendar top bar that opens a dropdown with status, feedback, privacy, and terms actions.

Enhancements:
- Streamline the user profile dropdown by removing support and legal links that are now accessible from the new help menu.

</details>