### PR TITLE
fix(settings): sync restored default view and stabilize week start selection

### DIFF
--- a/components/app/calendar.tsx
+++ b/components/app/calendar.tsx
@@ -136,6 +136,11 @@ export default function Calendar({ className, ...props }: CalendarProps) {
     "first-day-of-week",
     0,
   );
+  const normalizedFirstDayOfWeek = firstDayOfWeek === 1 ? 1 : 0;
+
+  const handleFirstDayOfWeekChange = (day: number) => {
+    setFirstDayOfWeek(day === 1 ? 1 : 0);
+  };
   const [timezone, setTimezone] = useLocalStorage<string>(
     "timezone",
     Intl.DateTimeFormat().resolvedOptions().timeZone,
@@ -189,12 +194,8 @@ export default function Calendar({ className, ...props }: CalendarProps) {
   const [toastPosition, setToastPosition] = useLocalStorage<
     "bottom-left" | "bottom-center" | "bottom-right"
   >("toast-position", "bottom-right");
-  const hasAppliedDefaultView = useRef(false);
-
   useEffect(() => {
-    if (hasAppliedDefaultView.current) return;
     setView(isCalendarView(defaultView) ? defaultView : "week");
-    hasAppliedDefaultView.current = true;
   }, [defaultView]);
 
   useEffect(() => {
@@ -915,7 +916,7 @@ export default function Calendar({ className, ...props }: CalendarProps) {
                 onEventClick={handleEventClick}
                 onTimeSlotClick={handleTimeRangeSelect}
                 language={language}
-                firstDayOfWeek={firstDayOfWeek}
+                firstDayOfWeek={normalizedFirstDayOfWeek}
                 timezone={timezone}
                 timeFormat={timeFormat}
                 onEditEvent={handleEventEdit}
@@ -942,7 +943,7 @@ export default function Calendar({ className, ...props }: CalendarProps) {
                 onEventClick={handleEventClick}
                 onTimeSlotClick={handleTimeRangeSelect}
                 language={language}
-                firstDayOfWeek={firstDayOfWeek}
+                firstDayOfWeek={normalizedFirstDayOfWeek}
                 timezone={timezone}
                 timeFormat={timeFormat}
                 onEditEvent={handleEventEdit}
@@ -970,7 +971,7 @@ export default function Calendar({ className, ...props }: CalendarProps) {
                 events={filteredEvents}
                 onEventClick={handleEventClick}
                 language={language}
-                firstDayOfWeek={firstDayOfWeek}
+                firstDayOfWeek={normalizedFirstDayOfWeek}
                 timezone={timezone}
               />
             )}
@@ -980,7 +981,7 @@ export default function Calendar({ className, ...props }: CalendarProps) {
                 events={filteredEvents}
                 onEventClick={handleEventClick}
                 language={language}
-                firstDayOfWeek={firstDayOfWeek}
+                firstDayOfWeek={normalizedFirstDayOfWeek}
                 isSidebarCollapsed={isSidebarCollapsed}
                 isSidebarExpanding={isSidebarExpanding}
               />
@@ -999,8 +1000,8 @@ export default function Calendar({ className, ...props }: CalendarProps) {
               <Settings
                 language={language}
                 setLanguage={setLanguage}
-                firstDayOfWeek={firstDayOfWeek}
-                setFirstDayOfWeek={setFirstDayOfWeek}
+                firstDayOfWeek={normalizedFirstDayOfWeek}
+                setFirstDayOfWeek={handleFirstDayOfWeekChange}
                 timezone={timezone}
                 setTimezone={setTimezone}
                 notificationSound={notificationSound}

--- a/components/app/profile/settings.tsx
+++ b/components/app/profile/settings.tsx
@@ -193,7 +193,9 @@ export default function Settings({
           <Label htmlFor="first-day">{t.firstDayOfWeek}</Label>
           <Select
             value={firstDayOfWeek.toString()}
-            onValueChange={(value) => setFirstDayOfWeek(Number.parseInt(value))}
+            onValueChange={(value) =>
+              setFirstDayOfWeek(value === "1" ? 1 : 0)
+            }
           >
             <SelectTrigger id="first-day">
               <SelectValue />


### PR DESCRIPTION
### Motivation
- 修复解锁云端备份后主视图未切换到云端 `default-view` 的问题，使恢复的数据能即时生效。
- 修复“每周第一天”切换时会自动跳回的问题，避免异常或非 0/1 值导致视图回退。
- 统一视图组件与设置之间的 `first-day-of-week` 行为，确保周/月/年视图与设置控件一致。

### Description
- 移除只在首次挂载时应用默认视图的保护逻辑，改为在 `default-view` 发生变化时总是调用 `setView`，文件：`components/app/calendar.tsx`。 
- 在日历层新增 `normalizedFirstDayOfWeek` 并添加 `handleFirstDayOfWeekChange`，将 `first-day-of-week` 约束并规范为 `0 | 1`，文件：`components/app/calendar.tsx`。 
- 将所有子视图（`WeekView`/`MonthView`/`YearView` 等）和设置页传递的 `firstDayOfWeek` 替换为归一化后的 `normalizedFirstDayOfWeek` 和规范化 setter，文件：`components/app/calendar.tsx`。 
- 加固设置页的选择器，把 `onValueChange` 映射为 `value === "1" ? 1 : 0` 以避免边界解析问题，文件：`components/app/profile/settings.tsx`。

### Testing
- 未运行自动化单元或集成测试（按请求不执行 `eslint` / 测试套件）。
- 代码变更已提交为 `d62d5df`（commit message: `fix(settings): sync restored default view and stabilize week start selection`）。

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69b4e45164a883329cc7daeae4ad06be)

## Summary by Sourcery

同步日历视图与设置行为，以统一默认视图选择与周起始日配置。

Bug Fixes（错误修复）:
- 确保在默认视图设置发生变化时（包括从云备份恢复之后），日历会切换到恢复的默认视图。
- 在整个日历和设置中，将周起始日的取值规范化为 0 或 1，以防止周起始日选择被重置或表现不一致。

Enhancements（改进）:
- 统一周视图、月视图、年视图以及设置面板，全部使用规范化的周起始日取值和受约束的设置方法，以确保行为一致。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Synchronize calendar view and settings behavior for default view selection and week start configuration.

Bug Fixes:
- Ensure the calendar switches to the restored default view whenever the default-view setting changes, including after cloud backup restore.
- Normalize first-day-of-week values to 0 or 1 throughout the calendar and settings to prevent the week start selection from reverting or behaving inconsistently.

Enhancements:
- Unify week, month, year views and the settings panel to all consume a normalized first-day-of-week value and constrained setter for consistent behavior.

</details>