### PR TITLE
fix(backup): persist restored settings and harden blob api errors

### DIFF
--- a/app/api/blob/route.ts
+++ b/app/api/blob/route.ts
@@ -6,14 +6,23 @@ import { deleteRecord, getRecord, putRecord } from "@/lib/atproto";
 
 export const runtime = "nodejs";
 
+const postgresUrl = process.env.POSTGRES_URL;
+const useSsl =
+  postgresUrl &&
+  !/localhost|127\.0\.0\.1/.test(postgresUrl) &&
+  !/sslmode=disable/.test(postgresUrl);
+
 const pool = new Pool({
-  connectionString: process.env.POSTGRES_URL,
-  ssl: { rejectUnauthorized: false }
+  connectionString: postgresUrl,
+  ssl: useSsl ? { rejectUnauthorized: false } : undefined,
 });
 
 let inited = false;
 
 async function initDB() {
+  if (!postgresUrl) {
+    throw new Error("POSTGRES_URL is not configured");
+  }
   if (inited) return;
   const client = await pool.connect();
   try {
@@ -94,10 +103,66 @@ export async function POST(req: NextRequest) {
 }
 
 export async function GET() {
-  const atproto = await getAtprotoSession();
-  if (atproto) {
+  try {
+    const atproto = await getAtprotoSession();
+    if (atproto) {
+      try {
+        const record = await getRecord({
+          pds: atproto.pds,
+          repo: atproto.did,
+          collection: ATPROTO_BACKUP_COLLECTION,
+          rkey: ATPROTO_BACKUP_RKEY,
+          accessToken: atproto.accessToken,
+          dpopPrivateKeyPem: atproto.dpopPrivateKeyPem,
+          dpopPublicJwk: atproto.dpopPublicJwk,
+        });
+        const value = record.value ?? {};
+        return NextResponse.json({
+          ciphertext: value.ciphertext,
+          iv: value.iv,
+          timestamp: value.updatedAt,
+          backend: "atproto",
+        });
+      } catch {
+        return NextResponse.json({ error: "Not found" }, { status: 404 });
+      }
+    }
+
+    const user = await currentUser();
+    if (!user)
+      return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
+
+    await initDB();
+
+    const client = await pool.connect();
     try {
-      const record = await getRecord({
+      const result = await client.query(
+        `SELECT encrypted_data, iv, timestamp FROM calendar_backups WHERE user_id = $1`,
+        [user.id],
+      );
+      if (result.rowCount === 0)
+        return NextResponse.json({ error: "Not found" }, { status: 404 });
+
+      return NextResponse.json({
+        ciphertext: result.rows[0].encrypted_data,
+        iv: result.rows[0].iv,
+        timestamp: result.rows[0].timestamp,
+        backend: "postgres",
+      });
+    } finally {
+      client.release();
+    }
+  } catch (e: unknown) {
+    const message = e instanceof Error ? e.message : "Internal error";
+    return NextResponse.json({ error: message }, { status: 500 });
+  }
+}
+
+export async function DELETE() {
+  try {
+    const atproto = await getAtprotoSession();
+    if (atproto) {
+      await deleteRecord({
         pds: atproto.pds,
         repo: atproto.did,
         collection: ATPROTO_BACKUP_COLLECTION,
@@ -106,67 +171,26 @@ export async function GET() {
         dpopPrivateKeyPem: atproto.dpopPrivateKeyPem,
         dpopPublicJwk: atproto.dpopPublicJwk,
       });
-      const value = record.value ?? {};
-      return NextResponse.json({
-        ciphertext: value.ciphertext,
-        iv: value.iv,
-        timestamp: value.updatedAt,
-        backend: "atproto",
-      });
-    } catch {
-      return NextResponse.json({ error: "Not found" }, { status: 404 });
+      return NextResponse.json({ success: true, backend: "atproto" });
     }
-  }
 
-  const user = await currentUser();
-  if (!user) return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
+    const user = await currentUser();
+    if (!user)
+      return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
 
-  await initDB();
+    await initDB();
 
-  const client = await pool.connect();
-  try {
-    const result = await client.query(
-      `SELECT encrypted_data, iv, timestamp FROM calendar_backups WHERE user_id = $1`,
-      [user.id],
-    );
-    if (result.rowCount === 0) return NextResponse.json({ error: "Not found" }, { status: 404 });
-
-    return NextResponse.json({
-      ciphertext: result.rows[0].encrypted_data,
-      iv: result.rows[0].iv,
-      timestamp: result.rows[0].timestamp,
-      backend: "postgres",
-    });
-  } finally {
-    client.release();
-  }
-}
-
-export async function DELETE() {
-  const atproto = await getAtprotoSession();
-  if (atproto) {
-    await deleteRecord({
-      pds: atproto.pds,
-      repo: atproto.did,
-      collection: ATPROTO_BACKUP_COLLECTION,
-      rkey: ATPROTO_BACKUP_RKEY,
-      accessToken: atproto.accessToken,
-      dpopPrivateKeyPem: atproto.dpopPrivateKeyPem,
-      dpopPublicJwk: atproto.dpopPublicJwk,
-    });
-    return NextResponse.json({ success: true, backend: "atproto" });
-  }
-
-  const user = await currentUser();
-  if (!user) return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
-
-  await initDB();
-
-  const client = await pool.connect();
-  try {
-    await client.query(`DELETE FROM calendar_backups WHERE user_id = $1`, [user.id]);
-    return NextResponse.json({ success: true, backend: "postgres" });
-  } finally {
-    client.release();
+    const client = await pool.connect();
+    try {
+      await client.query(`DELETE FROM calendar_backups WHERE user_id = $1`, [
+        user.id,
+      ]);
+      return NextResponse.json({ success: true, backend: "postgres" });
+    } finally {
+      client.release();
+    }
+  } catch (e: unknown) {
+    const message = e instanceof Error ? e.message : "Internal error";
+    return NextResponse.json({ error: message }, { status: 500 });
   }
 }

--- a/components/app/profile/user-profile-button.tsx
+++ b/components/app/profile/user-profile-button.tsx
@@ -57,6 +57,7 @@ import {
 import {
   readInMemoryStorage,
   clearEncryptionPassword,
+  isSensitiveStorageKey,
   markEncryptedSnapshot,
   readEncryptedLocalStorage,
   setEncryptionPassword,
@@ -134,6 +135,12 @@ async function applyCloudStorageToMemory(
       }
       writeInMemoryStorage(key, normalized);
       markEncryptedSnapshot(key, normalized);
+      if (!isSensitiveStorageKey(key)) {
+        localStorage.setItem(key, normalized);
+      }
+      window.dispatchEvent(
+        new CustomEvent("local-storage-written", { detail: { key } }),
+      );
     }),
   );
 }


### PR DESCRIPTION
### Motivation
- Restored user settings (language, default view, first day of week, etc.) were not being persisted back to `localStorage` after a cloud restore, causing the app to revert to old settings on reload and preventing correct re-backup.
- The `/api/blob` endpoint could throw unclear 500s due to unconditional SSL forcing for local Postgres and uncaught runtime errors during `GET`/`DELETE` flows.

### Description
- Persist non-sensitive restored keys from cloud backups into `localStorage` and dispatch a `local-storage-written` event inside `applyCloudStorageToMemory` so restored settings take effect immediately and trigger downstream updates (`components/app/profile/user-profile-button.tsx`).
- Import and use `isSensitiveStorageKey` to avoid writing sensitive keys to `localStorage` during restore (`components/app/profile/user-profile-button.tsx`).
- Introduce `postgresUrl` and compute `useSsl` to avoid forcing SSL for local Postgres instances, and throw a clear error when `POSTGRES_URL` is missing (`app/api/blob/route.ts`).
- Wrap `GET` and `DELETE` handlers in top-level `try/catch` blocks to return explicit JSON error messages and avoid uncaught 500 crashes, and adjust Postgres query flow for robust behavior (`app/api/blob/route.ts`).

### Testing
- No automated tests were executed for this change per the request to skip `eslint` and test runs.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69b4ddb483388332b453b64a47b9ba6f)

## Summary by Sourcery

确保恢复的设置会在本地持久化，并加固 blob 备份 API 的数据库和错误处理。

Bug 修复：
- 将从云备份中恢复的非敏感设置重新写入到 localStorage，以便在页面刷新后仍然存在，并能够在整个应用中传播。
- 通过验证 POSTGRES_URL 配置并在本地 Postgres 实例上避免强制启用 SSL，防止 blob 备份 API 出现不明确的 500 错误。
- 通过在缺少备份记录、认证失败和运行时错误时返回明确的 JSON 响应，提高 /api/blob GET 和 DELETE 的健壮性。

增强功能：
- 在写入恢复的设置到本地存储时派发一个 local-storage-written 事件，以便下游监听者可以立即更新。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Ensure restored settings are persisted locally and harden the blob backup API’s database and error handling.

Bug Fixes:
- Persist non-sensitive settings restored from cloud backups back into localStorage so they survive reloads and propagate through the app.
- Prevent unclear 500 errors from the blob backup API by validating POSTGRES_URL configuration and avoiding SSL enforcement for local Postgres instances.
- Improve /api/blob GET and DELETE robustness by handling missing backup records, auth failures, and runtime errors with explicit JSON responses.

Enhancements:
- Dispatch a local-storage-written event when writing restored settings so downstream listeners update immediately.

</details>