### PR TITLE
Anchor event preview as a Popover and pass clicked element anchor from views

### DIFF
--- a/components/app/auth-waiting-loading.tsx
+++ b/components/app/auth-waiting-loading.tsx
@@ -25,8 +25,8 @@ export default function AuthWaitingLoading() {
         <Image
           src="/icon.svg"
           alt="One Calendar"
-          width={128}
-          height={128}
+          width={96}
+          height={96}
           priority
         />
         <p className="text-sm text-slate-700 dark:text-slate-300">

--- a/components/app/calendar.tsx
+++ b/components/app/calendar.tsx
@@ -152,7 +152,7 @@ export default function Calendar({ className, ...props }: CalendarProps) {
   const notificationsInitializedRef = useRef(false);
   const [previewEvent, setPreviewEvent] = useState<CalendarEvent | null>(null);
   const [previewOpen, setPreviewOpen] = useState(false);
-  const [previewAnchorRect, setPreviewAnchorRect] = useState<DOMRect | null>(
+  const [previewAnchorEl, setPreviewAnchorEl] = useState<HTMLElement | null>(
     null,
   );
   const [focusUserProfileSection, setFocusUserProfileSection] =
@@ -441,7 +441,7 @@ export default function Calendar({ className, ...props }: CalendarProps) {
   ) => {
     setShareOnlyMode(false);
     setPreviewEvent(event);
-    setPreviewAnchorRect(anchorEl?.getBoundingClientRect() ?? null);
+    setPreviewAnchorEl(anchorEl ?? null);
     setPreviewOpen(true);
   };
 
@@ -580,7 +580,7 @@ export default function Calendar({ className, ...props }: CalendarProps) {
       setQuickCreateStartTime(null);
       setEventDialogOpen(true);
       setPreviewOpen(false);
-      setPreviewAnchorRect(null);
+      setPreviewAnchorEl(null);
     }
   };
 
@@ -591,7 +591,7 @@ export default function Calendar({ className, ...props }: CalendarProps) {
     };
     setEvents((prevEvents) => [...prevEvents, duplicatedEvent]);
     setPreviewOpen(false);
-    setPreviewAnchorRect(null);
+    setPreviewAnchorEl(null);
   };
 
   const handleTimeRangeSelect = (startTime: Date, endTime?: Date) => {
@@ -632,7 +632,7 @@ export default function Calendar({ className, ...props }: CalendarProps) {
   const handleShare = (event: CalendarEvent, shareOnly = false) => {
     setShareOnlyMode(shareOnly);
     setPreviewEvent(event);
-    setPreviewAnchorRect(null);
+    setPreviewAnchorEl(null);
     setOpenShareImmediately(true);
     setPreviewOpen(true);
   };
@@ -810,7 +810,7 @@ export default function Calendar({ className, ...props }: CalendarProps) {
                   onKeyDown={(e) => {
                     if (e.key === "Enter" && searchResultEvents.length > 0) {
                       setPreviewEvent(searchResultEvents[0]);
-                      setPreviewAnchorRect(null);
+                      setPreviewAnchorEl(null);
                       setPreviewOpen(true);
                       setSearchTerm("");
                       setIsSearchFocused(false);
@@ -831,7 +831,7 @@ export default function Calendar({ className, ...props }: CalendarProps) {
                               onMouseDown={(e) => {
                                 e.preventDefault();
                                 setPreviewEvent(event);
-                                setPreviewAnchorRect(null);
+                                setPreviewAnchorEl(null);
                                 setPreviewOpen(true);
                                 setSearchTerm("");
                                 setIsSearchFocused(false);
@@ -1068,7 +1068,7 @@ export default function Calendar({ className, ...props }: CalendarProps) {
             setPreviewOpen(open);
             if (!open) {
               setOpenShareImmediately(false);
-              setPreviewAnchorRect(null);
+              setPreviewAnchorEl(null);
             }
           }}
           onEdit={handleEventEdit}
@@ -1076,7 +1076,7 @@ export default function Calendar({ className, ...props }: CalendarProps) {
             if (previewEvent) {
               handleEventDelete(previewEvent.id);
               setPreviewOpen(false);
-              setPreviewAnchorRect(null);
+              setPreviewAnchorEl(null);
             }
           }}
           onDuplicate={handleEventDuplicate}
@@ -1084,7 +1084,7 @@ export default function Calendar({ className, ...props }: CalendarProps) {
           timezone={timezone}
           openShareImmediately={openShareImmediately}
           shareOnlyMode={shareOnlyMode}
-          anchorRect={previewAnchorRect}
+          anchorEl={previewAnchorEl}
         />
 
         <EventDialog

--- a/components/app/calendar.tsx
+++ b/components/app/calendar.tsx
@@ -21,7 +21,7 @@ import {
   CloudUpload,
   CheckCircle2,
   AlertCircle,
-  Loader2,
+  LoaderIcon,
   CircleHelp,
   ShieldCheck,
   MessageSquare,
@@ -152,6 +152,9 @@ export default function Calendar({ className, ...props }: CalendarProps) {
   const notificationsInitializedRef = useRef(false);
   const [previewEvent, setPreviewEvent] = useState<CalendarEvent | null>(null);
   const [previewOpen, setPreviewOpen] = useState(false);
+  const [previewAnchorRect, setPreviewAnchorRect] = useState<DOMRect | null>(
+    null,
+  );
   const [focusUserProfileSection, setFocusUserProfileSection] =
     useState<UserProfileSection | null>(null);
   const [sidebarDate, setSidebarDate] = useState<Date>(new Date());
@@ -248,7 +251,7 @@ export default function Calendar({ className, ...props }: CalendarProps) {
     if (!backupEnabled) return null;
 
     if (backupSyncStatus === "uploading") {
-      return <Loader2 className="h-4 w-4 animate-spin" />;
+      return <LoaderIcon className="h-4 w-4 animate-spin" />;
     }
     if (backupSyncStatus === "failed") {
       return <AlertCircle className="h-4 w-4 text-destructive" />;
@@ -432,9 +435,13 @@ export default function Calendar({ className, ...props }: CalendarProps) {
     }
   };
 
-  const handleEventClick = (event: CalendarEvent) => {
+  const handleEventClick = (
+    event: CalendarEvent,
+    anchorEl?: HTMLElement | null,
+  ) => {
     setShareOnlyMode(false);
     setPreviewEvent(event);
+    setPreviewAnchorRect(anchorEl?.getBoundingClientRect() ?? null);
     setPreviewOpen(true);
   };
 
@@ -573,6 +580,7 @@ export default function Calendar({ className, ...props }: CalendarProps) {
       setQuickCreateStartTime(null);
       setEventDialogOpen(true);
       setPreviewOpen(false);
+      setPreviewAnchorRect(null);
     }
   };
 
@@ -583,6 +591,7 @@ export default function Calendar({ className, ...props }: CalendarProps) {
     };
     setEvents((prevEvents) => [...prevEvents, duplicatedEvent]);
     setPreviewOpen(false);
+    setPreviewAnchorRect(null);
   };
 
   const handleTimeRangeSelect = (startTime: Date, endTime?: Date) => {
@@ -623,6 +632,7 @@ export default function Calendar({ className, ...props }: CalendarProps) {
   const handleShare = (event: CalendarEvent, shareOnly = false) => {
     setShareOnlyMode(shareOnly);
     setPreviewEvent(event);
+    setPreviewAnchorRect(null);
     setOpenShareImmediately(true);
     setPreviewOpen(true);
   };
@@ -800,6 +810,7 @@ export default function Calendar({ className, ...props }: CalendarProps) {
                   onKeyDown={(e) => {
                     if (e.key === "Enter" && searchResultEvents.length > 0) {
                       setPreviewEvent(searchResultEvents[0]);
+                      setPreviewAnchorRect(null);
                       setPreviewOpen(true);
                       setSearchTerm("");
                       setIsSearchFocused(false);
@@ -820,6 +831,7 @@ export default function Calendar({ className, ...props }: CalendarProps) {
                               onMouseDown={(e) => {
                                 e.preventDefault();
                                 setPreviewEvent(event);
+                                setPreviewAnchorRect(null);
                                 setPreviewOpen(true);
                                 setSearchTerm("");
                                 setIsSearchFocused(false);
@@ -1054,13 +1066,17 @@ export default function Calendar({ className, ...props }: CalendarProps) {
           open={previewOpen}
           onOpenChange={(open) => {
             setPreviewOpen(open);
-            if (!open) setOpenShareImmediately(false);
+            if (!open) {
+              setOpenShareImmediately(false);
+              setPreviewAnchorRect(null);
+            }
           }}
           onEdit={handleEventEdit}
           onDelete={() => {
             if (previewEvent) {
               handleEventDelete(previewEvent.id);
               setPreviewOpen(false);
+              setPreviewAnchorRect(null);
             }
           }}
           onDuplicate={handleEventDuplicate}
@@ -1068,6 +1084,7 @@ export default function Calendar({ className, ...props }: CalendarProps) {
           timezone={timezone}
           openShareImmediately={openShareImmediately}
           shareOnlyMode={shareOnlyMode}
+          anchorRect={previewAnchorRect}
         />
 
         <EventDialog

--- a/components/app/calendar.tsx
+++ b/components/app/calendar.tsx
@@ -1016,7 +1016,6 @@ export default function Calendar({ className, ...props }: CalendarProps) {
                 firstDayOfWeek={normalizedFirstDayOfWeek}
                 isSidebarCollapsed={isSidebarCollapsed}
                 isSidebarExpanding={isSidebarExpanding}
-                eventPreviewOpen={previewOpen}
               />
             )}
             {view === "analytics" && (

--- a/components/app/calendar.tsx
+++ b/components/app/calendar.tsx
@@ -152,7 +152,7 @@ export default function Calendar({ className, ...props }: CalendarProps) {
   const notificationsInitializedRef = useRef(false);
   const [previewEvent, setPreviewEvent] = useState<CalendarEvent | null>(null);
   const [previewOpen, setPreviewOpen] = useState(false);
-  const [previewAnchorEl, setPreviewAnchorEl] = useState<HTMLElement | null>(
+  const [previewAnchorRect, setPreviewAnchorRect] = useState<DOMRect | null>(
     null,
   );
   const [focusUserProfileSection, setFocusUserProfileSection] =
@@ -441,7 +441,7 @@ export default function Calendar({ className, ...props }: CalendarProps) {
   ) => {
     setShareOnlyMode(false);
     setPreviewEvent(event);
-    setPreviewAnchorEl(anchorEl ?? null);
+    setPreviewAnchorRect(anchorEl?.getBoundingClientRect() ?? null);
     setPreviewOpen(true);
   };
 
@@ -580,7 +580,7 @@ export default function Calendar({ className, ...props }: CalendarProps) {
       setQuickCreateStartTime(null);
       setEventDialogOpen(true);
       setPreviewOpen(false);
-      setPreviewAnchorEl(null);
+      setPreviewAnchorRect(null);
     }
   };
 
@@ -591,7 +591,7 @@ export default function Calendar({ className, ...props }: CalendarProps) {
     };
     setEvents((prevEvents) => [...prevEvents, duplicatedEvent]);
     setPreviewOpen(false);
-    setPreviewAnchorEl(null);
+    setPreviewAnchorRect(null);
   };
 
   const handleTimeRangeSelect = (startTime: Date, endTime?: Date) => {
@@ -632,7 +632,7 @@ export default function Calendar({ className, ...props }: CalendarProps) {
   const handleShare = (event: CalendarEvent, shareOnly = false) => {
     setShareOnlyMode(shareOnly);
     setPreviewEvent(event);
-    setPreviewAnchorEl(null);
+    setPreviewAnchorRect(null);
     setOpenShareImmediately(true);
     setPreviewOpen(true);
   };
@@ -810,7 +810,7 @@ export default function Calendar({ className, ...props }: CalendarProps) {
                   onKeyDown={(e) => {
                     if (e.key === "Enter" && searchResultEvents.length > 0) {
                       setPreviewEvent(searchResultEvents[0]);
-                      setPreviewAnchorEl(null);
+                      setPreviewAnchorRect(null);
                       setPreviewOpen(true);
                       setSearchTerm("");
                       setIsSearchFocused(false);
@@ -831,7 +831,7 @@ export default function Calendar({ className, ...props }: CalendarProps) {
                               onMouseDown={(e) => {
                                 e.preventDefault();
                                 setPreviewEvent(event);
-                                setPreviewAnchorEl(null);
+                                setPreviewAnchorRect(null);
                                 setPreviewOpen(true);
                                 setSearchTerm("");
                                 setIsSearchFocused(false);
@@ -1068,7 +1068,7 @@ export default function Calendar({ className, ...props }: CalendarProps) {
             setPreviewOpen(open);
             if (!open) {
               setOpenShareImmediately(false);
-              setPreviewAnchorEl(null);
+              setPreviewAnchorRect(null);
             }
           }}
           onEdit={handleEventEdit}
@@ -1076,7 +1076,7 @@ export default function Calendar({ className, ...props }: CalendarProps) {
             if (previewEvent) {
               handleEventDelete(previewEvent.id);
               setPreviewOpen(false);
-              setPreviewAnchorEl(null);
+              setPreviewAnchorRect(null);
             }
           }}
           onDuplicate={handleEventDuplicate}
@@ -1084,7 +1084,7 @@ export default function Calendar({ className, ...props }: CalendarProps) {
           timezone={timezone}
           openShareImmediately={openShareImmediately}
           shareOnlyMode={shareOnlyMode}
-          anchorEl={previewAnchorEl}
+          anchorRect={previewAnchorRect}
         />
 
         <EventDialog

--- a/components/app/calendar.tsx
+++ b/components/app/calendar.tsx
@@ -1016,6 +1016,7 @@ export default function Calendar({ className, ...props }: CalendarProps) {
                 firstDayOfWeek={normalizedFirstDayOfWeek}
                 isSidebarCollapsed={isSidebarCollapsed}
                 isSidebarExpanding={isSidebarExpanding}
+                eventPreviewOpen={previewOpen}
               />
             )}
             {view === "analytics" && (

--- a/components/app/calendar.tsx
+++ b/components/app/calendar.tsx
@@ -1085,6 +1085,7 @@ export default function Calendar({ className, ...props }: CalendarProps) {
           openShareImmediately={openShareImmediately}
           shareOnlyMode={shareOnlyMode}
           anchorRect={previewAnchorRect}
+          modal={view !== "year"}
         />
 
         <EventDialog

--- a/components/app/event/event-preview.tsx
+++ b/components/app/event/event-preview.tsx
@@ -30,6 +30,11 @@ import { isZhLanguage, translations } from "@/lib/i18n";
 import { cn } from "@/lib/utils";
 import { useCalendar } from "@/components/providers/calendar-context";
 import {
+  Popover,
+  PopoverAnchor,
+  PopoverContent,
+} from "@/components/ui/popover";
+import {
   Dialog,
   DialogContent,
   DialogHeader,
@@ -55,6 +60,7 @@ interface EventPreviewProps {
   timezone: string;
   openShareImmediately?: boolean;
   shareOnlyMode?: boolean;
+  anchorRect?: DOMRect | null;
 }
 
 export default function EventPreview({
@@ -68,6 +74,7 @@ export default function EventPreview({
   timezone,
   openShareImmediately,
   shareOnlyMode = false,
+  anchorRect = null,
 }: EventPreviewProps) {
   const { calendars } = useCalendar();
   const isZh = isZhLanguage(language);
@@ -443,16 +450,42 @@ export default function EventPreview({
     onDelete();
   };
 
+  const anchorStyle: React.CSSProperties = anchorRect
+    ? {
+        position: "fixed",
+        left: anchorRect.right,
+        top: anchorRect.top + anchorRect.height / 2,
+        width: 0,
+        height: 0,
+        pointerEvents: "none",
+      }
+    : {
+        position: "fixed",
+        left:
+          typeof window === "undefined" ? 0 : Math.round(window.innerWidth / 2),
+        top:
+          typeof window === "undefined"
+            ? 0
+            : Math.round(window.innerHeight / 2),
+        width: 0,
+        height: 0,
+        pointerEvents: "none",
+      };
+
   return (
     <>
       {!shareOnlyMode && (
-        <div
-          className="fixed inset-0 z-50 flex items-center justify-center bg-black/10"
-          onClick={() => onOpenChange(false)}
+        <Popover open={open} onOpenChange={onOpenChange}
         >
-          <div
-            className="bg-background rounded-xl shadow-lg w-full max-w-md mx-4 overflow-hidden"
-            onClick={(e) => e.stopPropagation()}
+          <PopoverAnchor asChild>
+            <div style={anchorStyle} />
+          </PopoverAnchor>
+          <PopoverContent
+            side={anchorRect ? "right" : "bottom"}
+            align={anchorRect ? "start" : "center"}
+            sideOffset={12}
+            className="w-[min(96vw,28rem)] rounded-xl p-0 overflow-hidden"
+            onOpenAutoFocus={(e) => e.preventDefault()}
           >
             <div className="flex justify-between items-center p-5">
               <div className="w-24" />
@@ -628,8 +661,8 @@ export default function EventPreview({
                 </div>
               )}
             </div>
-          </div>
-        </div>
+          </PopoverContent>
+        </Popover>
       )}
 
       <Dialog

--- a/components/app/event/event-preview.tsx
+++ b/components/app/event/event-preview.tsx
@@ -533,7 +533,7 @@ export default function EventPreview({
   return (
     <>
       {!shareOnlyMode && (
-        <Popover open={open} onOpenChange={onOpenChange} modal={false}>
+        <Popover open={open} onOpenChange={onOpenChange} modal>
           <PopoverAnchor asChild>
             <div style={anchorStyle} />
           </PopoverAnchor>

--- a/components/app/event/event-preview.tsx
+++ b/components/app/event/event-preview.tsx
@@ -516,7 +516,7 @@ export default function EventPreview({
   return (
     <>
       {!shareOnlyMode && (
-        <Popover open={open} onOpenChange={onOpenChange}>
+        <Popover open={open} onOpenChange={onOpenChange} modal={false}>
           <PopoverAnchor asChild>
             <div style={anchorStyle} />
           </PopoverAnchor>

--- a/components/app/event/event-preview.tsx
+++ b/components/app/event/event-preview.tsx
@@ -60,7 +60,7 @@ interface EventPreviewProps {
   timezone: string;
   openShareImmediately?: boolean;
   shareOnlyMode?: boolean;
-  anchorEl?: HTMLElement | null;
+  anchorRect?: DOMRect | null;
 }
 
 export default function EventPreview({
@@ -74,7 +74,7 @@ export default function EventPreview({
   timezone,
   openShareImmediately,
   shareOnlyMode = false,
-  anchorEl = null,
+  anchorRect = null,
 }: EventPreviewProps) {
   const { calendars } = useCalendar();
   const isZh = isZhLanguage(language);
@@ -95,7 +95,6 @@ export default function EventPreview({
   const [passwordEnabled, setPasswordEnabled] = useState(false);
   const [sharePassword, setSharePassword] = useState("");
   const [burnAfterRead, setBurnAfterRead] = useState(false);
-  const [liveAnchorRect, setLiveAnchorRect] = useState<DOMRect | null>(null);
   const colorMapping: Record<string, string> = {
     "bg-[#E6F6FD]": "#3B82F6",
     "bg-[#E7F8F2]": "#10B981",
@@ -168,27 +167,6 @@ export default function EventPreview({
       setIsBookmarked(isCurrentEventBookmarked);
     }
   }, [event, bookmarks]);
-
-  useEffect(() => {
-    if (!open) return;
-
-    const updateAnchorRect = () => {
-      if (anchorEl && anchorEl.isConnected) {
-        setLiveAnchorRect(anchorEl.getBoundingClientRect());
-        return;
-      }
-      setLiveAnchorRect(null);
-    };
-
-    updateAnchorRect();
-    window.addEventListener("scroll", updateAnchorRect, true);
-    window.addEventListener("resize", updateAnchorRect);
-
-    return () => {
-      window.removeEventListener("scroll", updateAnchorRect, true);
-      window.removeEventListener("resize", updateAnchorRect);
-    };
-  }, [open, anchorEl]);
 
   if (!event || (!open && !shareDialogOpen)) return null;
 
@@ -472,17 +450,17 @@ export default function EventPreview({
     onDelete();
   };
 
-  const popoverSide: "top" | "right" | "bottom" | "left" = liveAnchorRect
+  const popoverSide: "top" | "right" | "bottom" | "left" = anchorRect
     ? (() => {
         const viewportWidth =
           typeof window === "undefined" ? 0 : window.innerWidth;
         const viewportHeight =
           typeof window === "undefined" ? 0 : window.innerHeight;
         const spaces = {
-          top: liveAnchorRect.top,
-          right: viewportWidth - liveAnchorRect.right,
-          bottom: viewportHeight - liveAnchorRect.bottom,
-          left: liveAnchorRect.left,
+          top: anchorRect.top,
+          right: viewportWidth - anchorRect.right,
+          bottom: viewportHeight - anchorRect.bottom,
+          left: anchorRect.left,
         };
         const estimatedWidth = 460;
         const estimatedHeight = 520;
@@ -498,17 +476,17 @@ export default function EventPreview({
     : "bottom";
 
   const anchorStyle: React.CSSProperties = (() => {
-    if (liveAnchorRect) {
-      const midX = liveAnchorRect.left + liveAnchorRect.width / 2;
-      const midY = liveAnchorRect.top + liveAnchorRect.height / 2;
+    if (anchorRect) {
+      const midX = anchorRect.left + anchorRect.width / 2;
+      const midY = anchorRect.top + anchorRect.height / 2;
       const edgePoint =
         popoverSide === "right"
-          ? { left: liveAnchorRect.right, top: midY }
+          ? { left: anchorRect.right, top: midY }
           : popoverSide === "left"
-            ? { left: liveAnchorRect.left, top: midY }
+            ? { left: anchorRect.left, top: midY }
             : popoverSide === "top"
-              ? { left: midX, top: liveAnchorRect.top }
-              : { left: midX, top: liveAnchorRect.bottom };
+              ? { left: midX, top: anchorRect.top }
+              : { left: midX, top: anchorRect.bottom };
       return {
         position: "fixed",
         left: edgePoint.left,

--- a/components/app/event/event-preview.tsx
+++ b/components/app/event/event-preview.tsx
@@ -61,6 +61,7 @@ interface EventPreviewProps {
   openShareImmediately?: boolean;
   shareOnlyMode?: boolean;
   anchorRect?: DOMRect | null;
+  modal?: boolean;
 }
 
 export default function EventPreview({
@@ -75,6 +76,7 @@ export default function EventPreview({
   openShareImmediately,
   shareOnlyMode = false,
   anchorRect = null,
+  modal = true,
 }: EventPreviewProps) {
   const { calendars } = useCalendar();
   const isZh = isZhLanguage(language);
@@ -511,7 +513,7 @@ export default function EventPreview({
   return (
     <>
       {!shareOnlyMode && (
-        <Popover open={open} onOpenChange={onOpenChange} modal>
+        <Popover open={open} onOpenChange={onOpenChange} modal={modal}>
           <PopoverAnchor asChild>
             <div style={anchorStyle} />
           </PopoverAnchor>

--- a/components/app/event/event-preview.tsx
+++ b/components/app/event/event-preview.tsx
@@ -97,6 +97,7 @@ export default function EventPreview({
   const [passwordEnabled, setPasswordEnabled] = useState(false);
   const [sharePassword, setSharePassword] = useState("");
   const [burnAfterRead, setBurnAfterRead] = useState(false);
+  const ignoreOutsideUntilRef = useRef(0);
   const colorMapping: Record<string, string> = {
     "bg-[#E6F6FD]": "#3B82F6",
     "bg-[#E7F8F2]": "#10B981",
@@ -120,6 +121,12 @@ export default function EventPreview({
       }
     }
   }, [open, openShareImmediately, isSignedIn, atprotoSignedIn, language]);
+
+  useEffect(() => {
+    if (open && !modal) {
+      ignoreOutsideUntilRef.current = Date.now() + 150;
+    }
+  }, [open, modal]);
 
   useEffect(() => {
     fetch("/api/atproto/session")
@@ -524,7 +531,13 @@ export default function EventPreview({
             className="w-[min(96vw,28rem)] rounded-xl p-0 overflow-hidden"
             onOpenAutoFocus={(e) => e.preventDefault()}
             onInteractOutside={(e) => {
-              if (!modal) e.preventDefault();
+              if (!modal) {
+                if (Date.now() < ignoreOutsideUntilRef.current) {
+                  e.preventDefault();
+                  return;
+                }
+                onOpenChange(false);
+              }
             }}
           >
             <div className="flex justify-between items-center p-5">

--- a/components/app/event/event-preview.tsx
+++ b/components/app/event/event-preview.tsx
@@ -169,6 +169,27 @@ export default function EventPreview({
     }
   }, [event, bookmarks]);
 
+  useEffect(() => {
+    if (!open) return;
+
+    const updateAnchorRect = () => {
+      if (anchorEl && anchorEl.isConnected) {
+        setLiveAnchorRect(anchorEl.getBoundingClientRect());
+        return;
+      }
+      setLiveAnchorRect(null);
+    };
+
+    updateAnchorRect();
+    window.addEventListener("scroll", updateAnchorRect, true);
+    window.addEventListener("resize", updateAnchorRect);
+
+    return () => {
+      window.removeEventListener("scroll", updateAnchorRect, true);
+      window.removeEventListener("resize", updateAnchorRect);
+    };
+  }, [open, anchorEl]);
+
   if (!event || (!open && !shareDialogOpen)) return null;
 
   const getCalendarName = () => {
@@ -450,27 +471,6 @@ export default function EventPreview({
     e.stopPropagation();
     onDelete();
   };
-
-  useEffect(() => {
-    if (!open) return;
-
-    const updateAnchorRect = () => {
-      if (anchorEl && anchorEl.isConnected) {
-        setLiveAnchorRect(anchorEl.getBoundingClientRect());
-        return;
-      }
-      setLiveAnchorRect(null);
-    };
-
-    updateAnchorRect();
-    window.addEventListener("scroll", updateAnchorRect, true);
-    window.addEventListener("resize", updateAnchorRect);
-
-    return () => {
-      window.removeEventListener("scroll", updateAnchorRect, true);
-      window.removeEventListener("resize", updateAnchorRect);
-    };
-  }, [open, anchorEl]);
 
   const anchorStyle: React.CSSProperties = liveAnchorRect
     ? {

--- a/components/app/event/event-preview.tsx
+++ b/components/app/event/event-preview.tsx
@@ -523,6 +523,9 @@ export default function EventPreview({
             sideOffset={12}
             className="w-[min(96vw,28rem)] rounded-xl p-0 overflow-hidden"
             onOpenAutoFocus={(e) => e.preventDefault()}
+            onInteractOutside={(e) => {
+              if (!modal) e.preventDefault();
+            }}
           >
             <div className="flex justify-between items-center p-5">
               <div className="w-24" />

--- a/components/app/event/event-preview.tsx
+++ b/components/app/event/event-preview.tsx
@@ -472,28 +472,6 @@ export default function EventPreview({
     onDelete();
   };
 
-  const anchorStyle: React.CSSProperties = liveAnchorRect
-    ? {
-        position: "fixed",
-        left: liveAnchorRect.left + liveAnchorRect.width / 2,
-        top: liveAnchorRect.top + liveAnchorRect.height / 2,
-        width: 0,
-        height: 0,
-        pointerEvents: "none",
-      }
-    : {
-        position: "fixed",
-        left:
-          typeof window === "undefined" ? 0 : Math.round(window.innerWidth / 2),
-        top:
-          typeof window === "undefined"
-            ? 0
-            : Math.round(window.innerHeight / 2),
-        width: 0,
-        height: 0,
-        pointerEvents: "none",
-      };
-
   const popoverSide: "top" | "right" | "bottom" | "left" = liveAnchorRect
     ? (() => {
         const viewportWidth =
@@ -506,12 +484,51 @@ export default function EventPreview({
           bottom: viewportHeight - liveAnchorRect.bottom,
           left: liveAnchorRect.left,
         };
+        const estimatedWidth = 460;
+        const estimatedHeight = 520;
+        if (spaces.right >= estimatedWidth) return "right";
+        if (spaces.left >= estimatedWidth) return "left";
+        if (spaces.bottom >= estimatedHeight) return "bottom";
+        if (spaces.top >= estimatedHeight) return "top";
         const entries = Object.entries(spaces) as Array<
           ["top" | "right" | "bottom" | "left", number]
         >;
         return entries.sort((a, b) => b[1] - a[1])[0][0];
       })()
     : "bottom";
+
+  const anchorStyle: React.CSSProperties = (() => {
+    if (liveAnchorRect) {
+      const midX = liveAnchorRect.left + liveAnchorRect.width / 2;
+      const midY = liveAnchorRect.top + liveAnchorRect.height / 2;
+      const edgePoint =
+        popoverSide === "right"
+          ? { left: liveAnchorRect.right, top: midY }
+          : popoverSide === "left"
+            ? { left: liveAnchorRect.left, top: midY }
+            : popoverSide === "top"
+              ? { left: midX, top: liveAnchorRect.top }
+              : { left: midX, top: liveAnchorRect.bottom };
+      return {
+        position: "fixed",
+        left: edgePoint.left,
+        top: edgePoint.top,
+        width: 0,
+        height: 0,
+        pointerEvents: "none",
+      };
+    }
+
+    return {
+      position: "fixed",
+      left: typeof window === "undefined" ? 0 : Math.round(window.innerWidth / 2),
+      top:
+        typeof window === "undefined" ? 0 : Math.round(window.innerHeight / 2),
+      width: 0,
+      height: 0,
+      pointerEvents: "none",
+    };
+  })();
 
   return (
     <>

--- a/components/app/event/event-preview.tsx
+++ b/components/app/event/event-preview.tsx
@@ -60,7 +60,7 @@ interface EventPreviewProps {
   timezone: string;
   openShareImmediately?: boolean;
   shareOnlyMode?: boolean;
-  anchorRect?: DOMRect | null;
+  anchorEl?: HTMLElement | null;
 }
 
 export default function EventPreview({
@@ -74,7 +74,7 @@ export default function EventPreview({
   timezone,
   openShareImmediately,
   shareOnlyMode = false,
-  anchorRect = null,
+  anchorEl = null,
 }: EventPreviewProps) {
   const { calendars } = useCalendar();
   const isZh = isZhLanguage(language);
@@ -95,6 +95,7 @@ export default function EventPreview({
   const [passwordEnabled, setPasswordEnabled] = useState(false);
   const [sharePassword, setSharePassword] = useState("");
   const [burnAfterRead, setBurnAfterRead] = useState(false);
+  const [liveAnchorRect, setLiveAnchorRect] = useState<DOMRect | null>(null);
   const colorMapping: Record<string, string> = {
     "bg-[#E6F6FD]": "#3B82F6",
     "bg-[#E7F8F2]": "#10B981",
@@ -450,11 +451,32 @@ export default function EventPreview({
     onDelete();
   };
 
-  const anchorStyle: React.CSSProperties = anchorRect
+  useEffect(() => {
+    if (!open) return;
+
+    const updateAnchorRect = () => {
+      if (anchorEl && anchorEl.isConnected) {
+        setLiveAnchorRect(anchorEl.getBoundingClientRect());
+        return;
+      }
+      setLiveAnchorRect(null);
+    };
+
+    updateAnchorRect();
+    window.addEventListener("scroll", updateAnchorRect, true);
+    window.addEventListener("resize", updateAnchorRect);
+
+    return () => {
+      window.removeEventListener("scroll", updateAnchorRect, true);
+      window.removeEventListener("resize", updateAnchorRect);
+    };
+  }, [open, anchorEl]);
+
+  const anchorStyle: React.CSSProperties = liveAnchorRect
     ? {
         position: "fixed",
-        left: anchorRect.right,
-        top: anchorRect.top + anchorRect.height / 2,
+        left: liveAnchorRect.left + liveAnchorRect.width / 2,
+        top: liveAnchorRect.top + liveAnchorRect.height / 2,
         width: 0,
         height: 0,
         pointerEvents: "none",
@@ -472,17 +494,35 @@ export default function EventPreview({
         pointerEvents: "none",
       };
 
+  const popoverSide: "top" | "right" | "bottom" | "left" = liveAnchorRect
+    ? (() => {
+        const viewportWidth =
+          typeof window === "undefined" ? 0 : window.innerWidth;
+        const viewportHeight =
+          typeof window === "undefined" ? 0 : window.innerHeight;
+        const spaces = {
+          top: liveAnchorRect.top,
+          right: viewportWidth - liveAnchorRect.right,
+          bottom: viewportHeight - liveAnchorRect.bottom,
+          left: liveAnchorRect.left,
+        };
+        const entries = Object.entries(spaces) as Array<
+          ["top" | "right" | "bottom" | "left", number]
+        >;
+        return entries.sort((a, b) => b[1] - a[1])[0][0];
+      })()
+    : "bottom";
+
   return (
     <>
       {!shareOnlyMode && (
-        <Popover open={open} onOpenChange={onOpenChange}
-        >
+        <Popover open={open} onOpenChange={onOpenChange}>
           <PopoverAnchor asChild>
             <div style={anchorStyle} />
           </PopoverAnchor>
           <PopoverContent
-            side={anchorRect ? "right" : "bottom"}
-            align={anchorRect ? "start" : "center"}
+            side={popoverSide}
+            align="center"
             sideOffset={12}
             className="w-[min(96vw,28rem)] rounded-xl p-0 overflow-hidden"
             onOpenAutoFocus={(e) => e.preventDefault()}

--- a/components/app/sidebar/sidebar.tsx
+++ b/components/app/sidebar/sidebar.tsx
@@ -206,7 +206,7 @@ export default function Sidebar({
       style={{ "--sidebar-calendar-width": "17rem" } as CSSProperties}
       className={cn(
         "border-r bg-background overflow-y-auto transition-all duration-300 ease-in-out",
-        isCollapsed ? "w-0 opacity-0 overflow-hidden" : "w-[248px] opacity-100",
+        isCollapsed ? "w-0 opacity-0 overflow-hidden" : "w-[247px] opacity-100",
       )}
       onTransitionEnd={(event) => {
         if (

--- a/components/app/views/day-view.tsx
+++ b/components/app/views/day-view.tsx
@@ -30,7 +30,7 @@ const ContextMenuItem = (_props: any) => null;
 interface DayViewProps {
   date: Date;
   events: CalendarEvent[];
-  onEventClick: (event: CalendarEvent) => void;
+  onEventClick: (event: CalendarEvent, anchorEl?: HTMLElement | null) => void;
   onTimeSlotClick: (startDate: Date, endDate?: Date) => void;
   language: Language;
   timezone: string;
@@ -537,7 +537,7 @@ export default function DayView({
               e.stopPropagation();
               if (ignoreNextEventClickRef.current) return;
               if (!isDraggingRef.current) {
-                onEventClick(event);
+                onEventClick(event, e.currentTarget as HTMLElement);
               }
             }}
           >
@@ -777,7 +777,7 @@ export default function DayView({
                       e.stopPropagation();
                       if (ignoreNextEventClickRef.current) return;
                       if (!isDraggingRef.current) {
-                        onEventClick(event);
+                        onEventClick(event, e.currentTarget as HTMLElement);
                       }
                     }}
                   >

--- a/components/app/views/month-view.tsx
+++ b/components/app/views/month-view.tsx
@@ -16,7 +16,7 @@ import { cn } from "@/lib/utils";
 interface MonthViewProps {
   date: Date;
   events: CalendarEvent[];
-  onEventClick: (event: CalendarEvent) => void;
+  onEventClick: (event: CalendarEvent, anchorEl?: HTMLElement | null) => void;
   language: Language;
   firstDayOfWeek: number;
   timezone: string;
@@ -124,7 +124,9 @@ export default function MonthView({
                     "relative text-xs truncate rounded-md p-1 cursor-pointer text-white",
                     event.color,
                   )}
-                  onClick={() => onEventClick(event)}
+                  onClick={(e) =>
+                    onEventClick(event, e.currentTarget as HTMLElement)
+                  }
                   style={{
                     opacity: 1,
                     backgroundColor: isDark

--- a/components/app/views/week-view.tsx
+++ b/components/app/views/week-view.tsx
@@ -32,7 +32,7 @@ const ContextMenuItem = (_props: any) => null;
 interface WeekViewProps {
   date: Date;
   events: any[];
-  onEventClick: (event: any) => void;
+  onEventClick: (event: CalendarEvent, anchorEl?: HTMLElement | null) => void;
   onTimeSlotClick: (startDate: Date, endDate?: Date) => void;
   language: Language;
   firstDayOfWeek: number;
@@ -648,7 +648,7 @@ export default function WeekView({
               e.stopPropagation();
               if (ignoreNextEventClickRef.current) return;
               if (!isDraggingRef.current) {
-                onEventClick(event);
+                onEventClick(event, e.currentTarget as HTMLElement);
               }
             }}
           >
@@ -897,7 +897,7 @@ export default function WeekView({
                           onClick={(e) => {
                             e.stopPropagation();
                             if (!isDraggingRef.current) {
-                              onEventClick(event);
+                              onEventClick(event, e.currentTarget as HTMLElement);
                             }
                           }}
                         >

--- a/components/app/views/year-view.tsx
+++ b/components/app/views/year-view.tsx
@@ -15,7 +15,7 @@ import {
 } from "@/components/ui/popover";
 import { isZhLanguage, translations, type Language } from "@/lib/i18n";
 import type { CalendarEvent } from "../calendar";
-import { useMemo, useState } from "react";
+import { useEffect, useMemo, useState } from "react";
 import { cn } from "@/lib/utils";
 
 interface YearViewProps {
@@ -26,6 +26,7 @@ interface YearViewProps {
   firstDayOfWeek: number;
   isSidebarCollapsed?: boolean;
   isSidebarExpanding?: boolean;
+  eventPreviewOpen?: boolean;
 }
 
 function getDarkerColorClass(color: string) {
@@ -66,6 +67,7 @@ export default function YearView({
   firstDayOfWeek,
   isSidebarCollapsed = false,
   isSidebarExpanding = false,
+  eventPreviewOpen = false,
 }: YearViewProps) {
   const t = translations[language];
   const currentYear = date.getFullYear();
@@ -136,6 +138,12 @@ export default function YearView({
     [currentYear, firstDayOfWeek, t.months],
   );
 
+  useEffect(() => {
+    if (eventPreviewOpen && openDayKey !== null) {
+      setOpenDayKey(null);
+    }
+  }, [eventPreviewOpen, openDayKey]);
+
   return (
     <div className="p-3 md:p-4">
       <div
@@ -174,9 +182,9 @@ export default function YearView({
                 return (
                   <Popover
                     key={`${month.label}-${day.toISOString()}`}
-                    open={openDayKey === popoverKey}
+                    open={!eventPreviewOpen && openDayKey === popoverKey}
                     onOpenChange={(open) =>
-                      setOpenDayKey(open ? popoverKey : null)
+                      setOpenDayKey(open && !eventPreviewOpen ? popoverKey : null)
                     }
                   >
                     <PopoverTrigger asChild>

--- a/components/app/views/year-view.tsx
+++ b/components/app/views/year-view.tsx
@@ -21,7 +21,7 @@ import { cn } from "@/lib/utils";
 interface YearViewProps {
   date: Date;
   events: CalendarEvent[];
-  onEventClick: (event: CalendarEvent) => void;
+  onEventClick: (event: CalendarEvent, anchorEl?: HTMLElement | null) => void;
   language: Language;
   firstDayOfWeek: number;
   isSidebarCollapsed?: boolean;
@@ -217,9 +217,9 @@ export default function YearView({
                                   "relative w-full cursor-pointer truncate rounded-md p-1.5 pl-3 text-left text-xs",
                                   event.color,
                                 )}
-                                onClick={() => {
+                                onClick={(e) => {
                                   setOpenDayKey(null);
-                                  onEventClick(event);
+                                  onEventClick(event, e.currentTarget);
                                 }}
                                 style={{
                                   backgroundColor: isDark

--- a/components/app/views/year-view.tsx
+++ b/components/app/views/year-view.tsx
@@ -218,7 +218,6 @@ export default function YearView({
                                   event.color,
                                 )}
                                 onClick={(e) => {
-                                  setOpenDayKey(null);
                                   onEventClick(event, e.currentTarget);
                                 }}
                                 style={{

--- a/components/app/views/year-view.tsx
+++ b/components/app/views/year-view.tsx
@@ -15,7 +15,7 @@ import {
 } from "@/components/ui/popover";
 import { isZhLanguage, translations, type Language } from "@/lib/i18n";
 import type { CalendarEvent } from "../calendar";
-import { useEffect, useMemo, useState } from "react";
+import { useMemo, useState } from "react";
 import { cn } from "@/lib/utils";
 
 interface YearViewProps {
@@ -26,7 +26,6 @@ interface YearViewProps {
   firstDayOfWeek: number;
   isSidebarCollapsed?: boolean;
   isSidebarExpanding?: boolean;
-  eventPreviewOpen?: boolean;
 }
 
 function getDarkerColorClass(color: string) {
@@ -67,7 +66,6 @@ export default function YearView({
   firstDayOfWeek,
   isSidebarCollapsed = false,
   isSidebarExpanding = false,
-  eventPreviewOpen = false,
 }: YearViewProps) {
   const t = translations[language];
   const currentYear = date.getFullYear();
@@ -138,12 +136,6 @@ export default function YearView({
     [currentYear, firstDayOfWeek, t.months],
   );
 
-  useEffect(() => {
-    if (eventPreviewOpen && openDayKey !== null) {
-      setOpenDayKey(null);
-    }
-  }, [eventPreviewOpen, openDayKey]);
-
   return (
     <div className="p-3 md:p-4">
       <div
@@ -182,9 +174,9 @@ export default function YearView({
                 return (
                   <Popover
                     key={`${month.label}-${day.toISOString()}`}
-                    open={!eventPreviewOpen && openDayKey === popoverKey}
+                    open={openDayKey === popoverKey}
                     onOpenChange={(open) =>
-                      setOpenDayKey(open && !eventPreviewOpen ? popoverKey : null)
+                      setOpenDayKey(open ? popoverKey : null)
                     }
                   >
                     <PopoverTrigger asChild>


### PR DESCRIPTION
### Motivation

- Make the event preview UI behave like a contextual popover anchored to the clicked event element so it appears next to the source item instead of centered. 
- Ensure view components can provide the clicked DOM element to the calendar so the preview can be positioned correctly. 
- Fix a loader icon import and make minor UI size/width adjustments for consistency.

### Description

- Convert `EventPreview` from a centered overlay to a `Popover` anchored to a supplied `anchorRect`, add `anchorRect` prop handling and compute an `anchorStyle` for positioning, and wire up `PopoverAnchor`/`PopoverContent` with proper side/align/offset behavior. 
- Add `previewAnchorRect` state in `calendar.tsx`, set it from `handleEventClick` using `anchorEl.getBoundingClientRect()`, clear it when closing or editing/duplicating/sharing, and pass it into `EventPreview` as `anchorRect`. 
- Update the `onEventClick` signature across views (`day-view`, `week-view`, `month-view`, `year-view`) to accept an optional `anchorEl?: HTMLElement | null` and change all event click handlers to pass `e.currentTarget` so the calendar can compute the anchor rect. 
- Replace `Loader2` with `LoaderIcon` in `calendar.tsx`, reduce the auth waiting `Image` size from `128` to `96`, and tweak the sidebar width from `w-[248px]` to `w-[247px]` for a minor layout adjustment.

### Testing

- Ran a production build with TypeScript type-checking via `next build`, which completed successfully. 
- Ran local dev smoke checks (hot-reload and UI interaction flows) to validate popover anchoring and event preview actions, with no automated errors observed.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69d26b39cd3083269af101cad61dc49b)

## Summary by Sourcery

使用弹出框将日历事件预览锚定到被点击的事件元素上，从所有日历视图中传递锚点信息，并进行一些小的 UI 一致性调整。

新功能：
- 将事件预览显示为一个弹出框，并根据来自被点击事件元素的可选锚点矩形进行相对定位。
- 允许日历视图将被点击的 DOM 元素传递给中央日历处理器，从而让预览可以在相应的上下文中被锚定。

优化改进：
- 在打开、关闭或从事件预览中执行操作时重置并管理预览锚点状态，以保持正确的定位。
- 更换备份同步加载图标，略微缩小认证等待 Logo 的尺寸，并微调侧边栏宽度以提升布局一致性。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Anchor the calendar event preview to the clicked event element using a popover, propagate anchor information from all calendar views, and make small UI consistency tweaks.

New Features:
- Display event previews as a popover positioned relative to an optional anchor rectangle from the clicked event element.
- Allow calendar views to pass the clicked DOM element into the central calendar handler so previews can be contextually anchored.

Enhancements:
- Reset and manage preview anchor state when opening, closing, or performing actions from the event preview to maintain correct positioning.
- Replace the backup syncing loader icon, slightly reduce the auth waiting logo size, and fine-tune sidebar width for layout consistency.

</details>