### PR TITLE
fix(settings): persist week start and default view updates

### DIFF
--- a/hooks/useLocalStorage.ts
+++ b/hooks/useLocalStorage.ts
@@ -221,9 +221,9 @@ export async function writeEncryptedLocalStorage<T>(key: string, value: T) {
   if (typeof window === "undefined") return
   try {
     const raw = JSON.stringify(value)
+    inMemoryStorage.set(key, raw)
     if (ENCRYPTION_STATE.enabled && ENCRYPTION_STATE.password) {
       if (isSensitiveStorageKey(key)) {
-        inMemoryStorage.set(key, raw)
         encryptedSnapshots.set(key, { value: raw, failed: false })
         window.localStorage.removeItem(key)
         emitStorageWrite(key)
@@ -290,9 +290,9 @@ async function writeLocalStorage<T>(key: string, value: T) {
   if (typeof window === "undefined") return
   try {
     const raw = JSON.stringify(value)
+    inMemoryStorage.set(key, raw)
     if (ENCRYPTION_STATE.enabled && ENCRYPTION_STATE.password) {
       if (isSensitiveStorageKey(key)) {
-        inMemoryStorage.set(key, raw)
         encryptedSnapshots.set(key, { value: raw, failed: false })
         window.localStorage.removeItem(key)
         emitStorageWrite(key)


### PR DESCRIPTION
### Motivation

- Users reported `first-day-of-week` and `default-view` would revert after toggling due to a stale in-memory cache overriding new writes. 
- The change ensures setting toggles are immediately persisted locally and remain in-sync with the backup flow so toggles do not bounce back.

### Description

- Added `inMemoryStorage.set(key, raw)` at the start of `writeEncryptedLocalStorage` to update the memory cache before any encryption/localStorage actions in `hooks/useLocalStorage.ts`.
- Added `inMemoryStorage.set(key, raw)` at the start of the internal `writeLocalStorage` function to mirror the same behavior for non-encrypted writes.
- Kept existing behavior for `encryptedSnapshots` and `emitStorageWrite`, so backups and subscribers are still notified as before.

### Testing

- Performed repository validation commands: `git diff -- hooks/useLocalStorage.ts` which showed the intended changes, `git status --short`, and committed the change with `git commit` (succeeded).
- Inspected updated lines with `nl -ba hooks/useLocalStorage.ts | sed -n '214,312p'` to verify the new `inMemoryStorage` writes (succeeded).
- No unit or lint tests were run per repository instructions; validation was limited to static inspection and commit checks (all succeeded).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69b4c45856e88332968603c66ad6b086)

## Summary by Sourcery

Bug Fixes:
- 通过在更新内存缓存的同时同步写入加密和未加密的 localStorage，防止“每周第一天”和“默认视图”设置被重置。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Bug Fixes:
- Prevent first-day-of-week and default-view settings from reverting by synchronizing in-memory cache updates with encrypted and non-encrypted localStorage writes.

</details>