### PR TITLE
feat(landing): redesign page with anti-template aesthetic

### DIFF
--- a/app/globals.css
+++ b/app/globals.css
@@ -107,6 +107,30 @@ body {
   animation: landing-title-in-view 1300ms cubic-bezier(0.22, 1, 0.36, 1) both;
 }
 
+.landing-surface {
+  background:
+    radial-gradient(circle at 12% 8%, rgb(210 120 50 / 0.22), transparent 36%),
+    radial-gradient(circle at 80% 22%, rgb(124 83 38 / 0.2), transparent 38%),
+    linear-gradient(145deg, #0f0c09 0%, #0d0b08 52%, #15100b 100%);
+  position: relative;
+}
+
+.landing-surface::before {
+  content: "";
+  position: fixed;
+  inset: 0;
+  pointer-events: none;
+  opacity: 0.2;
+  background-image: radial-gradient(rgb(255 238 218 / 0.4) 0.5px, transparent 0.5px);
+  background-size: 3px 3px;
+}
+
+.landing-scratch-card {
+  border: 1px solid var(--landing-line);
+  background: linear-gradient(160deg, rgb(37 28 20 / 0.9), rgb(25 18 12 / 0.92));
+  box-shadow: inset 0 1px 0 rgb(255 255 255 / 0.05);
+}
+
 @layer components {
   .cn-toast {
     background-color: hsl(var(--popover));
@@ -118,11 +142,15 @@ body {
 
 @layer base {
   :root {
-    --landing-bg: #080808;
-    --landing-panel: #0b0b0b;
-    --landing-text: #ffffff;
-    --landing-muted: #9b9b9b;
-    --landing-subtle: #6f6f6f;
+    --landing-bg: #0d0b08;
+    --landing-panel: #17120d;
+    --landing-panel-soft: #1d1711;
+    --landing-text: #f8efe5;
+    --landing-muted: #c8b6a1;
+    --landing-subtle: #a18870;
+    --landing-line: #4e3d2e;
+    --landing-accent: #efb16f;
+    --landing-ink: #22170d;
     --background: 0 0% 100%;
     --foreground: 0 0% 3.9%;
     --card: 0 0% 100%;

--- a/app/page.tsx
+++ b/app/page.tsx
@@ -13,8 +13,8 @@ import {
 
 export default function LandingPage() {
   return (
-    <main className="min-h-screen bg-[var(--landing-bg)] text-[var(--landing-text)]">
-      <div className="mx-auto flex w-full max-w-7xl flex-col px-6 md:px-10">
+    <main className="landing-surface min-h-screen text-[var(--landing-text)]">
+      <div className="mx-auto flex w-full max-w-7xl flex-col px-5 md:px-10">
         <LandingHeader />
         <LandingHero />
         <LandingFeatures />

--- a/components/landing/cta.tsx
+++ b/components/landing/cta.tsx
@@ -1,31 +1,36 @@
 export function LandingCta() {
   return (
-    <section className="py-24 text-center md:py-28">
-      <p className="text-xs uppercase tracking-[0.28em] text-[var(--landing-subtle)]">
-        Ready to simplify planning
-      </p>
-      <h2 className="mx-auto mt-4 max-w-3xl text-4xl font-semibold leading-tight text-white md:text-6xl">
-        Your time. Your data. Yours.
-      </h2>
-      <p className="mx-auto mt-4 max-w-2xl text-sm text-[var(--landing-muted)] md:text-base">
-        Keep your schedule clear with privacy-first defaults, portable formats,
-        and dependable sync.
-      </p>
-      <div className="mt-8 flex flex-wrap justify-center gap-3">
-        <a
-          href="/sign-up"
-          aria-label="Create your free account"
-          className="rounded-md bg-white px-6 py-2.5 text-sm font-medium text-black transition duration-200 hover:-translate-y-0.5 hover:brightness-110"
-        >
-          Start free
-        </a>
-        <a
-          href="https://docs.xyehr.cn/docs/one-calendar"
-          aria-label="Read product documentation"
-          className="rounded-md border border-white/20 px-6 py-2.5 text-sm text-[var(--landing-muted)] transition duration-200 hover:-translate-y-0.5 hover:border-white/35 hover:text-white"
-        >
-          Read docs
-        </a>
+    <section className="py-24 md:py-28">
+      <div className="grid gap-8 border border-[var(--landing-line)] bg-[var(--landing-panel-soft)] p-7 md:grid-cols-[1.3fr_0.7fr] md:p-10">
+        <div>
+          <p className="text-xs uppercase tracking-[0.22em] text-[var(--landing-subtle)]">
+            ready when you are
+          </p>
+          <h2 className="mt-4 max-w-3xl text-4xl font-semibold leading-tight text-[var(--landing-text)] md:text-6xl">
+            Own your schedule,
+            <br />
+            not someone else’s dashboard.
+          </h2>
+          <p className="mt-4 max-w-2xl text-sm text-[var(--landing-muted)] md:text-base">
+            现在开始，把时间管理拉回你手里。没有花哨流程，只有能落地的日程动作。
+          </p>
+        </div>
+        <div className="flex flex-col items-start justify-end gap-3 md:items-end">
+          <a
+            href="/sign-up"
+            aria-label="Create your free account"
+            className="rounded-sm border border-[var(--landing-accent)] bg-[var(--landing-accent)] px-6 py-2.5 text-sm font-semibold text-[var(--landing-ink)] transition-transform duration-300 [transition-timing-function:cubic-bezier(0.2,0.9,0.2,1)] hover:-translate-y-0.5"
+          >
+            start free
+          </a>
+          <a
+            href="https://docs.xyehr.cn/docs/one-calendar"
+            aria-label="Read product documentation"
+            className="rounded-sm border border-[var(--landing-line)] px-6 py-2.5 text-sm text-[var(--landing-muted)] transition-transform duration-300 [transition-timing-function:cubic-bezier(0.2,0.9,0.2,1)] hover:translate-x-1 hover:text-[var(--landing-text)]"
+          >
+            read docs
+          </a>
+        </div>
       </div>
     </section>
   );

--- a/components/landing/faq.tsx
+++ b/components/landing/faq.tsx
@@ -1,81 +1,55 @@
-import {
-  Accordion,
-  AccordionContent,
-  AccordionItem,
-  AccordionTrigger,
-} from "@/components/ui/accordion";
 import { LandingTitle } from "./title";
 
 const faqItems = [
   {
-    q: "What is One Calendar’s core product focus?",
-    a: "One Calendar is an open-source, privacy-first calendar focused on planning clarity, fast interaction, and long-term data control.",
+    q: "One Calendar 最核心解决什么问题？",
+    a: "它把排程做回基础动作：快、清楚、可迁移。你不必先学习一套复杂系统。",
   },
   {
-    q: "Which import/export formats are supported?",
-    a: "The product supports iCalendar (.ics), JSON, and CSV import/export workflows for easier migration and backup.",
+    q: "支持哪些导入导出格式？",
+    a: "支持 .ics、JSON、CSV。迁移和备份都可以直接做。",
   },
   {
-    q: "Does it support end-to-end encryption?",
-    a: "Yes. End-to-end encryption (E2EE) is available as an optional capability for privacy-sensitive schedules.",
+    q: "隐私是可选项还是默认项？",
+    a: "默认不追踪。端到端加密可以按需开启，用于敏感日程。",
   },
   {
-    q: "What powers cloud sync and authentication?",
-    a: "Cloud sync is optional and PostgreSQL-based, while authentication is handled through Clerk.",
+    q: "是否适合团队协作？",
+    a: "适合。发布节奏、里程碑、跨时区会议都能在同一时间线上管理。",
   },
   {
-    q: "Can I move my data away from One Calendar?",
-    a: "Yes. Portability is a key principle, so your data can be exported and moved across tools without lock-in.",
-  },
-  {
-    q: "Is it suitable for team workflows?",
-    a: "Yes. It works well for release planning, recurring team meetings, milestone tracking, and cross-time-zone coordination.",
-  },
-  {
-    q: "How is the mobile experience?",
-    a: "The landing and core interfaces are responsive. Mobile prioritizes quick access, while desktop emphasizes editing speed.",
-  },
-  {
-    q: "Are keyboard shortcuts and fast editing supported?",
-    a: "Yes. One Calendar is designed for high-frequency operation with keyboard shortcuts and low-friction edits.",
-  },
-  {
-    q: "Is the project open-source and self-hostable?",
-    a: "Yes. The codebase is open-source and can be reviewed, deployed, and extended according to your needs.",
-  },
-  {
-    q: "Is it a good fit for individual users?",
-    a: "Absolutely. It works for study plans, health routines, family schedules, travel planning, and personal project timelines.",
+    q: "可以自托管或二次开发吗？",
+    a: "可以。项目开源，你可以审查、部署和扩展。",
   },
 ];
 
 export function LandingFaq() {
   return (
-    <section id="faq" className="border-b border-white/10 py-24 md:py-28">
-      <div className="grid w-full gap-8 md:grid-cols-[300px_1fr]">
+    <section id="faq" className="border-b border-[var(--landing-line)] py-24 md:py-28">
+      <div className="grid w-full gap-10 md:grid-cols-[0.65fr_1.35fr]">
         <LandingTitle
           as="h2"
-          className="text-3xl font-semibold text-white md:text-5xl"
+          className="text-3xl font-semibold text-[var(--landing-text)] md:text-5xl"
         >
           FAQ
         </LandingTitle>
-        <div className="px-0 md:px-2">
-          <Accordion type="single" collapsible className="w-full">
-            {faqItems.map((item, idx) => (
-              <AccordionItem
-                key={item.q}
-                value={`faq-${idx}`}
-                className="border-white/10"
-              >
-                <AccordionTrigger className="py-5 text-left text-base font-medium text-white hover:no-underline">
-                  {item.q}
-                </AccordionTrigger>
-                <AccordionContent className="pb-5 text-sm text-[var(--landing-muted)] md:text-base">
-                  {item.a}
-                </AccordionContent>
-              </AccordionItem>
-            ))}
-          </Accordion>
+        <div className="space-y-3">
+          {faqItems.map((item) => (
+            <details
+              key={item.q}
+              className="group border border-[var(--landing-line)] bg-[var(--landing-panel-soft)] p-5"
+            >
+              <summary className="cursor-pointer list-none pr-8 text-base font-medium text-[var(--landing-text)] marker:hidden">
+                {item.q}
+                <span className="float-right text-[var(--landing-subtle)] transition-transform duration-300 [transition-timing-function:cubic-bezier(0.2,0.9,0.2,1)] group-open:rotate-45">
+                  +
+                </span>
+              </summary>
+              <p className="mt-3 text-sm leading-relaxed text-[var(--landing-muted)] md:text-base">
+                {item.a}
+              </p>
+            </details>
+          ))}
         </div>
       </div>
     </section>

--- a/components/landing/features.tsx
+++ b/components/landing/features.tsx
@@ -2,75 +2,66 @@ import { LandingTitle } from "./title";
 
 const features = [
   {
-    title: "Fast planning",
-    description:
-      "Drag, resize, and edit events inline without modal-heavy flow.",
+    title: "抓取和拖动足够顺手",
+    description: "直接拖拽、拉伸、改名。信息就在原位，不把你赶进弹窗迷宫。",
     icon: <path d="M4 10h24M8 4v8m16-8v8M5 18h22M5 24h12" />,
+    shape: "md:translate-y-8",
   },
   {
-    title: "Privacy by default",
-    description:
-      "No analytics scripts by default with optional end-to-end encryption.",
+    title: "默认安静，不偷看你",
+    description: "不开追踪脚本，隐私策略写在前面，不藏在设置角落。",
     icon: (
       <path d="M16 4 6 9v7c0 6 4 9 10 12 6-3 10-6 10-12V9L16 4Zm0 8v7m-3-4h6" />
     ),
+    shape: "md:-translate-y-6",
   },
   {
-    title: "Open and portable",
-    description:
-      "Import/export with .ics, .json, and .csv while keeping full control.",
+    title: "导入导出不设门槛",
+    description: "ics、json、csv 都能进出。换工具时，不需要先求人。",
     icon: <path d="M16 4v16m0 0-5-5m5 5 5-5M5 26h22" />,
+    shape: "",
   },
   {
-    title: "Multi-view workflow",
-    description:
-      "Switch between day, week, month, and year perspectives without losing context.",
+    title: "视图切换不会断片",
+    description: "日、周、月、年快速跳转，思路连着走，不会每次重建上下文。",
     icon: <path d="M5 8h22M5 16h22M5 24h22M10 4v24M22 4v24" />,
+    shape: "md:translate-y-5",
   },
   {
-    title: "Keyboard-first speed",
-    description:
-      "Navigate and edit quickly with shortcuts designed for high-frequency planning.",
+    title: "键盘友好",
+    description: "高频编辑靠快捷键完成，手不用离开键盘太久。",
     icon: <path d="M4 9h24v14H4zM8 13h4m4 0h8m-14 4h12" />,
-  },
-  {
-    title: "Cross-device consistency",
-    description:
-      "A consistent experience across desktop and mobile layouts for daily reliability.",
-    icon: (
-      <path d="M10 5h12a2 2 0 0 1 2 2v14a2 2 0 0 1-2 2H10a2 2 0 0 1-2-2V7a2 2 0 0 1 2-2Zm4 15h4" />
-    ),
+    shape: "md:-translate-y-10",
   },
 ];
 
 export function LandingFeatures() {
   return (
-    <section id="features" className="border-y border-white/10 py-24 md:py-28">
-      <div className="grid gap-10 lg:grid-cols-[1fr_1fr] lg:items-start">
+    <section id="features" className="border-y border-[var(--landing-line)] py-24 md:py-28">
+      <div className="grid gap-8 lg:grid-cols-[0.85fr_1.15fr] lg:items-start">
         <LandingTitle
           as="h2"
-          className="text-3xl font-semibold leading-tight text-white md:text-5xl"
+          className="text-3xl font-semibold leading-tight text-[var(--landing-text)] md:text-5xl"
         >
-          Fast planning.
+          快，不浮夸。
           <br />
-          Less noise.
+          够用，也够狠。
         </LandingTitle>
-        <p className="max-w-xl text-base text-[var(--landing-muted)] md:text-lg">
-          Every interaction is designed to keep flow intact: fast edits, secure
-          defaults, and formats that remain portable across tools.
+        <p className="max-w-2xl text-base text-[var(--landing-muted)] md:pl-10 md:text-lg">
+          我们拒绝模板味的“效率仪式感”。每个模块都围绕真实动作：打开、修改、收工。
         </p>
       </div>
 
-      <div className="mt-14 grid gap-6 md:grid-cols-2 xl:grid-cols-3">
+      <div className="mt-14 grid gap-5 md:grid-cols-2 xl:grid-cols-[1.1fr_0.9fr_1fr]">
         {features.map((feature) => (
           <article
             key={feature.title}
-            className="rounded-xl border border-white/10 p-6"
+            className={`landing-scratch-card p-6 ${feature.shape}`}
           >
             <svg
               viewBox="0 0 32 32"
               aria-hidden="true"
-              className="mb-5 h-9 w-9 stroke-white"
+              className="mb-5 h-9 w-9 stroke-[var(--landing-text)]"
               fill="none"
               strokeWidth="1.5"
               strokeLinecap="round"
@@ -78,7 +69,10 @@ export function LandingFeatures() {
             >
               {feature.icon}
             </svg>
-            <LandingTitle as="h3" className="text-xl font-medium text-white">
+            <LandingTitle
+              as="h3"
+              className="text-xl font-medium text-[var(--landing-text)]"
+            >
               {feature.title}
             </LandingTitle>
             <p className="mt-3 text-sm leading-relaxed text-[var(--landing-subtle)]">

--- a/components/landing/hero.tsx
+++ b/components/landing/hero.tsx
@@ -3,40 +3,67 @@ import bannerDark from "@/public/Banner-dark.jpg";
 import { LandingHeroDemo } from "./hero-demo";
 import { LandingTitle } from "./title";
 
+const manifesto = [
+  "日程不是 KPI 看板，它该像你的纸质手账。",
+  "每个动作都快，不靠十层弹窗。",
+  "隐私是默认值，不是额外付费项。",
+];
+
 export function LandingHero() {
   return (
-    <section id="top" className="py-16 md:py-24">
-      <div className="mx-auto max-w-4xl text-center">
-        <LandingTitle
-          as="h1"
-          className="text-4xl font-semibold leading-tight tracking-tight text-white md:text-[56px]"
-        >
-          The calendar that keeps
-          <br />
-          your life private
-        </LandingTitle>
-        <p className="mx-auto mt-5 max-w-2xl text-sm text-[var(--landing-muted)] md:text-base">
-          Secure by design. Powerful by default.
-        </p>
-        <div className="mt-8 flex justify-center gap-3">
-          <a
-            href="/sign-up"
-            aria-label="Get started"
-            className="rounded-md bg-white px-5 py-2.5 text-sm font-medium text-black transition duration-200 hover:-translate-y-0.5 hover:brightness-110"
+    <section id="top" className="py-14 md:py-20">
+      <div className="grid gap-10 lg:grid-cols-[1.25fr_0.75fr] lg:items-end">
+        <div className="space-y-7">
+          <p className="inline-block border border-[var(--landing-line)] bg-[var(--landing-panel-soft)] px-3 py-1 text-xs uppercase tracking-[0.16em] text-[var(--landing-muted)]">
+            anti-template scheduling
+          </p>
+          <LandingTitle
+            as="h1"
+            className="max-w-4xl text-4xl font-semibold leading-[0.95] tracking-[-0.02em] text-[var(--landing-text)] md:text-7xl"
           >
-            Get started
-          </a>
-          <a
-            href="#features"
-            aria-label="View product features"
-            className="rounded-md border border-white/15 px-5 py-2.5 text-sm text-[var(--landing-muted)] transition duration-200 hover:-translate-y-0.5 hover:border-white/30 hover:text-white"
-          >
-            View features
-          </a>
+            Keep your calendar
+            <br />
+            rough, fast,
+            <br />
+            and yours.
+          </LandingTitle>
+          <p className="max-w-xl text-base text-[var(--landing-muted)] md:text-lg">
+            One Calendar strips the fake productivity glow. You open it, place
+            time blocks, move on.
+          </p>
+          <div className="flex flex-wrap items-center gap-3">
+            <a
+              href="/sign-up"
+              aria-label="Get started"
+              className="rounded-sm border border-[var(--landing-accent)] bg-[var(--landing-accent)] px-6 py-2.5 text-sm font-semibold text-[var(--landing-ink)] transition-transform duration-300 [transition-timing-function:cubic-bezier(0.2,0.9,0.2,1)] hover:-translate-y-0.5"
+            >
+              get started
+            </a>
+            <a
+              href="#features"
+              aria-label="View product features"
+              className="rounded-sm border border-[var(--landing-line)] bg-[var(--landing-panel-soft)] px-6 py-2.5 text-sm text-[var(--landing-text)] transition-transform duration-300 [transition-timing-function:cubic-bezier(0.2,0.9,0.2,1)] hover:translate-x-1"
+            >
+              see the workflow
+            </a>
+          </div>
         </div>
+
+        <aside className="landing-scratch-card rotate-[-1.6deg] p-5 md:p-6">
+          <p className="text-xs uppercase tracking-[0.2em] text-[var(--landing-subtle)]">
+            manifesto
+          </p>
+          <ul className="mt-4 space-y-4 text-sm leading-relaxed text-[var(--landing-muted)] md:text-base">
+            {manifesto.map((item) => (
+              <li key={item} className="border-l border-[var(--landing-line)] pl-4">
+                {item}
+              </li>
+            ))}
+          </ul>
+        </aside>
       </div>
 
-      <div className="mt-12">
+      <div className="mt-12 overflow-hidden border border-[var(--landing-line)] bg-[var(--landing-panel)] p-2">
         <Image
           src={bannerDark}
           alt="One Calendar dark preview"


### PR DESCRIPTION
### Motivation
- Move the landing page away from a template SaaS look toward a warm, textured, asymmetric “anti-template” aesthetic with stronger editorial copy and non-default components.
- Remove reliance on standard centered/heroes, default color palettes (indigo/purple/blue gradients), and uncustomized UI primitives to satisfy the project’s visual and copy constraints.

### Description
- Introduce a new landing surface and textured warm theme tokens in `app/globals.css` and add `landing-scratch-card` styles for non-flat, tactile cards.
- Replace the page wrapper in `app/page.tsx` to use the new `landing-surface` container and adjust overall padding.
- Rebuild the hero in `components/landing/hero.tsx` as an asymmetric split layout with a manifesto side-card, custom short-copy headings, and bespoke button timing (custom cubic-bezier); keep the demo image and demo panel.
- Rework content blocks: `components/landing/features.tsx` now uses uneven card rhythm, Chinese copy, and `landing-scratch-card` styling; `components/landing/faq.tsx` replaces the shadcn accordion with native `details/summary` custom-styled panels; `components/landing/cta.tsx` is refactored into a non-centered two-column CTA with updated copy and button styling.

### Testing
- No automated tests were run (per request).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69b51c9f1118833291a7ffbb329c288f)

## Summary by Sourcery

重新设计登陆页面，使其采用更温暖、有质感的反模板风格美学，带有编辑化语气和具备触感的卡片呈现方式。

新增功能：
- 在首屏（hero）部分引入宣言式侧边卡片，配备自定义的行动召唤按钮及展示时机控制。
- 以更加叙事化、并适配本地中文语境的文案呈现功能和常见问题内容，使用不规则卡片布局和刮刮卡式样的视觉风格。

增强与改进：
- 更新全局登陆主题的设计令牌和背景容器，采用温暖、有质感的视觉系统，并引入全新的界面表层与卡片样式。
- 重新设计首屏、功能、常见问题和行动召唤（CTA）板块，采用不对称的编辑化布局，使用原生折叠/展开组件并更新相关文案。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Redesign the landing page to adopt a warmer, textured anti-template aesthetic with an editorial tone and tactile card treatments.

New Features:
- Introduce a manifesto side-card in the hero section with custom call-to-action buttons and timing.
- Present feature and FAQ content in a more narrative, Chinese-localized voice with uneven card layouts and scratch-card styling.

Enhancements:
- Update global landing theme tokens and background container to a warm, textured visual system with new surface and card styles.
- Rework the hero, features, FAQ, and CTA sections into an asymmetric, editorial layout using native disclosure elements and revised copy.

</details>