### PR TITLE
fix(auth): support Clerk key fallback to prevent auth loading hang

### DIFF
--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -55,12 +55,16 @@ export default function RootLayout({
 }: {
   children: React.ReactNode
 }) {
+  const clerkPublishableKey =
+    process.env.NEXT_PUBLIC_CLERK_PUBLISHABLE_KEY ?? process.env.CLERK_PUBLISHABLE_KEY
+
   return (
     <html lang="en" suppressHydrationWarning>
       <body
         className={`${GeistSans.className} ${instrumentSans.variable} ${instrumentSerif.variable} ${jetbrainsMono.variable} antialiased`}
       >
         <ClerkProvider
+          publishableKey={clerkPublishableKey}
           localization={enUS}
           fallbackRedirectUrl="/"
           forceRedirectUrl="/"

--- a/proxy.ts
+++ b/proxy.ts
@@ -1,6 +1,8 @@
 import { clerkMiddleware } from "@clerk/nextjs/server"
 
 export default clerkMiddleware({
+  publishableKey: process.env.NEXT_PUBLIC_CLERK_PUBLISHABLE_KEY ?? process.env.CLERK_PUBLISHABLE_KEY,
+  secretKey: process.env.CLERK_SECRET_KEY,
   publicRoutes: [
     "/",
     "/app",


### PR DESCRIPTION
### Motivation
- Clerk's package update and env var name differences could cause the client `ClerkProvider` to miss the publishable key and keep `isLoaded` false, leaving auth pages stuck on "Loading auth...".
- The server-side middleware should use the same key source so frontend and middleware remain consistent across legacy and new environment variable names.

### Description
- Added a publishable key fallback `process.env.NEXT_PUBLIC_CLERK_PUBLISHABLE_KEY ?? process.env.CLERK_PUBLISHABLE_KEY` and passed it to `ClerkProvider` via `publishableKey` in `app/layout.tsx`.
- Passed the same publishable key fallback and `secretKey: process.env.CLERK_SECRET_KEY` into `clerkMiddleware` in `proxy.ts` to align server-side auth behavior.
- These changes preserve compatibility with older `CLERK_PUBLISHABLE_KEY` usage and prevent auth initialization from hanging.

### Testing
- Confirmed that `app/layout.tsx` and `proxy.ts` were updated with the new fallback logic and middleware options.
- No automated tests (`eslint`, `build`, or CI) were executed as requested.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69d25e4a5d1c8326809dcdc435ba38d3)

## Summary by Sourcery

确保 Clerk 认证在前端和中间件中使用一致的可公开密钥（publishable key）回退机制，以防在环境变量名称不一致时导致认证初始化卡住。

Bug Fixes:
- 在 `ClerkProvider` 中提供可公开密钥的回退值，以避免在主环境变量缺失时认证页面出现卡死问题。
- 使 `clerkMiddleware` 配置与相同的可公开密钥和密钥（secret key）环境变量保持一致，从而保证服务端认证行为的一致性。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Ensure Clerk authentication uses a consistent publishable key fallback across frontend and middleware to prevent auth initialization from hanging when environment variable names differ.

Bug Fixes:
- Provide a publishable key fallback in the ClerkProvider to avoid auth pages hanging when the primary env var is missing.
- Align clerkMiddleware configuration with the same publishable and secret key env vars to keep server-side auth behavior consistent.

</details>