### PR TITLE
fix(backup): apply restored default view and first-day settings

### DIFF
--- a/components/app/profile/user-profile-button.tsx
+++ b/components/app/profile/user-profile-button.tsx
@@ -59,6 +59,7 @@ import {
   clearEncryptionPassword,
   isSensitiveStorageKey,
   markEncryptedSnapshot,
+  removeInMemoryStorage,
   readEncryptedLocalStorage,
   setEncryptionPassword,
   writeInMemoryStorage,
@@ -136,6 +137,7 @@ async function applyCloudStorageToMemory(
       writeInMemoryStorage(key, normalized);
       markEncryptedSnapshot(key, normalized);
       if (!isSensitiveStorageKey(key)) {
+        removeInMemoryStorage(key);
         localStorage.setItem(key, normalized);
       }
       window.dispatchEvent(

--- a/hooks/useLocalStorage.ts
+++ b/hooks/useLocalStorage.ts
@@ -110,6 +110,10 @@ export function writeInMemoryStorage(key: string, value: string) {
   inMemoryStorage.set(key, value)
 }
 
+export function removeInMemoryStorage(key: string) {
+  inMemoryStorage.delete(key)
+}
+
 export function readInMemoryStorage(key: string) {
   return inMemoryStorage.get(key) ?? null
 }
@@ -175,7 +179,7 @@ export async function readEncryptedLocalStorage<T>(key: string, initialValue: T)
   }
   try {
     const inMemoryValue = inMemoryStorage.get(key)
-    if (inMemoryValue !== undefined) {
+    if (isSensitiveStorageKey(key) && inMemoryValue !== undefined) {
       return coerceStoredValue(inMemoryValue, initialValue)
     }
     const snapshot = encryptedSnapshots.get(key)
@@ -250,7 +254,7 @@ async function readLocalStorage<T>(key: string, initialValue: T): Promise<T> {
   }
   try {
     const inMemoryValue = inMemoryStorage.get(key)
-    if (inMemoryValue !== undefined) {
+    if (isSensitiveStorageKey(key) && inMemoryValue !== undefined) {
       return coerceStoredValue(inMemoryValue, initialValue)
     }
     const item = window.localStorage.getItem(key)


### PR DESCRIPTION
### Motivation
- Restored cloud settings (`default-view`, `first-day-of-week`) did not take effect after unlocking because in-memory storage values shadowed localStorage writes and caused the UI to revert immediately.

### Description
- Added `removeInMemoryStorage` to `hooks/useLocalStorage.ts` to allow clearing in-memory shadow entries.
- Updated `readEncryptedLocalStorage` and `readLocalStorage` to only consider `inMemoryStorage` for sensitive keys so non-sensitive settings read from `localStorage` correctly.
- When applying cloud backups in `components/app/profile/user-profile-button.tsx`, clear the in-memory entry for non-sensitive keys before writing to `localStorage` to ensure restored settings persist and are observed by consumers.

### Testing
- Ran `git status --short` and `git show --stat --oneline HEAD` to validate files staged and commit summary, both succeeded.  
- Manually inspected the unlock/restore code path and `useLocalStorage` precedence to confirm restored `default-view` and `first-day-of-week` are written to and read from `localStorage` as intended.  
- Did not run automated test suite or `eslint` per project instructions; no automated tests were executed.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69b4f6caed14833299fbae541573ef8b)

## Summary by Sourcery

确保恢复的云备份设置能够正确持久化，并从 localStorage 中读取，而不会被内存中的值覆盖。

Bug 修复：
- 修复解锁后恢复的默认视图和“每周第一天”设置未生效的问题，原因是内存存储遮蔽了 localStorage 中的值。

改进：
- 限制在从加密和普通 localStorage 读取时，只有敏感键才优先生效于内存存储。
- 添加一个用于移除内存存储条目的 API，并在应用非敏感云备份设置、写入 localStorage 之前使用该 API。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Ensure restored cloud backup settings correctly persist and are read from localStorage instead of being overridden by in-memory values.

Bug Fixes:
- Fix restored default view and first-day-of-week settings not taking effect after unlock due to in-memory storage shadowing localStorage values.

Enhancements:
- Restrict in-memory storage precedence to sensitive keys only when reading from encrypted and regular localStorage.
- Add an API to remove in-memory storage entries and use it when applying non-sensitive cloud backup settings before writing to localStorage.

</details>