### PR TITLE
fix: prevent stale backup restore data from cache

### DIFF
--- a/app/api/blob/route.ts
+++ b/app/api/blob/route.ts
@@ -5,6 +5,7 @@ import { getAtprotoSession } from "@/lib/atproto-auth";
 import { deleteRecord, getRecord, putRecord } from "@/lib/atproto";
 
 export const runtime = "nodejs";
+export const dynamic = "force-dynamic";
 
 const postgresUrl = process.env.POSTGRES_URL;
 const useSsl =
@@ -42,6 +43,14 @@ async function initDB() {
 
 const ATPROTO_BACKUP_COLLECTION = "app.onecalendar.backup";
 const ATPROTO_BACKUP_RKEY = "latest";
+
+function jsonNoStore(body: unknown, init?: ResponseInit) {
+  const response = NextResponse.json(body, init);
+  response.headers.set("Cache-Control", "no-store, no-cache, must-revalidate");
+  response.headers.set("Pragma", "no-cache");
+  response.headers.set("Expires", "0");
+  return response;
+}
 
 export async function POST(req: NextRequest) {
   try {
@@ -117,20 +126,19 @@ export async function GET() {
           dpopPublicJwk: atproto.dpopPublicJwk,
         });
         const value = record.value ?? {};
-        return NextResponse.json({
+        return jsonNoStore({
           ciphertext: value.ciphertext,
           iv: value.iv,
           timestamp: value.updatedAt,
           backend: "atproto",
         });
       } catch {
-        return NextResponse.json({ error: "Not found" }, { status: 404 });
+        return jsonNoStore({ error: "Not found" }, { status: 404 });
       }
     }
 
     const user = await currentUser();
-    if (!user)
-      return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
+    if (!user) return jsonNoStore({ error: "Unauthorized" }, { status: 401 });
 
     await initDB();
 
@@ -141,9 +149,9 @@ export async function GET() {
         [user.id],
       );
       if (result.rowCount === 0)
-        return NextResponse.json({ error: "Not found" }, { status: 404 });
+        return jsonNoStore({ error: "Not found" }, { status: 404 });
 
-      return NextResponse.json({
+      return jsonNoStore({
         ciphertext: result.rows[0].encrypted_data,
         iv: result.rows[0].iv,
         timestamp: result.rows[0].timestamp,
@@ -154,7 +162,7 @@ export async function GET() {
     }
   } catch (e: unknown) {
     const message = e instanceof Error ? e.message : "Internal error";
-    return NextResponse.json({ error: message }, { status: 500 });
+    return jsonNoStore({ error: message }, { status: 500 });
   }
 }
 

--- a/components/app/profile/user-profile-button.tsx
+++ b/components/app/profile/user-profile-button.tsx
@@ -104,7 +104,7 @@ const BACKUP_KEY_DEFAULTS: Record<string, unknown> = {
 };
 
 async function apiGet() {
-  const r = await fetch("/api/blob");
+  const r = await fetch("/api/blob", { cache: "no-store" });
   if (r.status === 404) return null;
   if (!r.ok) throw new Error();
   return r.json();


### PR DESCRIPTION
### Motivation
- Users could see a “backup succeeded” message but after a refresh and unlocking the app would restore an older backup version due to cached responses from the backup read endpoint.
- The intent is to ensure the restore path always fetches the latest encrypted blob from the server rather than a cached snapshot.

### Description
- Force the backup API route to always be dynamic by exporting `export const dynamic = "force-dynamic"` in `app/api/blob/route.ts`.
- Add a `jsonNoStore()` helper that returns JSON responses with `Cache-Control: no-store`, `Pragma: no-cache` and `Expires: 0` and use it for all `GET /api/blob` responses to prevent stale client-side caching.
- Update the client-side restore fetch to `fetch("/api/blob", { cache: "no-store" })` in `components/app/profile/user-profile-button.tsx` (the `apiGet` function) to avoid browser cache hits during unlock.

### Testing
- No automated tests were executed for this change (no test suite run as part of this patch).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69d2ef125ea88326beacaaf04712c3cc)

## Summary by Sourcery

确保在备份恢复时始终获取最新的响应，而不是从缓存中提供，以避免恢复到过期的数据。

Bug Fixes:
- 通过将备份 API 路由标记为动态并禁用其 GET 响应的缓存，防止恢复到过期的备份数据。
- 在客户端以 `cache` 模式设置为 `no-store` 的方式获取备份 blob，避免在备份恢复过程中命中浏览器缓存。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Ensure backup restore responses are always fetched fresh instead of served from caches to avoid restoring stale data.

Bug Fixes:
- Prevent stale backup data from being restored by marking the backup API route as dynamic and disabling caching on its GET responses.
- Avoid browser cache hits during backup restore by fetching the backup blob with cache mode set to no-store on the client.

</details>