### PR TITLE
fix(calendar): apply persisted default view only once to avoid overriding manual switches

### DIFF
--- a/components/app/calendar.tsx
+++ b/components/app/calendar.tsx
@@ -92,6 +92,12 @@ type ViewType =
   | "analytics"
   | "settings";
 
+const isCalendarView = (
+  view: string,
+): view is "day" | "week" | "four-day" | "month" | "year" => {
+  return ["day", "week", "four-day", "month", "year"].includes(view);
+};
+
 export interface CalendarEvent {
   id: string;
   title: string;
@@ -183,11 +189,12 @@ export default function Calendar({ className, ...props }: CalendarProps) {
   const [toastPosition, setToastPosition] = useLocalStorage<
     "bottom-left" | "bottom-center" | "bottom-right"
   >("toast-position", "bottom-right");
+  const hasAppliedDefaultView = useRef(false);
 
   useEffect(() => {
-    if (view !== defaultView) {
-      setView(defaultView as ViewType);
-    }
+    if (hasAppliedDefaultView.current) return;
+    setView(isCalendarView(defaultView) ? defaultView : "week");
+    hasAppliedDefaultView.current = true;
   }, [defaultView]);
 
   useEffect(() => {


### PR DESCRIPTION
### Motivation
- Persisted `default-view` could be reapplied whenever storage/backup state refreshed, which caused the UI to jump back to the saved view after a user manually switched views.

### Description
- Add a strict calendar view guard function `isCalendarView` and a `hasAppliedDefaultView` ref, and change the initialization effect to apply the persisted `default-view` only once on mount while falling back to `week` for invalid values.
- Change implemented in `components/app/calendar.tsx` (initial view hydration logic and type guard added).

### Testing
- No automated tests were run locally; the change is small and will be exercised by the repository CI when available.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69acd6c5886c8332a35c8e8ed771eb53)

## 由 Sourcery 生成的摘要

确保日历只在挂载（mount）时应用一次持久化的默认视图，并在需要时回退到有效视图。

Bug 修复：
- 通过仅在首次加载时应用存储的默认视图，防止用户手动切换视图后，日历又恢复为持久化的默认视图。
- 校验存储的默认视图，当持久化的值无效时，回退到周视图。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Ensure the calendar applies the persisted default view only once on mount and falls back to a valid view when needed.

Bug Fixes:
- Prevent the calendar from reverting to the persisted default view after users manually switch views by applying the stored default only once.
- Validate the stored default view and fall back to the week view when the persisted value is invalid.

</details>