### PR TITLE
fix(auth): gate Clerk flows until SDK is loaded and stabilize OAuth redirects

### DIFF
--- a/components/auth/login-form.tsx
+++ b/components/auth/login-form.tsx
@@ -74,7 +74,6 @@ export function LoginForm({
 
     try {
       if (!isLoaded || !signIn) {
-        setError("Auth service is still loading. Please try again in a moment.");
         return;
       }
 
@@ -102,34 +101,25 @@ export function LoginForm({
     }
   };
 
-  const handleOAuthLogin = (strategy: "oauth_google" | "oauth_microsoft" | "oauth_github") => {
+  const handleOAuthLogin = async (strategy: "oauth_google" | "oauth_microsoft" | "oauth_github") => {
     const siteKey = process.env.NEXT_PUBLIC_TURNSTILE_SITE_KEY;
     if (siteKey && !isCaptchaCompleted) {
       setError("Please complete the CAPTCHA verification.");
       return;
     }
     if (!isLoaded || !signIn) {
-      setError("Auth service is still loading. Please try again in a moment.");
       return;
     }
 
-    const redirect =
-      signIn.authenticateWithRedirect ??
-      (signIn as unknown as { authWithRedirect?: typeof signIn.authenticateWithRedirect })
-        .authWithRedirect ??
-      (signIn as unknown as { authenticatorWithRedirect?: typeof signIn.authenticateWithRedirect })
-        .authenticatorWithRedirect;
-
-    if (!redirect) {
-      setError("OAuth is unavailable right now. Please refresh and try again.");
-      return;
+    try {
+      await signIn.authenticateWithRedirect({
+        strategy,
+        redirectUrl: "/sign-in/sso-callback",
+        redirectUrlComplete: "/app",
+      });
+    } catch (err: any) {
+      setError(err.errors?.[0]?.longMessage || "OAuth login failed. Please try again.");
     }
-
-    redirect.call(signIn, {
-      strategy,
-      redirectUrl: "/sign-in/sso-callback",
-      redirectUrlComplete: "/app",
-    });
   };
 
   const siteKey = process.env.NEXT_PUBLIC_TURNSTILE_SITE_KEY;
@@ -148,6 +138,7 @@ export function LoginForm({
                   variant="outline"
                   className="w-full"
                   type="button"
+                  disabled={!isLoaded}
                   onClick={() => handleOAuthLogin("oauth_microsoft")}
                 >
                   <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 23 23" width="20" height="20">
@@ -162,6 +153,7 @@ export function LoginForm({
                   variant="outline"
                   className="w-full"
                   type="button"
+                  disabled={!isLoaded}
                   onClick={() => handleOAuthLogin("oauth_google")}
                 >
                   <svg xmlns="http://www.w3.org/2000/svg" height="24" viewBox="0 0 24 24" width="24">
@@ -177,6 +169,7 @@ export function LoginForm({
                   variant="outline"
                   className="w-full"
                   type="button"
+                  disabled={!isLoaded}
                   onClick={() => handleOAuthLogin("oauth_github")}
                 >
                   <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" width="20" height="20">
@@ -244,9 +237,9 @@ export function LoginForm({
                 <Button
                   type="submit"
                   className="w-full bg-[#0066ff] hover:bg-[#0047cc] text-white"
-                  disabled={siteKey && (!isCaptchaCompleted || isLoading)}
+                  disabled={!isLoaded || (siteKey && (!isCaptchaCompleted || isLoading))}
                 >
-                  {isLoading ? "Signing in..." : "Sign in"}
+                  {!isLoaded ? "Loading auth..." : isLoading ? "Signing in..." : "Sign in"}
                 </Button>
               </div>
               <div className="text-center text-sm">

--- a/components/auth/reset-form.tsx
+++ b/components/auth/reset-form.tsx
@@ -21,7 +21,7 @@ export function ResetPasswordForm({
   className,
   ...props
 }: React.ComponentPropsWithoutRef<"div">) {
-  const { signIn } = useSignIn();
+  const { isLoaded, signIn } = useSignIn();
   const router = useRouter();
   const [step, setStep] = useState<"email" | "code" | "password">("email");
   const [formData, setFormData] = useState({
@@ -82,14 +82,17 @@ export function ResetPasswordForm({
     setError("");
 
     try {
+      if (!isLoaded || !signIn) {
+        return;
+      }
       if (step === "email") {
-        await signIn?.create({
+        await signIn.create({
           strategy: "reset_password_email_code",
           identifier: formData.email,
         });
         setStep("code");
       } else if (step === "code") {
-        const result = await signIn?.attemptFirstFactor({
+        const result = await signIn.attemptFirstFactor({
           strategy: "reset_password_email_code",
           code: formData.code,
         });
@@ -97,7 +100,7 @@ export function ResetPasswordForm({
           setStep("password");
         }
       } else {
-        const result = await signIn?.resetPassword({
+        const result = await signIn.resetPassword({
           password: formData.password,
         });
         if (result?.status === "complete") {
@@ -237,12 +240,14 @@ export function ResetPasswordForm({
                 type="submit"
                 className="w-full bg-[#0066ff] hover:bg-[#0047cc] text-white"
                 disabled={
-                  siteKey && step === "email"
+                  !isLoaded
+                    ? true
+                    : siteKey && step === "email"
                     ? !isCaptchaCompleted || isLoading
                     : isLoading
                 }
               >
-                {isLoading ? "Processing..." : stepContent.buttonText}
+                {!isLoaded ? "Loading auth..." : isLoading ? "Processing..." : stepContent.buttonText}
               </Button>
 
               <div className="text-center text-sm">

--- a/components/auth/sign-up-form.tsx
+++ b/components/auth/sign-up-form.tsx
@@ -136,25 +136,17 @@ export function SignUpForm({
       return;
     }
     if (!isLoaded || !signUp) {
-      setError("Auth service is still loading. Please try again in a moment.");
       return;
     }
-
-    const redirect =
-      signUp.authenticateWithRedirect ??
-      (signUp as unknown as { authWithRedirect?: typeof signUp.authenticateWithRedirect })
-        .authWithRedirect;
-
-    if (!redirect) {
-      setError("OAuth is unavailable right now. Please refresh and try again.");
-      return;
-    }
-
-    redirect.call(signUp, {
-      strategy,
-      redirectUrl: "/sign-up/sso-callback",
-      redirectUrlComplete: "/app",
-    });
+    signUp
+      .authenticateWithRedirect({
+        strategy,
+        redirectUrl: "/sign-up/sso-callback",
+        redirectUrlComplete: "/app",
+      })
+      .catch((err: any) => {
+        setError(err.errors?.[0]?.longMessage || "OAuth sign up failed. Please try again.");
+      });
   };
 
   const handleSubmit = async (e: React.FormEvent) => {
@@ -169,7 +161,6 @@ export function SignUpForm({
 
     try {
       if (!isLoaded || !signUp) {
-        setError("Auth service is still loading. Please try again in a moment.");
         return;
       }
 
@@ -295,6 +286,7 @@ export function SignUpForm({
                   variant="outline"
                   className="w-full"
                   type="button"
+                  disabled={!isLoaded}
                   onClick={() => handleOAuthSignUp("oauth_microsoft")}
                 >
                   <svg
@@ -314,6 +306,7 @@ export function SignUpForm({
                   variant="outline"
                   className="w-full"
                   type="button"
+                  disabled={!isLoaded}
                   onClick={() => handleOAuthSignUp("oauth_google")}
                 >
                   <svg
@@ -346,6 +339,7 @@ export function SignUpForm({
                   variant="outline"
                   className="w-full"
                   type="button"
+                  disabled={!isLoaded}
                   onClick={() => handleOAuthSignUp("oauth_github")}
                 >
                   <svg
@@ -448,9 +442,9 @@ export function SignUpForm({
                 <Button
                   type="submit"
                   className="w-full bg-[#0066ff] hover:bg-[#0047cc] text-white"
-                  disabled={siteKey && (!isCaptchaCompleted || isLoading)}
+                  disabled={!isLoaded || (siteKey && (!isCaptchaCompleted || isLoading))}
                 >
-                  {isLoading ? "Creating account..." : "Create account"}
+                  {!isLoaded ? "Loading auth..." : isLoading ? "Creating account..." : "Create account"}
                 </Button>
               </div>
 


### PR DESCRIPTION
### Motivation

- Prevent users from triggering custom Clerk flows before the Clerk SDK finishes initializing, which caused repeated "Auth service is still loading" errors on login/signup/reset pages.
- Use Clerk's supported redirect API for OAuth to remove fragile fallback logic and improve reliability for SSO flows.

### Description

- Gate all custom Clerk actions behind `isLoaded` from `useSignIn` / `useSignUp` and `useSignIn` in the reset flow so no SDK methods are invoked before the SDK is ready.
- Disable all auth action buttons while the Clerk SDK is not loaded and show a `Loading auth...` label on submit buttons until ready.
- Replace legacy/compatibility OAuth fallbacks with `authenticateWithRedirect` calls for sign-in and sign-up, and consolidate error handling for OAuth failures.
- Files changed: `components/auth/login-form.tsx`, `components/auth/sign-up-form.tsx`, and `components/auth/reset-form.tsx`.

### Testing

- Ran a code search `rg -n "Auth service is still loading" components/auth` to verify the hard error path was removed, and it returned no matches (succeeded). 
- Inspected diffs with `git diff` for the three modified files to confirm the new gating, disabled button props, and `authenticateWithRedirect` usage (succeeded). 
- Printed relevant file regions with `nl -ba` / `sed` to manually verify the UI text states and conditional logic were applied correctly (succeeded). 
- All automated checks performed in the rollout (searches and diffs) completed successfully.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69d25ade5ca48326aa2228b885235287)

## Summary by Sourcery

在依赖 Clerk 的身份验证表单中，将所有基于 Clerk 的认证流程统一依赖于 SDK 就绪状态，并将 OAuth 登录/注册切换到受支持的重定向 API，同时改进加载与错误处理体验。

Bug 修复：
- 防止登录、注册和重置密码流程在 Clerk SDK 尚未完全加载时调用其方法。
- 通过在初始化完成前禁用认证操作，避免向用户展示“Auth service is still loading”（认证服务仍在加载中）之类的错误信息。

增强改进：
- 对 OAuth 登录和注册，直接使用 Clerk 的 `authenticateWithRedirect` API，而不是沿用旧版的回退式重定向逻辑。
- 统一并明确 OAuth 登录和注册失败时的错误消息。
- 在登录、注册和密码重置表单中，当认证 SDK 正在初始化时，显示“Loading auth...”状态，并禁用提交/OAuth 按钮。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Gate Clerk-based auth flows on SDK readiness and switch OAuth sign-in/sign-up to the supported redirect API while improving loading and error handling in auth forms.

Bug Fixes:
- Prevent login, sign-up, and password reset flows from invoking Clerk SDK methods before the SDK is fully loaded.
- Avoid user-facing "Auth service is still loading" errors by disabling auth actions until initialization completes.

Enhancements:
- Use Clerk's `authenticateWithRedirect` API directly for OAuth login and sign-up instead of legacy fallback redirects.
- Unify and clarify OAuth error messages for failed login and sign-up attempts.
- Show a "Loading auth..." state and disable submit/OAuth buttons while the auth SDK is initializing across login, sign-up, and reset forms.

</details>