### PR TITLE
feat: add shatter particle animation before event deletion

### DIFF
--- a/components/app/views/day-view.tsx
+++ b/components/app/views/day-view.tsx
@@ -12,6 +12,7 @@ import {
   add,
 } from "date-fns";
 import { cn } from "@/lib/utils";
+import { playEventShatterAnimation } from "@/lib/event-shatter";
 import type { CalendarEvent } from "../calendar";
 import { translations, type Language } from "@/lib/i18n";
 
@@ -83,6 +84,11 @@ export default function DayView({
     window.setTimeout(() => {
       ignoreNextEventClickRef.current = false;
     }, 0);
+  };
+
+  const handleDeleteEvent = async (event: CalendarEvent) => {
+    await playEventShatterAnimation(event.id);
+    onDeleteEvent?.(event);
   };
 
 
@@ -502,6 +508,7 @@ export default function DayView({
       <ContextMenu key={`allday-${event.id}`}>
         <ContextMenuTrigger asChild>
           <div
+            data-event-shatter-id={event.id}
             className={cn(
               "relative rounded-lg p-1 text-xs cursor-pointer overflow-hidden",
               event.color,
@@ -560,7 +567,7 @@ export default function DayView({
             {menuLabels.bookmark}
           </ContextMenuItem>
           <ContextMenuItem
-            onSelect={(e) => { e.preventDefault(); e.stopPropagation(); queueIgnoreEventClick(); onDeleteEvent?.(event); }}
+            onSelect={(e) => { e.preventDefault(); e.stopPropagation(); queueIgnoreEventClick(); void handleDeleteEvent(event); }}
             className="text-red-600"
           >
             <Trash2 className="mr-2 h-4 w-4" />
@@ -720,6 +727,7 @@ export default function DayView({
               <ContextMenu key={event.id}>
                 <ContextMenuTrigger asChild>
                   <div
+                    data-event-shatter-id={event.id}
                     className={cn(
                       "relative absolute rounded-lg p-2 text-sm cursor-pointer overflow-hidden",
                       event.color,
@@ -797,7 +805,7 @@ export default function DayView({
                     {menuLabels.bookmark}
                   </ContextMenuItem>
                   <ContextMenuItem
-                    onSelect={(e) => { e.preventDefault(); e.stopPropagation(); queueIgnoreEventClick(); onDeleteEvent?.(event); }}
+                    onSelect={(e) => { e.preventDefault(); e.stopPropagation(); queueIgnoreEventClick(); void handleDeleteEvent(event); }}
                     className="text-red-600"
                   >
                     <Trash2 className="mr-2 h-4 w-4" />

--- a/components/app/views/week-view.tsx
+++ b/components/app/views/week-view.tsx
@@ -15,6 +15,7 @@ import {
   startOfDay,
 } from "date-fns";
 import { cn } from "@/lib/utils";
+import { playEventShatterAnimation } from "@/lib/event-shatter";
 import { translations, type Language } from "@/lib/i18n";
 
 const ContextMenu = ({ children }: { children: React.ReactNode }) => <>{children}</>;
@@ -111,6 +112,11 @@ export default function WeekView({
     window.setTimeout(() => {
       ignoreNextEventClickRef.current = false;
     }, 0);
+  };
+
+  const handleDeleteEvent = async (event: CalendarEvent) => {
+    await playEventShatterAnimation(event.id);
+    onDeleteEvent?.(event);
   };
 
 
@@ -609,6 +615,7 @@ export default function WeekView({
       >
         <ContextMenuTrigger asChild>
           <div
+            data-event-shatter-id={event.id}
             className={cn(
               "relative rounded-lg p-1 text-xs cursor-pointer overflow-hidden",
               event.color,
@@ -668,7 +675,7 @@ export default function WeekView({
             {menuLabels.bookmark}
           </ContextMenuItem>
           <ContextMenuItem
-            onSelect={(e) => { e.preventDefault(); e.stopPropagation(); queueIgnoreEventClick(); onDeleteEvent?.(event); }}
+            onSelect={(e) => { e.preventDefault(); e.stopPropagation(); queueIgnoreEventClick(); void handleDeleteEvent(event); }}
             className="text-red-600"
           >
             <Trash2 className="mr-2 h-4 w-4" />
@@ -842,6 +849,7 @@ export default function WeekView({
                     >
                       <ContextMenuTrigger asChild>
                         <div
+                          data-event-shatter-id={event.id}
                           className={cn(
                             "relative absolute rounded-lg p-2 text-sm cursor-pointer overflow-hidden",
                             event.color,
@@ -923,7 +931,7 @@ export default function WeekView({
                           {menuLabels.bookmark}
                         </ContextMenuItem>
                         <ContextMenuItem
-                          onSelect={(e) => { e.preventDefault(); e.stopPropagation(); queueIgnoreEventClick(); onDeleteEvent?.(event); }}
+                          onSelect={(e) => { e.preventDefault(); e.stopPropagation(); queueIgnoreEventClick(); void handleDeleteEvent(event); }}
                           className="text-red-600"
                         >
                           <Trash2 className="mr-2 h-4 w-4" />

--- a/lib/event-shatter.ts
+++ b/lib/event-shatter.ts
@@ -1,0 +1,109 @@
+"use client";
+
+const MIN_DURATION_MS = 500;
+const MAX_DURATION_MS = 700;
+
+const easeOutCubic = (t: number) => 1 - Math.pow(1 - t, 3);
+
+function createParticles(width: number, height: number) {
+  const area = width * height;
+  const particleCount = Math.min(42, Math.max(18, Math.round(area / 280)));
+  const centerX = width / 2;
+  const centerY = height / 2;
+
+  return Array.from({ length: particleCount }, () => {
+    const originX = Math.random() * width;
+    const originY = Math.random() * height;
+    const distanceFromCenter = Math.hypot(originX - centerX, originY - centerY);
+    const normalizedDistance = Math.min(
+      1,
+      distanceFromCenter / Math.hypot(centerX, centerY),
+    );
+
+    const size = (2 + Math.random() * 4) * (1 - normalizedDistance * 0.35);
+    const travelY = -(60 + Math.random() * 40);
+    const travelX = (Math.random() - 0.5) * 26;
+
+    return {
+      originX,
+      originY,
+      size: Math.max(1.2, size),
+      travelX,
+      travelY,
+      driftX: (Math.random() - 0.5) * 6,
+    };
+  });
+}
+
+async function shatterElement(element: HTMLElement) {
+  const rect = element.getBoundingClientRect();
+  if (rect.width === 0 || rect.height === 0) return;
+
+  const dpr = window.devicePixelRatio || 1;
+  const canvas = document.createElement("canvas");
+  canvas.width = Math.round(rect.width * dpr);
+  canvas.height = Math.round(rect.height * dpr);
+  canvas.style.position = "fixed";
+  canvas.style.left = `${rect.left}px`;
+  canvas.style.top = `${rect.top}px`;
+  canvas.style.width = `${rect.width}px`;
+  canvas.style.height = `${rect.height}px`;
+  canvas.style.pointerEvents = "none";
+  canvas.style.zIndex = "9999";
+
+  const ctx = canvas.getContext("2d");
+  if (!ctx) return;
+  ctx.scale(dpr, dpr);
+
+  const style = window.getComputedStyle(element);
+  const particleColor = style.backgroundColor || "#3b82f6";
+  const particles = createParticles(rect.width, rect.height);
+  const duration = MIN_DURATION_MS + Math.random() * (MAX_DURATION_MS - MIN_DURATION_MS);
+
+  document.body.appendChild(canvas);
+
+  const previousVisibility = element.style.visibility;
+  element.style.visibility = "hidden";
+
+  await new Promise<void>((resolve) => {
+    const start = performance.now();
+
+    const render = (now: number) => {
+      const progress = Math.min(1, (now - start) / duration);
+      const eased = easeOutCubic(progress);
+      const fade = 1 - eased;
+
+      ctx.clearRect(0, 0, rect.width, rect.height);
+      ctx.globalAlpha = fade;
+      ctx.fillStyle = particleColor;
+
+      for (const particle of particles) {
+        const x = particle.originX + particle.travelX * eased + particle.driftX * progress;
+        const y = particle.originY + particle.travelY * eased;
+        ctx.fillRect(x, y, particle.size, particle.size);
+      }
+
+      if (progress < 1) {
+        requestAnimationFrame(render);
+      } else {
+        canvas.remove();
+        element.style.visibility = previousVisibility;
+        resolve();
+      }
+    };
+
+    requestAnimationFrame(render);
+  });
+}
+
+export async function playEventShatterAnimation(eventId: string) {
+  if (typeof window === "undefined") return;
+
+  const elements = Array.from(
+    document.querySelectorAll<HTMLElement>("[data-event-shatter-id]"),
+  ).filter((element) => element.dataset.eventShatterId === eventId);
+
+  if (elements.length === 0) return;
+
+  await Promise.all(elements.map((element) => shatterElement(element)));
+}


### PR DESCRIPTION
### Motivation
- Provide a satisfying ‘‘shatter into particles’’ animation when the user deletes an event, and only run the actual deletion after the animation completes.  
- Animation should be upward-dominant with slight horizontal randomness, variable particle sizes (smaller at edges), fade-out with an ease-out curve, and run ~500–700ms.  
- Ensure immediate hiding of the source card (no flicker), support concurrent animations for multiple events, clean up DOM after animation, and keep mobile/devicePixelRatio rendering correct.

### Description
- Added a new client-side utility `lib/event-shatter.ts` that renders a canvas over the source element, generates variable-size particles, animates them primarily upward with light horizontal drift (travelY ≈ -60 to -100px, travelX random), fades with an ease-out curve, uses devicePixelRatio for sharp rendering, and removes the canvas and restores state when done.  
- Wired the animation into views by importing `playEventShatterAnimation` in `components/app/views/day-view.tsx` and `components/app/views/week-view.tsx`, and added `handleDeleteEvent` which `await`s the animation before invoking the existing `onDeleteEvent` handler.  
- Tagged event DOM nodes (all-day and timed blocks) with `data-event-shatter-id={event.id}` so the shatter utility can target all rendered fragments for the same event and run them in parallel without interfering.  
- Animation implementation immediately sets the element `visibility` to `hidden` on start (first frame) and ensures all temporary DOM (canvas) is removed at the end to avoid leaks, supporting multiple simultaneous deletions.

### Testing
- Ran `bun --version` which succeeded in the environment.  
- Attempted to run the dev server with `bun run dev` for visual verification, but it failed because `next` was not available in this environment, so visual/manual verification could not be completed.  
- No automated unit tests were added or run as part of this change (no existing test harness executed in this environment).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69a12e9636048332825a766076857e49)

## Summary by Sourcery

在日视图和周视图中，当删除日程事件时，先在客户端播放碎裂粒子动画，再执行实际删除操作。

New Features:
- 引入基于 canvas 的碎裂粒子动画工具，通过共享的数据属性来标识需要动画的事件。
- 在日视图和周视图中删除事件时触发碎裂动画，并在动画完成后再调用删除处理函数。

Enhancements:
- 在日视图和周视图中的事件元素上添加稳定的数据属性，以便在删除时该事件的所有可视片段能够一起执行动画。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Add a client-side shatter particle animation that plays on event deletion in day and week calendar views before the actual delete occurs.

New Features:
- Introduce a canvas-based shatter particle animation utility for events identified by a shared data attribute.
- Trigger the shatter animation when deleting events from both day and week views, awaiting completion before invoking the delete handler.

Enhancements:
- Tag event elements in day and week views with a stable data attribute so all visual fragments of an event animate together on deletion.

</details>