### PR TITLE
fix(auth): restore clerk oauth redirect compatibility and sw cache safety

### DIFF
--- a/app/(auth)/sign-in/sso-callback/page.tsx
+++ b/app/(auth)/sign-in/sso-callback/page.tsx
@@ -1,15 +1,12 @@
 'use client';
 
-import { AuthenticateWithRedirectCallback, useClerk } from '@clerk/nextjs';
+import { AuthenticateWithRedirectCallback } from '@clerk/nextjs';
 import { useEffect } from 'react';
 
 export default function SSOSignInCallback() {
-  const { setSession } = useClerk();
-
   useEffect(() => {
-    fetch("/api/atproto/logout", { method: "POST" }).catch(() => undefined);
-    setSession?.({ forceRedirectUrl: '/app' });
-  }, [setSession]);
+    fetch('/api/atproto/logout', { method: 'POST' }).catch(() => undefined);
+  }, []);
 
   return <AuthenticateWithRedirectCallback />;
 }

--- a/app/(auth)/sign-up/sso-callback/page.tsx
+++ b/app/(auth)/sign-up/sso-callback/page.tsx
@@ -1,15 +1,12 @@
 'use client';
 
-import { AuthenticateWithRedirectCallback, useClerk } from '@clerk/nextjs';
+import { AuthenticateWithRedirectCallback } from '@clerk/nextjs';
 import { useEffect } from 'react';
 
 export default function SSOSignUpCallback() {
-  const { setSession } = useClerk();
-
   useEffect(() => {
-    fetch("/api/atproto/logout", { method: "POST" }).catch(() => undefined);
-    setSession?.({ forceRedirectUrl: '/app' });
-  }, [setSession]);
+    fetch('/api/atproto/logout', { method: 'POST' }).catch(() => undefined);
+  }, []);
 
   return <AuthenticateWithRedirectCallback />;
 }

