### PR TITLE
Improve metadata and title handling for shared event pages

### DIFF
--- a/app/(app)/share/[id]/layout.tsx
+++ b/app/(app)/share/[id]/layout.tsx
@@ -1,20 +1,49 @@
 import { Metadata } from "next"
+import { headers } from "next/headers"
 import { ReactNode } from "react"
 
 export async function generateMetadata(
   { params }: { params: { id: string } }
 ): Promise<Metadata> {
+  const fallbackMetadata: Metadata = {
+    title: "One Calendar",
+    icons: {
+      icon: "/icon.svg",
+    },
+  }
+
   try {
-    const baseUrl = process.env.NEXT_PUBLIC_BASE_URL || "http://localhost:3000"
+    const headerStore = await headers()
+    const forwardedHost = headerStore.get("x-forwarded-host")
+    const host = forwardedHost || headerStore.get("host")
+    const protocol = headerStore.get("x-forwarded-proto") || "https"
+    const baseUrl = process.env.NEXT_PUBLIC_BASE_URL || (host ? `${protocol}://${host}` : "http://localhost:3000")
     const res = await fetch(`${baseUrl}/api/share?id=${params.id}`, {
       cache: "no-store",
     })
 
-    if (!res.ok) throw new Error("Failed to fetch shared event")
+    if (res.status === 401) {
+      const result = await res.json().catch(() => null)
+      if (result?.requiresPassword) {
+        return {
+          title: "Protected | One Calendar",
+          icons: {
+            icon: "/icon.svg",
+          },
+        }
+      }
+      return fallbackMetadata
+    }
+
+    if (!res.ok) {
+      return fallbackMetadata
+    }
 
     const result = await res.json()
 
-    if (!result.success || !result.data) throw new Error("Invalid share data")
+    if (!result.success || !result.data) {
+      return fallbackMetadata
+    }
 
     const event = typeof result.data === "object" ? result.data : JSON.parse(result.data)
     const eventTitle = typeof event.title === "string" ? event.title : "Untitled"
@@ -25,14 +54,8 @@ export async function generateMetadata(
         icon: "/icon.svg",
       },
     }
-  } catch (err) {
-    console.error("[generateMetadata error]", err)
-    return {
-      title: "One Calendar",
-      icons: {
-        icon: "/icon.svg",
-      },
-    }
+  } catch {
+    return fallbackMetadata
   }
 }
 

--- a/components/app/profile/shared-event.tsx
+++ b/components/app/profile/shared-event.tsx
@@ -159,6 +159,17 @@ export default function SharedEventView({
     fetchSharedEvent();
   }, [shareId, handle]);
 
+  useEffect(() => {
+    if (event?.title) {
+      document.title = `${event.title} | One Calendar`;
+      return;
+    }
+
+    if (requiresPassword) {
+      document.title = "Protected | One Calendar";
+    }
+  }, [event, requiresPassword]);
+
   const tryDecryptWithPassword = async () => {
     if (!shareId) return;
 


### PR DESCRIPTION
### Motivation

- Ensure page metadata for shared event pages is derived from the actual request host and protocol when available.  
- Surface a distinct title for password-protected shares instead of falling back to a generic title.  
- Simplify error handling and provide a stable fallback metadata object to avoid noisy logs and inconsistent responses.

### Description

- Use `headers()` from `next/headers` in `app/(app)/share/[id]/layout.tsx` to derive `host`, `x-forwarded-host`, and `x-forwarded-proto` and build `baseUrl` when `NEXT_PUBLIC_BASE_URL` is not set.  
- Introduce a `fallbackMetadata` object and return it on fetch failures or parsing errors.  
- Handle `401` responses specially by returning `Protected | One Calendar` metadata when the share requires a password, otherwise return the fallback metadata.  
- Add a client-side `useEffect` in `components/app/profile/shared-event.tsx` to update `document.title` when an event is loaded or when a share is password-protected.

### Testing

- Ran the app build with `npm run build` and TypeScript checks with `tsc --noEmit`, both succeeded.  
- Executed the existing unit test suite with `npm test`, which passed without failures.  
- Verified basic local behavior by loading shared and password-protected share pages in development, confirming metadata and document title changes.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69d24cf4dd108326a09179933ea5f3c1)

## Summary by Sourcery

改进共享事件页面的元数据生成和文档标题，提供更健壮的回退方案，并对受保护的分享进行特殊处理。

新功能：
- 当未配置显式的公共基础 URL 时，从请求头中推导共享事件元数据的基础 URL。
- 基于已加载事件标题或受保护分享状态，在共享事件页面中设置浏览器文档标题。

错误修复：
- 当分享 API 响应失败或包含无效数据时，返回稳定的回退元数据，而不是抛出错误。
- 将表示密码保护分享的 401 响应视为一个独立情况，并使用专门的元数据标题进行处理。

增强：
- 通过集中使用可复用的回退元数据对象，简化共享事件元数据生成中的错误处理逻辑。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Improve metadata generation and document titles for shared event pages, with robust fallbacks and special handling for protected shares.

New Features:
- Derive the base URL for shared event metadata from request headers when an explicit public base URL is not configured.
- Set the browser document title on shared event pages based on the loaded event title or protected-share state.

Bug Fixes:
- Return stable fallback metadata when share API responses are unsuccessful or contain invalid data instead of throwing errors.
- Treat 401 responses that indicate password-protected shares as a distinct case with a dedicated metadata title.

Enhancements:
- Simplify error handling in shared event metadata generation by centralizing a reusable fallback metadata object.

</details>