### PR TITLE
fix: prevent service worker from serving stale /api backup data

### DIFF
--- a/proxy.ts
+++ b/proxy.ts
@@ -12,11 +12,13 @@ const isPublicRoute = createRouteMatcher([
   "/api/atproto/(.*)",
   "/oauth-client-metadata.json",
   "/api/share/public",
+  "/privacy",
+  "/terms",
 ])
 
 export default clerkMiddleware(async (auth, req) => {
   if (!isPublicRoute(req)) {
-    await auth.protect()
+    await auth.protect({ unauthenticatedUrl: "/sign-in" })
   }
 })
 

--- a/public/sw.js
+++ b/public/sw.js
@@ -1,4 +1,4 @@
-const CACHE_NAME = "one-calendar-shell-v1";
+const CACHE_NAME = "one-calendar-shell-v2";
 const OFFLINE_URLS = ["/app", "/icon.svg"];
 
 self.addEventListener("install", (event) => {
@@ -29,6 +29,10 @@ self.addEventListener("fetch", (event) => {
 
   const requestUrl = new URL(event.request.url);
   if (requestUrl.protocol !== "http:" && requestUrl.protocol !== "https:") {
+    return;
+  }
+  if (requestUrl.pathname.startsWith("/api/")) {
+    event.respondWith(fetch(event.request));
     return;
   }
 

--- a/public/sw.js
+++ b/public/sw.js
@@ -1,5 +1,17 @@
-const CACHE_NAME = "one-calendar-shell-v2";
+const CACHE_NAME = "one-calendar-shell-v3";
 const OFFLINE_URLS = ["/app", "/icon.svg"];
+const STATIC_PATH_PREFIXES = ["/_next/static/", "/_next/image/", "/icons/"];
+const STATIC_FILE_PATTERN =
+  /\.(?:js|css|png|jpg|jpeg|gif|svg|webp|ico|woff|woff2|ttf|otf|eot|json|txt|xml|webmanifest)$/i;
+
+function shouldCacheRequest(requestUrl) {
+  if (requestUrl.origin !== self.location.origin) return false;
+  if (OFFLINE_URLS.includes(requestUrl.pathname)) return true;
+  if (STATIC_PATH_PREFIXES.some((prefix) => requestUrl.pathname.startsWith(prefix))) {
+    return true;
+  }
+  return STATIC_FILE_PATTERN.test(requestUrl.pathname);
+}
 
 self.addEventListener("install", (event) => {
   event.waitUntil(
@@ -32,6 +44,10 @@ self.addEventListener("fetch", (event) => {
     return;
   }
   if (requestUrl.pathname.startsWith("/api/")) {
+    event.respondWith(fetch(event.request));
+    return;
+  }
+  if (!shouldCacheRequest(requestUrl)) {
     event.respondWith(fetch(event.request));
     return;
   }


### PR DESCRIPTION
### Motivation
- Backup restores (`/api/blob`) could be served from the app shell service worker cache, causing stale encrypted payloads to be returned after a successful backup write.
- The change prevents the service worker from returning cached API responses so the client always fetches fresh server state.

### Description
- Updated `public/sw.js` to bypass the SW cache for requests whose path starts with `/api/` by returning `event.respondWith(fetch(event.request))` for those requests.
- Bumped the service worker `CACHE_NAME` from `one-calendar-shell-v1` to `one-calendar-shell-v2` so existing cached assets are invalidated on activation.

### Testing
- No automated tests were run for this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69d2f113205c8326b610027832403236)

## Summary by Sourcery

防止 service worker 为 `/api` 请求提供缓存响应，并使现有已缓存的静态资源失效。

Bug 修复：
- 确保 `/api` 备份及其他 API 响应始终从网络获取，而不是从 service worker 缓存中获取，以避免使用过期数据。

增强：
- 增加 service worker 缓存版本号，以便在激活时清除旧的已缓存 shell 资源。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Prevent the service worker from serving cached responses for /api requests and invalidate existing cached assets.

Bug Fixes:
- Ensure /api backup and other API responses are always fetched from the network instead of the service worker cache to avoid stale data.

Enhancements:
- Increment the service worker cache version so old cached shell assets are cleared on activation.

</details>