### PR TITLE
Upgrade Clerk Next.js integration from v6 to v7 APIs

### DIFF
--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -66,8 +66,10 @@ export default function RootLayout({
         <ClerkProvider
           publishableKey={clerkPublishableKey}
           localization={enUS}
-          fallbackRedirectUrl="/"
-          forceRedirectUrl="/"
+          signInFallbackRedirectUrl="/"
+          signUpFallbackRedirectUrl="/"
+          signInForceRedirectUrl="/"
+          signUpForceRedirectUrl="/"
           signInUrl="/sign-in"
           signUpUrl="/sign-up"
         >

--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -66,8 +66,8 @@ export default function RootLayout({
         <ClerkProvider
           publishableKey={clerkPublishableKey}
           localization={enUS}
-          signInFallbackRedirectUrl="/"
-          signUpFallbackRedirectUrl="/"
+          signInFallbackRedirectUrl="/app"
+          signUpFallbackRedirectUrl="/app"
           signInForceRedirectUrl="/"
           signUpForceRedirectUrl="/"
           signInUrl="/sign-in"

--- a/components/auth/login-form.tsx
+++ b/components/auth/login-form.tsx
@@ -20,7 +20,7 @@ export function LoginForm({
   className,
   ...props
 }: React.ComponentPropsWithoutRef<"div">) {
-  const { signIn, setActive } = useSignIn();
+  const { signIn } = useSignIn();
   const [email, setEmail] = useState("");
   const [password, setPassword] = useState("");
   const [isLoading, setIsLoading] = useState(false);
@@ -74,14 +74,29 @@ export function LoginForm({
     setError("");
 
     try {
-      const result = await signIn.create({
-        identifier: email,
+      const { error } = await signIn.password({
+        emailAddress: email,
         password,
       });
+      if (error) {
+        setError(error.longMessage || error.message || "Login failed. Please try again.");
+        return;
+      }
 
-      if (result.status === "complete") {
-        await setActive({ session: result.createdSessionId });
-        router.push("/");
+      if (signIn.status === "complete") {
+        const { error: finalizeError } = await signIn.finalize({
+          navigate: ({ decorateUrl }) => {
+            const url = decorateUrl("/");
+            if (url.startsWith("http")) {
+              window.location.href = url;
+              return;
+            }
+            router.push(url);
+          },
+        });
+        if (finalizeError) {
+          setError(finalizeError.longMessage || finalizeError.message || "Login failed. Please try again.");
+        }
       }
     } catch (err: any) {
       setError(err.errors?.[0]?.longMessage || "Login failed. Please try again.");
@@ -102,14 +117,15 @@ export function LoginForm({
       setError("Please complete the CAPTCHA verification.");
       return;
     }
-    signIn.authenticateWithRedirect({
+    signIn.sso({
       strategy,
-      redirectUrl: "/sign-in/sso-callback",
-      redirectUrlComplete: "/",
+      redirectUrl: "/",
+      redirectCallbackUrl: "/sign-in/sso-callback",
     });
   };
 
   const siteKey = process.env.NEXT_PUBLIC_TURNSTILE_SITE_KEY;
+  const hasCaptcha = Boolean(siteKey);
 
   return (
     <div className={cn("flex flex-col gap-6", className)} {...props}>
@@ -203,11 +219,11 @@ export function LoginForm({
                     onChange={(e) => setPassword(e.target.value)}
                   />
                 </div>
-                {siteKey && (
+                {hasCaptcha && (
                     <div className="turnstile-container">
                       <Turnstile
                         ref={turnstileRef}
-                        siteKey={siteKey}
+                        siteKey={siteKey!}
                         onSuccess={handleTurnstileSuccess}
                         onError={() => {
                           console.error("Turnstile widget error");
@@ -224,7 +240,7 @@ export function LoginForm({
                 <Button
                   type="submit"
                   className="w-full bg-[#0066ff] hover:bg-[#0047cc] text-white"
-                  disabled={siteKey && (!isCaptchaCompleted || isLoading)}
+                  disabled={hasCaptcha ? !isCaptchaCompleted || isLoading : isLoading}
                 >
                   {isLoading ? "Signing in..." : "Sign in"}
                 </Button>

--- a/components/auth/reset-form.tsx
+++ b/components/auth/reset-form.tsx
@@ -21,7 +21,7 @@ export function ResetPasswordForm({
   className,
   ...props
 }: React.ComponentPropsWithoutRef<"div">) {
-  const { isLoaded, signIn } = useSignIn();
+  const { signIn } = useSignIn();
   const router = useRouter();
   const [step, setStep] = useState<"email" | "code" | "password">("email");
   const [formData, setFormData] = useState({
@@ -82,29 +82,51 @@ export function ResetPasswordForm({
     setError("");
 
     try {
-      if (!isLoaded || !signIn) {
-        return;
-      }
       if (step === "email") {
-        await signIn.create({
-          strategy: "reset_password_email_code",
-          identifier: formData.email,
-        });
+        const { error: createError } = await signIn.create({ identifier: formData.email });
+        if (createError) {
+          setError(createError.longMessage || createError.message || "An error occurred. Please try again.");
+          return;
+        }
+        const { error: sendCodeError } = await signIn.resetPasswordEmailCode.sendCode();
+        if (sendCodeError) {
+          setError(sendCodeError.longMessage || sendCodeError.message || "An error occurred. Please try again.");
+          return;
+        }
         setStep("code");
       } else if (step === "code") {
-        const result = await signIn.attemptFirstFactor({
-          strategy: "reset_password_email_code",
+        const { error: verifyCodeError } = await signIn.resetPasswordEmailCode.verifyCode({
           code: formData.code,
         });
-        if (result?.status === "needs_new_password") {
+        if (verifyCodeError) {
+          setError(verifyCodeError.longMessage || verifyCodeError.message || "An error occurred. Please try again.");
+          return;
+        }
+        if (signIn.status === "needs_new_password") {
           setStep("password");
         }
       } else {
-        const result = await signIn.resetPassword({
+        const { error: submitPasswordError } = await signIn.resetPasswordEmailCode.submitPassword({
           password: formData.password,
         });
-        if (result?.status === "complete") {
-          router.push("/app");
+        if (submitPasswordError) {
+          setError(submitPasswordError.longMessage || submitPasswordError.message || "An error occurred. Please try again.");
+          return;
+        }
+        if (signIn.status === "complete") {
+          const { error: finalizeError } = await signIn.finalize({
+            navigate: ({ decorateUrl }) => {
+              const url = decorateUrl("/app");
+              if (url.startsWith("http")) {
+                window.location.href = url;
+                return;
+              }
+              router.push(url);
+            },
+          });
+          if (finalizeError) {
+            setError(finalizeError.longMessage || finalizeError.message || "An error occurred. Please try again.");
+          }
         }
       }
     } catch (err: any) {
@@ -198,6 +220,7 @@ export function ResetPasswordForm({
 
   const stepContent = getStepContent();
   const siteKey = process.env.NEXT_PUBLIC_TURNSTILE_SITE_KEY;
+  const hasCaptcha = Boolean(siteKey);
 
   return (
     <div className={cn("flex flex-col gap-6", className)} {...props}>
@@ -211,11 +234,11 @@ export function ResetPasswordForm({
             <div className="grid gap-6">
               {stepContent.fields}
 
-              {step === "email" && siteKey && (
+              {step === "email" && hasCaptcha && (
                 <div className="turnstile-container">
                   <Turnstile
                     ref={turnstileRef}
-                    siteKey={siteKey}
+                    siteKey={siteKey!}
                     onSuccess={handleTurnstileSuccess}
                     onError={() => {
                       setIsCaptchaCompleted(false);
@@ -240,14 +263,12 @@ export function ResetPasswordForm({
                 type="submit"
                 className="w-full bg-[#0066ff] hover:bg-[#0047cc] text-white"
                 disabled={
-                  !isLoaded
-                    ? true
-                    : siteKey && step === "email"
+                  hasCaptcha && step === "email"
                     ? !isCaptchaCompleted || isLoading
                     : isLoading
                 }
               >
-                {!isLoaded ? "Loading auth..." : isLoading ? "Processing..." : stepContent.buttonText}
+                {isLoading ? "Processing..." : stepContent.buttonText}
               </Button>
 
               <div className="text-center text-sm">

--- a/components/auth/sign-up-form.tsx
+++ b/components/auth/sign-up-form.tsx
@@ -2,7 +2,7 @@
 
 import { Button } from "@/components/ui/button";
 import { cn } from "@/lib/utils";
-import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
+import { Card, CardContent, CardDescription, CardHeader, CardTitle } from "@/components/ui/card";
 import { Input } from "@/components/ui/input";
 import { Label } from "@/components/ui/label";
 import { useSignUp } from "@clerk/nextjs";
@@ -14,7 +14,7 @@ export function SignUpForm({
   className,
   ...props
 }: React.ComponentPropsWithoutRef<"div">) {
-  const { isLoaded, signUp, setActive } = useSignUp();
+  const { signUp } = useSignUp();
   const router = useRouter();
   const [step, setStep] = useState<"initial" | "verification">("initial");
   const [formData, setFormData] = useState({
@@ -135,14 +135,11 @@ export function SignUpForm({
       setError("Please complete the CAPTCHA verification.");
       return;
     }
-    if (!isLoaded || !signUp) {
-      return;
-    }
     signUp
-      .authenticateWithRedirect({
+      .sso({
         strategy,
-        redirectUrl: "/sign-up/sso-callback",
-        redirectUrlComplete: "/app",
+        redirectUrl: "/app",
+        redirectCallbackUrl: "/sign-up/sso-callback",
       })
       .catch((err: any) => {
         setError(err.errors?.[0]?.longMessage || "OAuth sign up failed. Please try again.");
@@ -160,10 +157,6 @@ export function SignUpForm({
     setError("");
 
     try {
-      if (!isLoaded || !signUp) {
-        return;
-      }
-
       if (step === "initial") {
         if (!isEmailDomainAllowed(formData.email)) {
           setError(
@@ -173,21 +166,46 @@ export function SignUpForm({
           return;
         }
 
-        await signUp.create({
+        const { error: passwordError } = await signUp.password({
           firstName: formData.firstName,
           lastName: formData.lastName,
           emailAddress: formData.email,
           password: formData.password,
         });
-        await signUp.prepareEmailAddressVerification();
+        if (passwordError) {
+          setError(
+            passwordError.longMessage || passwordError.message || "An error occurred. Please try again.",
+          );
+          return;
+        }
+        await signUp.verifications.sendEmailCode();
         setStep("verification");
       } else {
-        const completeSignUp = await signUp.attemptEmailAddressVerification({
+        const { error: verifyError } = await signUp.verifications.verifyEmailCode({
           code: formData.code,
         });
-        if (completeSignUp.status === "complete") {
-          await setActive({ session: completeSignUp.createdSessionId });
-          router.push("/app");
+        if (verifyError) {
+          setError(
+            verifyError.longMessage || verifyError.message || "An error occurred. Please try again.",
+          );
+          return;
+        }
+        if (signUp.status === "complete") {
+          const { error: finalizeError } = await signUp.finalize({
+            navigate: ({ decorateUrl }) => {
+              const url = decorateUrl("/app");
+              if (url.startsWith("http")) {
+                window.location.href = url;
+                return;
+              }
+              router.push(url);
+            },
+          });
+          if (finalizeError) {
+            setError(
+              finalizeError.longMessage || finalizeError.message || "An error occurred. Please try again.",
+            );
+          }
         }
       }
     } catch (err: any) {
@@ -251,7 +269,7 @@ export function SignUpForm({
                     type="button"
                     onClick={async () => {
                       try {
-                        await signUp?.prepareEmailAddressVerification();
+                        await signUp.verifications.sendEmailCode();
                       } catch (err) {
                         setError("Failed to resend code. Please try again.");
                       }
@@ -271,6 +289,7 @@ export function SignUpForm({
   }
 
   const siteKey = process.env.NEXT_PUBLIC_TURNSTILE_SITE_KEY;
+  const hasCaptcha = Boolean(siteKey);
 
   return (
     <div className={cn("flex flex-col gap-6", className)} {...props}>
@@ -286,7 +305,6 @@ export function SignUpForm({
                   variant="outline"
                   className="w-full"
                   type="button"
-                  disabled={!isLoaded}
                   onClick={() => handleOAuthSignUp("oauth_microsoft")}
                 >
                   <svg
@@ -306,7 +324,6 @@ export function SignUpForm({
                   variant="outline"
                   className="w-full"
                   type="button"
-                  disabled={!isLoaded}
                   onClick={() => handleOAuthSignUp("oauth_google")}
                 >
                   <svg
@@ -339,7 +356,6 @@ export function SignUpForm({
                   variant="outline"
                   className="w-full"
                   type="button"
-                  disabled={!isLoaded}
                   onClick={() => handleOAuthSignUp("oauth_github")}
                 >
                   <svg
@@ -412,11 +428,11 @@ export function SignUpForm({
                     value={formData.password}
                     onChange={handleChange}
                   />
-                  {siteKey ? (
+                  {hasCaptcha ? (
                     <div className="turnstile-container">
                       <Turnstile
                         ref={turnstileRef}
-                        siteKey={siteKey}
+                        siteKey={siteKey!}
                         onSuccess={handleTurnstileSuccess}
                         onError={() => {
                           console.error("Turnstile widget error");
@@ -442,9 +458,9 @@ export function SignUpForm({
                 <Button
                   type="submit"
                   className="w-full bg-[#0066ff] hover:bg-[#0047cc] text-white"
-                  disabled={!isLoaded || (siteKey && (!isCaptchaCompleted || isLoading))}
+                  disabled={hasCaptcha ? !isCaptchaCompleted || isLoading : isLoading}
                 >
-                  {!isLoaded ? "Loading auth..." : isLoading ? "Creating account..." : "Create account"}
+                  {isLoading ? "Creating account..." : "Create account"}
                 </Button>
               </div>
 

--- a/package.json
+++ b/package.json
@@ -12,7 +12,7 @@
   },
   "dependencies": {
     "@clerk/localizations": "4.3.0",
-    "@clerk/nextjs": "6.39.1",
+    "@clerk/nextjs": "^7.0.0",
     "@hookform/resolvers": "5.2.2",
     "@marsidev/react-turnstile": "latest",
     "@radix-ui/react-accordion": "latest",

--- a/proxy.ts
+++ b/proxy.ts
@@ -1,19 +1,23 @@
-import { clerkMiddleware } from "@clerk/nextjs/server"
+import { clerkMiddleware, createRouteMatcher } from "@clerk/nextjs/server"
 
-export default clerkMiddleware({
-  publicRoutes: [
-    "/",
-    "/app",
-    "/sign-in",
-    "/sign-up",
-    "/reset-password",
-    "/api/share",
-    "/api/verify",
-    "/at-oauth",
-    "/api/atproto/(.*)",
-    "/oauth-client-metadata.json",
-    "/api/share/public"
-  ],
+const isPublicRoute = createRouteMatcher([
+  "/",
+  "/app",
+  "/sign-in(.*)",
+  "/sign-up(.*)",
+  "/reset-password",
+  "/api/share",
+  "/api/verify",
+  "/at-oauth",
+  "/api/atproto/(.*)",
+  "/oauth-client-metadata.json",
+  "/api/share/public",
+])
+
+export default clerkMiddleware(async (auth, req) => {
+  if (!isPublicRoute(req)) {
+    await auth.protect()
+  }
 })
 
 export const config = {


### PR DESCRIPTION
### Motivation
- Bring the project to Clerk `@clerk/nextjs` v7-compatible APIs while preserving existing authentication behavior and custom flows.
- Replace deprecated provider and middleware props/usages from v6 to the v7/Core-3 recommended patterns to avoid runtime/type regressions.

### Description
- Bumped `@clerk/nextjs` in `package.json` to `^7.0.0` and updated `app/layout.tsx` to use v7 `ClerkProvider` redirect props (`signInFallbackRedirectUrl`, `signUpFallbackRedirectUrl`, `signInForceRedirectUrl`, `signUpForceRedirectUrl`).
- Rewrote the middleware in `proxy.ts` to use `createRouteMatcher()` + `clerkMiddleware(async (auth, req) => ...)` and call `auth.protect()` for non-public routes (preserves the original public route list).
- Migrated custom auth flows to Clerk v7 Future-style APIs across the forms:
  - `components/auth/login-form.tsx`: use `signIn.password()` and `signIn.finalize()` for password sign-in and `signIn.sso()` for OAuth flows.
  - `components/auth/sign-up-form.tsx`: use `signUp.password()` for password sign-up, `signUp.verifications.sendEmailCode()` / `verifyEmailCode()` for email verification, `signUp.finalize()` to finalize the session, and `signUp.sso()` for OAuth.
  - `components/auth/reset-form.tsx`: use `signIn.resetPasswordEmailCode.sendCode()` / `verifyCode()` / `submitPassword()` and `signIn.finalize()` for reset flows.
- Adjusted error handling to the v7 `ClerkError` shape (use `.longMessage` / `.message`) and tightened Turnstile `siteKey` usage with non-null assertions where applicable.

### Testing
- Ran a focused TypeScript check for upgraded files with `bunx tsc --noEmit 2>&1 | rg "app/layout.tsx|components/auth/login-form.tsx|components/auth/sign-up-form.tsx|components/auth/reset-form.tsx|proxy.ts"`, and no TypeScript errors were reported for the modified files (success).
- Ran a full project build with `bun run build`, which failed in the environment due to external Google Fonts fetch/network errors during the Next.js/Turbopack font fetch step; this failure is environment/network-related and not related to the Clerk API changes (build aborted because Google Fonts could not be fetched).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69d265337edc8326964b65c95e8e3168)

## Summary by Sourcery

在保留现有认证流程和路由行为的前提下，将应用的 Clerk Next.js 集成升级到 v7 API。

Bug 修复：
- 通过使用 Clerk v7 的错误对象，并在登录、注册和重置流程中展示更友好的错误信息，提高认证错误处理的健壮性。

增强内容：
- 将登录、注册、OAuth 和密码重置流程迁移到 Clerk v7 的 Future 风格方法，使用基于 finalize 的导航替代直接会话激活。
- 在根布局中更新 `ClerkProvider` 配置，使用 v7 的登录/注册重定向参数，以实现统一的认证后路由行为。
- 优化 Turnstile CAPTCHA 处理逻辑，通过布尔标志控制其使用、调整禁用状态，并在渲染时断言站点密钥的存在。
- 将中间件重构为 v7 模式：使用 `createRouteMatcher` 配合 `clerkMiddleware`，对非公共路由使用 `auth.protect` 进行保护，同时扩展公共认证路由以包含嵌套路由的登录/注册路径。

构建：
- 在 `package.json` 中将 `@clerk/nextjs` 依赖从 v6 升级到 ^7.0.0。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Upgrade the app’s Clerk Next.js integration to v7 APIs while preserving existing authentication flows and routing behavior.

Bug Fixes:
- Improve robustness of auth error handling by using Clerk v7 error objects and surfacing user-friendly messages across login, sign-up, and reset flows.

Enhancements:
- Migrate login, sign-up, OAuth, and password reset flows to Clerk v7 Future-style methods with finalize-based navigation instead of direct session activation.
- Update ClerkProvider configuration in the root layout to use v7 sign-in/sign-up redirect props for consistent post-auth routing.
- Refine Turnstile CAPTCHA handling by guarding usage with a boolean flag, adjusting disabled states, and asserting presence of the site key when rendering.
- Refactor middleware to the v7 pattern using createRouteMatcher plus clerkMiddleware with auth.protect on non-public routes while expanding public auth routes to include nested sign-in/sign-up paths.

Build:
- Bump @clerk/nextjs dependency from v6 to ^7.0.0 in package.json.

</details>