### PR TITLE
fix(next): convert config to ts and scope sitemap tracing

### DIFF
--- a/app/sitemap.ts
+++ b/app/sitemap.ts
@@ -3,15 +3,16 @@ import fs from "fs";
 import path from "path";
 
 const baseUrl = process.env.NEXT_PUBLIC_BASE_URL || "https://calendar.xyehr.cn";
+const appDirectory = path.join(process.cwd(), "app");
 
 export const revalidate = 86400;
 
 export default async function sitemap(): Promise<MetadataRoute.Sitemap> {
-  const getFileModDate = (filePath: string) => {
+  const getFileModDate = (...segments: string[]) => {
     try {
-      const stats = fs.statSync(path.join(process.cwd(), filePath));
+      const stats = fs.statSync(path.join(appDirectory, ...segments));
       return new Date(stats.mtime);
-    } catch (e) {
+    } catch {
       return new Date();
     }
   };
@@ -19,43 +20,43 @@ export default async function sitemap(): Promise<MetadataRoute.Sitemap> {
   const routes: MetadataRoute.Sitemap = [
     {
       url: baseUrl,
-      lastModified: getFileModDate("app/page.tsx"),
+      lastModified: getFileModDate("page.tsx"),
       changeFrequency: "daily",
       priority: 1.0,
     },
     {
       url: `${baseUrl}/about`,
-      lastModified: getFileModDate("app/about/page.tsx"),
+      lastModified: getFileModDate("about", "page.tsx"),
       changeFrequency: "monthly",
       priority: 0.8,
     },
     {
       url: `${baseUrl}/privacy`,
-      lastModified: getFileModDate("app/privacy/page.tsx"),
+      lastModified: getFileModDate("privacy", "page.tsx"),
       changeFrequency: "monthly",
       priority: 0.8,
     },
     {
       url: `${baseUrl}/terms`,
-      lastModified: getFileModDate("app/terms/page.tsx"),
+      lastModified: getFileModDate("terms", "page.tsx"),
       changeFrequency: "monthly",
       priority: 0.8,
     },
     {
       url: `${baseUrl}/app`,
-      lastModified: getFileModDate("app/app/page.tsx"),
+      lastModified: getFileModDate("app", "page.tsx"),
       changeFrequency: "daliy",
       priority: 1.0,
     },
     {
       url: `${baseUrl}/sign-in`,
-      lastModified: getFileModDate("app/sign-in/page.tsx"),
+      lastModified: getFileModDate("sign-in", "page.tsx"),
       changeFrequency: "monthly",
       priority: 0.7,
     },
     {
       url: `${baseUrl}/sign-up`,
-      lastModified: getFileModDate("app/sign-up/page.tsx"),
+      lastModified: getFileModDate("sign-up", "page.tsx"),
       changeFrequency: "monthly",
       priority: 0.7,
     },

--- a/next.config.ts
+++ b/next.config.ts
@@ -1,14 +1,6 @@
 import { execSync } from "node:child_process";
-import { readFileSync } from "node:fs";
-
-let userConfig = undefined;
-try {
-  userConfig = await import("./next.config");
-} catch (e) {}
-
-const packageJson = JSON.parse(
-  readFileSync(new URL("./package.json", import.meta.url), "utf8"),
-);
+import type { NextConfig } from "next";
+import packageJson from "./package.json";
 
 const getGitCommit = () => {
   try {
@@ -18,7 +10,7 @@ const getGitCommit = () => {
   }
 };
 
-const nextConfig = {
+const nextConfig: NextConfig = {
   typescript: {
     ignoreBuildErrors: true,
   },
@@ -31,7 +23,6 @@ const nextConfig = {
     NEXT_PUBLIC_GIT_COMMIT: getGitCommit(),
     NEXT_PUBLIC_BUILD_TIME: new Date().toISOString(),
   },
-
   experimental: {
     optimizePackageImports: [
       "lucide-react",
@@ -41,27 +32,5 @@ const nextConfig = {
     ],
   },
 };
-
-mergeConfig(nextConfig, userConfig);
-
-function mergeConfig(nextConfig, userConfig) {
-  if (!userConfig) {
-    return;
-  }
-
-  for (const key in userConfig) {
-    if (
-      typeof nextConfig[key] === "object" &&
-      !Array.isArray(nextConfig[key])
-    ) {
-      nextConfig[key] = {
-        ...nextConfig[key],
-        ...userConfig[key],
-      };
-    } else {
-      nextConfig[key] = userConfig[key];
-    }
-  }
-}
 
 export default nextConfig;


### PR DESCRIPTION
### Motivation
- Turbopack/NFT tracing reported that the whole project was traced due to dynamic filesystem usage and a dynamic `import` in the Next config and sitemap generation, causing noisy warnings at deploy time.
- Convert the config to a statically-imported TypeScript file and restrict sitemap file access to a specific subfolder to avoid unintentional repo-wide tracing while keeping behavior unchanged.

### Description
- Replace `next.config.mjs` with `next.config.ts` and switch the dynamic `import("./next.config")` / runtime `readFileSync` pattern to a static `import` of `package.json`, retaining the existing `typescript`, `images`, `env`, and `experimental.optimizePackageImports` settings.
- Scope sitemap file mtime lookups to the `app` directory by introducing `appDirectory = path.join(process.cwd(), 'app')` and changing `getFileModDate` to only join path segments under that directory.
- Simplify error handling in `sitemap` to return a fallback `new Date()` when a file stat fails, preserving `lastModified` semantics.

### Testing
- No automated build or test run was executed (per instructions), and `eslint`/`next build` were intentionally not run.
- Changed files were inspected with `nl -ba next.config.ts` and `nl -ba app/sitemap.ts` to verify the intended edits were applied successfully.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69bf249d41348332a7c8095ce7e50e79)

## 由 Sourcery 提供的摘要

转换 Next.js 配置和站点地图（sitemap）生成方式，以避免导致广泛追踪的动态文件系统和配置导入，同时保持现有行为不变。

Bug 修复：
- 将站点地图文件修改时间的查询范围限制在 Next.js app 目录内，防止对整个代码仓库进行文件系统追踪。

增强：
- 将 Next.js 配置从动态的 ESM 配置文件迁移到带类型的 TypeScript 配置，并以静态方式导入 `package.json`。
- 简化站点地图的错误处理逻辑，当文件状态（stat）调用失败时回退到当前日期。

构建：
- 调整 Next.js 构建配置，改为使用带有类型化 `NextConfig` 导出的 `next.config.ts`，而不是 `next.config.mjs`。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Convert Next.js configuration and sitemap generation to avoid dynamic filesystem and config imports that cause broad tracing, while preserving existing behavior.

Bug Fixes:
- Limit sitemap file modification time lookups to the Next.js app directory to prevent repository-wide filesystem tracing.

Enhancements:
- Migrate Next.js configuration from a dynamic ESM config file to a typed TypeScript config that statically imports package.json.
- Simplify sitemap error handling by falling back to the current date when file stat calls fail.

Build:
- Adjust Next.js build configuration to use next.config.ts with a typed NextConfig export instead of next.config.mjs.

</details>