### PR TITLE
small change

### DIFF
--- a/components/app/calendar.tsx
+++ b/components/app/calendar.tsx
@@ -648,9 +648,10 @@ export default function Calendar({ className, ...props }: CalendarProps) {
           }}
         />
 
-        <div className="flex min-h-0 min-w-0 flex-1 flex-col pr-14">
+        <div className="flex min-h-0 min-w-0 flex-1 flex-col">
           {" "}
           <header className="flex items-center px-4 h-16 border-b relative z-40 bg-background">
+            <div className="pointer-events-none absolute right-0 bottom-0 h-px w-14 bg-background" />
             <div className="flex items-center space-x-4">
               <Button variant="outline" onClick={toggleSidebar} size="sm">
                 <PanelLeft />

--- a/components/app/sidebar/right-sidebar.tsx
+++ b/components/app/sidebar/right-sidebar.tsx
@@ -70,7 +70,7 @@ export default function RightSidebar({
 
   return (
     <>
-      <div className="w-14 bg-background border-l flex flex-col items-center py-4 absolute right-0 top-16 bottom-0 z-30">
+      <div className="w-14 bg-background flex flex-col items-center py-4 absolute right-0 top-0 bottom-0 z-30">
         <div className="flex flex-col items-center space-y-6 flex-1">
           {}
           <Button


### PR DESCRIPTION
### Motivation
- 让顶部栏在与右侧边栏交接处占据视觉主导并去掉那条短短的分隔线，以获得更连贯的界面显示。

### Description
- 在 `components/app/calendar.tsx` 中移除了主内容容器的 `pr-14`，以允许顶部栏延伸到最右侧并不再为空出右侧区域。 
- 在 `components/app/calendar.tsx` 的 `header` 中新增一个覆盖条 `div`：`pointer-events-none absolute right-0 bottom-0 h-px w-14 bg-background`，用于遮盖原先交界处的短线。 
- 在 `components/app/sidebar/right-sidebar.tsx` 中将右侧边栏定位从 `top-16` 调整为 `top-0`，并移除了 `border-l`，使侧栏从页面顶端起并由顶部栏在交接处覆盖显示。

### Testing
- 未运行任何自动化测试（按要求未进行 `eslint` 或测试套件执行）。

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69ab8badd42c833288dc365f4227bdaf)

## Summary by Sourcery

调整日历布局，使顶部栏在视觉上与右侧侧边栏重叠，在它们的连接处不再显示分隔线。

增强内容：
- 将日历的主体内容和页眉延伸到页面右边缘，并添加背景条带，以在视觉上覆盖与右侧侧边栏的连接处。
- 将右侧侧边栏对齐至从页面顶部开始，并移除其左边框，使其与顶部栏的衔接更为流畅自然。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Adjust the calendar layout so the top bar visually overlaps the right sidebar without a separating line at their junction.

Enhancements:
- Extend the calendar main content and header to the right edge and add a background strip to visually cover the junction with the right sidebar.
- Align the right sidebar to start from the top of the page and remove its left border for a more seamless integration with the top bar.

</details>