### PR TITLE
fix: prevent unintended cloud write when unlocking profile backup

### DIFF
--- a/components/app/profile/user-profile-button.tsx
+++ b/components/app/profile/user-profile-button.tsx
@@ -252,6 +252,7 @@ export default function UserProfileButton({
 
   const keyRef = useRef<string | null>(null);
   const restoredRef = useRef(false);
+  const skipNextAutoBackupRef = useRef(false);
   const timerRef = useRef<any>(null);
   const [backupTick, setBackupTick] = useState(0);
 
@@ -331,6 +332,10 @@ export default function UserProfileButton({
 
   useEffect(() => {
     if (!enabled || !keyRef.current || !restoredRef.current) return;
+    if (skipNextAutoBackupRef.current) {
+      skipNextAutoBackupRef.current = false;
+      return;
+    }
     if (timerRef.current) clearTimeout(timerRef.current);
 
     timerRef.current = setTimeout(async () => {
@@ -527,6 +532,7 @@ export default function UserProfileButton({
 
       keyRef.current = password;
       restoredRef.current = true;
+      skipNextAutoBackupRef.current = true;
       localStorage.setItem(AUTO_KEY, "true");
       setEnabled(true);
       broadcastBackupStatus("done");


### PR DESCRIPTION
### Motivation
- Unlocking a cloud backup with a password is intended to read/decrypt cloud data and restore it locally, but the restore flow immediately triggered the auto-backup effect and posted to `/api/blob`, causing an unintended write and updated server timestamp.
- The change prevents that first unintended write while preserving normal auto-backup behavior for subsequent user changes.

### Description
- Added a one-shot guard `skipNextAutoBackupRef` (a `useRef` boolean) to `components/app/profile/user-profile-button.tsx` to mark that the next auto-backup cycle should be skipped.
- Updated the auto-backup `useEffect` to return early and clear the guard when `skipNextAutoBackupRef.current` is set, avoiding the immediate `apiPost` after restore.
- Set `skipNextAutoBackupRef.current = true` in `unlock()` immediately after a successful restore so the restore remains read-only from the cloud perspective.

### Testing
- Ran repository validation commands `git diff -- components/app/profile/user-profile-button.tsx`, `git -C /workspace/One-Calendar status --short`, and `git -C /workspace/One-Calendar log -1 --oneline`, all of which completed successfully. 
- No automated unit or integration test suites were run as part of this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69d2eb4c47588326a58197e7562ea132)

## Summary by Sourcery

错误修复：
- 确保在解锁并恢复云端配置文件备份时，不会立即向服务器触发非预期的自动备份写入。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Bug Fixes:
- Ensure unlocking and restoring a cloud profile backup does not trigger an immediate unintended auto-backup write to the server.

</details>