--- a/components/auth/login-form.tsx
+++ b/components/auth/login-form.tsx
@@ -14,7 +14,7 @@ export function LoginForm({
   className,
   ...props
 }: React.ComponentPropsWithoutRef<"div">) {
-  const { signIn, setActive } = useSignIn();
+  const { isLoaded, signIn, setActive } = useSignIn();
   const [email, setEmail] = useState("");
   const [password, setPassword] = useState("");
   const [isLoading, setIsLoading] = useState(false);
@@ -70,6 +70,11 @@ export function LoginForm({
     setError("");
 
     try {
+      if (!isLoaded || !signIn) {
+        setError("Auth service is still loading. Please try again in a moment.");
+        return;
+      }
+
       const result = await signIn.create({
         identifier: email,
         password,
@@ -102,7 +107,23 @@ export function LoginForm({
       setError("Please complete the CAPTCHA verification.");
       return;
     }
-    signIn.authenticateWithRedirect({
+
+    if (!isLoaded || !signIn) {
+      setError("Auth service is still loading. Please try again in a moment.");
+      return;
+    }
+
+    const redirect =
+      signIn.authenticateWithRedirect ??
+      (signIn as unknown as { authWithRedirect?: typeof signIn.authenticateWithRedirect })
+        .authWithRedirect;
+
+    if (!redirect) {
+      setError("OAuth is unavailable right now. Please refresh and try again.");
+      return;
+    }
+
+    redirect.call(signIn, {
       strategy,
       redirectUrl: "/sign-in/sso-callback",
       redirectUrlComplete: "/app",

--- a/components/auth/sign-up-form.tsx
+++ b/components/auth/sign-up-form.tsx
@@ -14,7 +14,7 @@ export function SignUpForm({
   className,
   ...props
 }: React.ComponentPropsWithoutRef<"div">) {
-  const { signUp, setActive } = useSignUp();
+  const { isLoaded, signUp, setActive } = useSignUp();
   const router = useRouter();
   const [step, setStep] = useState<"initial" | "verification">("initial");
   const [formData, setFormData] = useState({
@@ -135,7 +135,22 @@ export function SignUpForm({
       setError("Please complete the CAPTCHA verification.");
       return;
     }
-    signUp.authenticateWithRedirect({
+    if (!isLoaded || !signUp) {
+      setError("Auth service is still loading. Please try again in a moment.");
+      return;
+    }
+
+    const redirect =
+      signUp.authenticateWithRedirect ??
+      (signUp as unknown as { authWithRedirect?: typeof signUp.authenticateWithRedirect })
+        .authWithRedirect;
+
+    if (!redirect) {
+      setError("OAuth is unavailable right now. Please refresh and try again.");
+      return;
+    }
+
+    redirect.call(signUp, {
       strategy,
       redirectUrl: "/sign-up/sso-callback",
       redirectUrlComplete: "/app",
@@ -153,6 +168,11 @@ export function SignUpForm({
     setError("");
 
     try {
+      if (!isLoaded || !signUp) {
+        setError("Auth service is still loading. Please try again in a moment.");
+        return;
+      }
+
       if (step === "initial") {
         if (!isEmailDomainAllowed(formData.email)) {
           setError(

--- a/public/sw.js
+++ b/public/sw.js
@@ -27,6 +27,11 @@ self.addEventListener("activate", (event) => {
 self.addEventListener("fetch", (event) => {
   if (event.request.method !== "GET") return;
 
+  const requestUrl = new URL(event.request.url);
+  if (requestUrl.protocol !== "http:" && requestUrl.protocol !== "https:") {
+    return;
+  }
+
   event.respondWith(
     caches.match(event.request).then((cachedResponse) => {
       if (cachedResponse) {
@@ -39,9 +44,13 @@ self.addEventListener("fetch", (event) => {
             return networkResponse;
           }
 
+          if (networkResponse.type !== "basic") {
+            return networkResponse;
+          }
+
           const responseToCache = networkResponse.clone();
           caches.open(CACHE_NAME).then((cache) => {
-            cache.put(event.request, responseToCache);
+            cache.put(event.request, responseToCache).catch(() => undefined);
           });
 
           return networkResponse;


### PR DESCRIPTION
### Motivation
- Fix intermittent sign-in failures where Clerk frontend calls returned 400 due to calling auth methods before the Clerk client was ready. 
- Resolve OAuth runtime error `u.authwithredirect is not a function` caused by SDK method-name differences. 
- Prevent Service Worker runtime errors from `cache.put` or unsupported request/response types that can break offline caching.

### Description
- Add Clerk readiness guards by using `isLoaded` and checking `signIn`/`signUp` before calling auth methods in `components/auth/login-form.tsx` and `components/auth/sign-up-form.tsx` to avoid init race conditions. 
- Add a compatibility fallback for OAuth redirect calls by preferring `authenticateWithRedirect` and falling back to `authWithRedirect`, then invoking via `redirect.call(...)` to support different Clerk SDK variants. 
- Simplify SSO callback pages by removing `setSession` usage and keeping only `AuthenticateWithRedirectCallback` plus the `atproto` logout side effect in `app/(auth)/sign-in/sso-callback/page.tsx` and `app/(auth)/sign-up/sso-callback/page.tsx`. 
- Harden the service worker `public/sw.js` to skip non-HTTP(S) requests, only cache same-origin/basic responses, and swallow `cache.put` failures to avoid uncaught runtime exceptions.

### Testing
- Verified working tree and diffs with `git status --short` and `git diff` showing changes to `components/auth/login-form.tsx`, `components/auth/sign-up-form.tsx`, `app/(auth)/sign-in/sso-callback/page.tsx`, `app/(auth)/sign-up/sso-callback/page.tsx`, and `public/sw.js`. 
- Committed changes successfully with message `fix(auth): restore clerk oauth redirect compatibility and sw cache safety`. 
- No ESLint or automated test suites were run per repository instruction (no automated tests executed).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69accdcd357483329a4d102ba255aee8)

## Summary by Sourcery

改进基于 Clerk 的身份验证健壮性、OAuth 重定向兼容性以及 Service Worker 缓存的安全性。

Bug 修复：
- 防止在 Clerk 客户端完全加载之前，登录和注册流程调用 Clerk 认证方法，从而避免间歇性的 400 错误。
- 通过同时支持 `authenticateWithRedirect` 和旧版的 `authWithRedirect` 进行 OAuth 重定向，恢复与不同 Clerk SDK 版本的兼容性。
- 通过忽略非 HTTP(S) 的 fetch 请求、仅缓存同源的 basic 响应，并吞掉 `cache.put` 错误，避免 Service Worker 在运行时发生故障。
- 简化 SSO 回调处理，仅依赖 `AuthenticateWithRedirectCallback`，同时保留对 ATProto 的登出副作用，从而防止潜在的重定向/会话问题。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Improve Clerk-based authentication robustness, OAuth redirect compatibility, and service worker caching safety.

Bug Fixes:
- Prevent login and signup flows from calling Clerk auth methods before the client is fully loaded to avoid intermittent 400 errors.
- Restore compatibility with different Clerk SDK versions by supporting both `authenticateWithRedirect` and legacy `authWithRedirect` for OAuth redirects.
- Avoid service worker runtime failures by ignoring non-HTTP(S) fetch requests, only caching same-origin basic responses, and swallowing `cache.put` errors.
- Simplify SSO callback handling to rely solely on `AuthenticateWithRedirectCallback` while preserving the ATProto logout side effect, preventing potential redirect/session issues.

</details>