### PR TITLE
fix(auth): stop botid from blocking login flows

### DIFF
--- a/app/api/botid/route.ts
+++ b/app/api/botid/route.ts
@@ -1,25 +1,32 @@
-import { checkBotId } from "botid/server";
 import { NextRequest, NextResponse } from "next/server";
 
+type BotIdChallenge = {
+  b?: number;
+  d?: number;
+};
+
+function parseChallenge(rawHeader: string | null): BotIdChallenge | null {
+  if (!rawHeader) return null;
+
+  try {
+    const parsed = JSON.parse(rawHeader) as BotIdChallenge;
+    if (typeof parsed !== "object" || parsed === null) return null;
+    return parsed;
+  } catch {
+    return null;
+  }
+}
+
 export async function POST(request: NextRequest) {
-  const challengeHeader = request.headers.get("x-is-human");
+  const challenge = parseChallenge(request.headers.get("x-is-human"));
 
-  // Auth pages should not hard-fail when the BotID client script or headers are unavailable.
-  if (!challengeHeader) {
-    return NextResponse.json({
-      success: true,
-      skipped: true,
-    });
-  }
-
-  const verification = await checkBotId();
-
-  if (verification.isBot) {
-    return NextResponse.json(
-      { error: "Bot detected. Access denied." },
-      { status: 403 },
-    );
-  }
-
-  return NextResponse.json({ success: true });
+  // Login / sign-up / reset flows must never be hard-blocked by BotID,
+  // because false positives on this endpoint prevent legitimate users from authenticating.
+  // We still expose whether the client challenge was present for future debugging.
+  return NextResponse.json({
+    success: true,
+    skipped: true,
+    hasChallenge: challenge !== null,
+    challengeRequiresAnalysis: challenge?.d === 1,
+  });
 }

--- a/instrumentation-client.ts
+++ b/instrumentation-client.ts
@@ -2,7 +2,6 @@ import { initBotId } from "botid/client/core";
 
 initBotId({
   protect: [
-    { path: "/api/botid", method: "POST" },
     { path: "/api/share", method: "GET" },
     { path: "/api/share", method: "POST" },
     { path: "/api/share/public", method: "GET" },


### PR DESCRIPTION
### Motivation
- 登录/注册/重置密码流程调用的 `/api/botid` 因为触发 BotID 服务返回 403 导致正常用户被误判为机器人而无法认证。 
- 需要让认证端点不被 BotID 强制阻断，但仍保留用于排查的挑战元数据；分享相关接口仍需保留 BotID 保护。

### Description
- 修改 `app/api/botid/route.ts`，移除服务端 `checkBotId` 调用并改为解析 `x-is-human` 头，返回不阻断的成功响应对象（包含 `skipped`、`hasChallenge`、`challengeRequiresAnalysis` 等字段）。
- 从客户端初始化配置 `instrumentation-client.ts` 中移除了对 `"/api/botid"` 的保护条目，从而避免前端在认证流程中触发 BotID 的拦截链路。
- 保留对分享相关 API（`/api/share`、`/api/share/public` 等）的 BotID 保护不变。
- 已提交改动，提交信息为 `fix(auth): stop botid from blocking login flows`。

### Testing
- 未运行任何自动化测试或 lint（按请求未执行自动化/ESLint）；变更已通过本地文件修改并提交。

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69be278a58e48332a42f3957e46dfe63)

## Summary by Sourcery

放宽对 `/api/botid` 端点的 BotID 强制校验，这样在保持暴露调试用挑战元数据的同时，不再阻塞认证流程。

新功能：
- 在 `/api/botid` 响应中暴露 BotID 挑战存在与“需要分析”标志，以提升可观测性。

错误修复：
- 防止登录、注册和重置密码流程因 BotID 误报而被强制阻断。

改进：
- 简化 `/api/botid` 处理程序，仅解析客户端提供的挑战请求头，而不再调用 BotID 服务器验证 API。
- 将 BotID 客户端防护限制在与分享相关的 API，通过从受保护路径配置中移除 `/api/botid` 来实现。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Relax BotID enforcement on the /api/botid endpoint so authentication flows are no longer blocked while still surfacing challenge metadata for debugging.

New Features:
- Expose BotID challenge presence and analysis-needed flags in the /api/botid response for observability.

Bug Fixes:
- Prevent login, signup, and password reset flows from being hard-blocked by BotID false positives.

Enhancements:
- Simplify the /api/botid handler to parse client-provided challenge headers without calling the BotID server verification API.
- Limit BotID client protection to share-related APIs by removing /api/botid from the protected paths configuration.

</details>