### PR TITLE
fix: prevent unauthenticated route 500 and restyle analytics/settings panels

### DIFF
--- a/components/app/analytics/build-info-card.tsx
+++ b/components/app/analytics/build-info-card.tsx
@@ -1,6 +1,5 @@
 "use client";
 
-import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
 import { translations, type Language } from "@/lib/i18n";
 import { useEffect, useMemo, useState } from "react";
 
@@ -55,11 +54,9 @@ export default function BuildInfoCard({ language }: BuildInfoCardProps) {
   );
 
   return (
-    <Card>
-      <CardHeader>
-        <CardTitle>{t.buildInfoTitle}</CardTitle>
-      </CardHeader>
-      <CardContent className="space-y-3 text-sm">
+    <div className="rounded-lg border p-4 space-y-3">
+      <h2 className="text-base font-semibold">{t.buildInfoTitle}</h2>
+      <div className="space-y-3 text-sm">
         <div className="flex items-center justify-between gap-4">
           <span className="text-muted-foreground">{t.buildInfoVersion}</span>
           <span className="font-mono">{APP_VERSION}</span>
@@ -72,7 +69,7 @@ export default function BuildInfoCard({ language }: BuildInfoCardProps) {
           <span className="text-muted-foreground">{t.buildInfoDeployment}</span>
           <span>{t.buildInfoDeployedAgo.replace("{time}", deployedAgo)}</span>
         </div>
-      </CardContent>
-    </Card>
+      </div>
+    </div>
   );
 }

--- a/components/app/analytics/events-calendar.tsx
+++ b/components/app/analytics/events-calendar.tsx
@@ -22,7 +22,6 @@ import {
   SelectValue,
 } from "@/components/ui/select";
 import { isZhLanguage, translations, useLanguage } from "@/lib/i18n";
-import { Card, CardContent } from "@/components/ui/card";
 import React, { useEffect, useState } from "react";
 
 interface CalendarEvent {
@@ -286,9 +285,7 @@ const EventsCalendar: React.FC = () => {
   };
 
   return (
-    <Card className="overflow-hidden">
-      <CardContent className="pt-4">{renderCalendarGrid()}</CardContent>
-    </Card>
+    <div className="rounded-lg border p-4">{renderCalendarGrid()}</div>
   );
 };
 

--- a/components/app/analytics/import-export.tsx
+++ b/components/app/analytics/import-export.tsx
@@ -8,13 +8,6 @@ import {
   SelectValue,
 } from "@/components/ui/select";
 import {
-  Card,
-  CardContent,
-  CardDescription,
-  CardHeader,
-  CardTitle,
-} from "@/components/ui/card";
-import {
   Dialog,
   DialogContent,
   DialogHeader,
@@ -737,15 +730,15 @@ END:VEVENT
   };
 
   return (
-    <Card className="w-full">
-      <CardHeader>
+    <div className="w-full rounded-lg border p-4 space-y-6">
+      <div>
         <div className="flex justify-between items-center">
           <div>
-            <CardTitle>{t.importExport}</CardTitle>
-            <CardDescription>
+            <h2 className="text-base font-semibold">{t.importExport}</h2>
+            <p className="text-sm text-muted-foreground">
               {t.importExportDesc ||
                 "Exchange data with other calendar applications"}
-            </CardDescription>
+            </p>
           </div>
           <div className="flex space-x-2">
             <Button variant="outline" onClick={() => setImportDialogOpen(true)}>
@@ -758,9 +751,9 @@ END:VEVENT
             </Button>
           </div>
         </div>
-      </CardHeader>
+      </div>
 
-      <CardContent>
+      <div>
         <div className="space-y-6">
           <Alert>
             <AlertCircle className="h-4 w-4" />
@@ -778,7 +771,7 @@ END:VEVENT
             </ul>
           </div>
         </div>
-      </CardContent>
+      </div>
 
       {}
       <Dialog open={importDialogOpen} onOpenChange={setImportDialogOpen}>
@@ -1027,6 +1020,6 @@ END:VEVENT
           </div>
         </DialogContent>
       </Dialog>
-    </Card>
+    </div>
   );
 }

--- a/components/app/analytics/share-management.tsx
+++ b/components/app/analytics/share-management.tsx
@@ -8,13 +8,6 @@ import {
   AlertDialogCancel,
   AlertDialogAction,
 } from "@/components/ui/alert-dialog";
-import {
-  Card,
-  CardHeader,
-  CardTitle,
-  CardDescription,
-  CardContent,
-} from "@/components/ui/card";
 import { Copy, ExternalLink, Lock, Trash2 } from "lucide-react";
 import { translations, useLanguage } from "@/lib/i18n";
 import { Button } from "@/components/ui/button";
@@ -146,17 +139,19 @@ export default function ShareManagement() {
   };
 
   return (
-    <Card className="w-full">
-      <CardHeader>
+    <div className="w-full rounded-lg border p-4 space-y-6">
+      <div>
         <div className="flex justify-between items-center">
           <div>
-            <CardTitle>{t.shareManagementTitle}</CardTitle>
-            <CardDescription>{t.shareManagementDescription}</CardDescription>
+            <h2 className="text-base font-semibold">{t.shareManagementTitle}</h2>
+            <p className="text-sm text-muted-foreground">
+              {t.shareManagementDescription}
+            </p>
           </div>
         </div>
-      </CardHeader>
+      </div>
 
-      <CardContent>
+      <div>
         {sharedEvents.length === 0 ? (
           <div className="text-center py-8 text-muted-foreground">
             {t.noShares}
@@ -219,7 +214,7 @@ export default function ShareManagement() {
             ))}
           </div>
         )}
-      </CardContent>
+      </div>
 
       <AlertDialog open={deleteDialogOpen} onOpenChange={setDeleteDialogOpen}>
         <AlertDialogContent>
@@ -308,6 +303,6 @@ export default function ShareManagement() {
           </AlertDialogFooter>
         </AlertDialogContent>
       </AlertDialog>
-    </Card>
+    </div>
   );
 }

--- a/components/app/analytics/time-analytics.tsx
+++ b/components/app/analytics/time-analytics.tsx
@@ -19,13 +19,6 @@ import {
   SelectTrigger,
   SelectValue,
 } from "@/components/ui/select";
-import {
-  Card,
-  CardContent,
-  CardDescription,
-  CardHeader,
-  CardTitle,
-} from "@/components/ui/card";
 import { analyzeTimeUsage, type TimeAnalytics } from "@/lib/time-analytics";
 import type { CalendarCategory } from "../sidebar/sidebar";
 import { useLocalStorage } from "@/hooks/useLocalStorage";
@@ -168,14 +161,14 @@ export default function TimeAnalyticsComponent({
   })();
 
   return (
-    <Card className="w-full">
-      <CardHeader>
+    <div className="w-full rounded-lg border p-4 space-y-6">
+      <div>
         <div className="flex items-center justify-between gap-3">
           <div>
-            <CardTitle>{t.timeAnalytics}</CardTitle>
-            <CardDescription>
+            <h2 className="text-base font-semibold">{t.timeAnalytics}</h2>
+            <p className="text-sm text-muted-foreground">
               {t.timeAnalyticsDesc || "Analyze how you spend your time"}
-            </CardDescription>
+            </p>
           </div>
           <Select
             value={timeRange}
@@ -195,8 +188,8 @@ export default function TimeAnalyticsComponent({
             </SelectContent>
           </Select>
         </div>
-      </CardHeader>
-      <CardContent>
+      </div>
+      <div>
         <div className="grid grid-cols-1 md:grid-cols-2 gap-4">
           <div>
             <h3 className="text-lg font-medium mb-2">{t.timeDistribution}</h3>
@@ -252,84 +245,70 @@ export default function TimeAnalyticsComponent({
           </div>
         </div>
         <div className="grid grid-cols-1 md:grid-cols-3 gap-4 mt-6">
-          <Card>
-            <CardContent className="pt-6">
-              <div className="text-center">
-                <h3 className="text-lg font-medium">{t.totalEvents}</h3>
-                <p className="text-3xl font-bold mt-2">
-                  {analytics.totalEvents}
-                </p>
-              </div>
-            </CardContent>
-          </Card>
-          <Card>
-            <CardContent className="pt-6">
-              <div className="text-center">
-                <h3 className="text-lg font-medium">{t.mostProductiveDay}</h3>
-                <p className="text-3xl font-bold mt-2">
-                  {analytics.mostProductiveDay
-                    ? new Date(analytics.mostProductiveDay).toLocaleDateString()
-                    : t.noData}
-                </p>
-              </div>
-            </CardContent>
-          </Card>
-          <Card>
-            <CardContent className="pt-6">
-              <div className="text-center">
-                <h3 className="text-lg font-medium">{t.mostProductiveHour}</h3>
-                <p className="text-3xl font-bold mt-2">
-                  {analytics.mostProductiveHour !== undefined
-                    ? `${analytics.mostProductiveHour}:00`
-                    : t.noData}
-                </p>
-              </div>
-            </CardContent>
-          </Card>
+          <div className="rounded-lg border p-4">
+            <div className="text-center">
+              <h3 className="text-lg font-medium">{t.totalEvents}</h3>
+              <p className="text-3xl font-bold mt-2">{analytics.totalEvents}</p>
+            </div>
+          </div>
+          <div className="rounded-lg border p-4">
+            <div className="text-center">
+              <h3 className="text-lg font-medium">{t.mostProductiveDay}</h3>
+              <p className="text-3xl font-bold mt-2">
+                {analytics.mostProductiveDay
+                  ? new Date(analytics.mostProductiveDay).toLocaleDateString()
+                  : t.noData}
+              </p>
+            </div>
+          </div>
+          <div className="rounded-lg border p-4">
+            <div className="text-center">
+              <h3 className="text-lg font-medium">{t.mostProductiveHour}</h3>
+              <p className="text-3xl font-bold mt-2">
+                {analytics.mostProductiveHour !== undefined
+                  ? `${analytics.mostProductiveHour}:00`
+                  : t.noData}
+              </p>
+            </div>
+          </div>
         </div>
 
         <div className="grid grid-cols-1 md:grid-cols-3 gap-4 mt-4">
-          <Card>
-            <CardContent className="pt-6">
-              <div className="text-center">
-                <h3 className="text-lg font-medium">
-                  {t.totalHours || "Total Hours"}
-                </h3>
-                <p className="text-3xl font-bold mt-2">
-                  {analytics.totalHours.toFixed(1)}h
-                </p>
-              </div>
-            </CardContent>
-          </Card>
-          <Card>
-            <CardContent className="pt-6">
-              <div className="text-center">
-                <h3 className="text-lg font-medium">
-                  {t.averageEventDuration || "Average Event Duration"}
-                </h3>
-                <p className="text-3xl font-bold mt-2">
-                  {analytics.averageEventDuration.toFixed(1)}h
-                </p>
-              </div>
-            </CardContent>
-          </Card>
-          <Card>
-            <CardContent className="pt-6">
-              <div className="text-center">
-                <h3 className="text-lg font-medium">
-                  {t.busiestCategory || "Busiest Category"}
-                </h3>
-                <p className="text-2xl font-bold mt-2">
-                  {busiestCategoryName || t.noData}
-                </p>
-                <p className="text-sm text-muted-foreground mt-1">
-                  {t.activeDays || "Active Days"}: {analytics.activeDays}
-                </p>
-              </div>
-            </CardContent>
-          </Card>
+          <div className="rounded-lg border p-4">
+            <div className="text-center">
+              <h3 className="text-lg font-medium">
+                {t.totalHours || "Total Hours"}
+              </h3>
+              <p className="text-3xl font-bold mt-2">
+                {analytics.totalHours.toFixed(1)}h
+              </p>
+            </div>
+          </div>
+          <div className="rounded-lg border p-4">
+            <div className="text-center">
+              <h3 className="text-lg font-medium">
+                {t.averageEventDuration || "Average Event Duration"}
+              </h3>
+              <p className="text-3xl font-bold mt-2">
+                {analytics.averageEventDuration.toFixed(1)}h
+              </p>
+            </div>
+          </div>
+          <div className="rounded-lg border p-4">
+            <div className="text-center">
+              <h3 className="text-lg font-medium">
+                {t.busiestCategory || "Busiest Category"}
+              </h3>
+              <p className="text-2xl font-bold mt-2">
+                {busiestCategoryName || t.noData}
+              </p>
+              <p className="text-sm text-muted-foreground mt-1">
+                {t.activeDays || "Active Days"}: {analytics.activeDays}
+              </p>
+            </div>
+          </div>
         </div>
-      </CardContent>
-    </Card>
+      </div>
+    </div>
   );
 }

--- a/proxy.ts
+++ b/proxy.ts
@@ -18,7 +18,7 @@ const isPublicRoute = createRouteMatcher([
 
 export default clerkMiddleware(async (auth, req) => {
   if (!isPublicRoute(req)) {
-    await auth.protect({ unauthenticatedUrl: "/sign-in" })
+    await auth.protect()
   }
 })
 


### PR DESCRIPTION
### Motivation
- 修复未登录访问受保护路由时可能触发 500 的问题，问题来源于中间件对 `auth.protect` 的参数使用导致鉴权异常。 
- 将分析/设置页的卡片样式统一为设置页使用的线框容器风格（`<div className="rounded-lg border p-4 ...">`）以保持一致的视觉样式。

### Description
- 在 `proxy.ts` 中将 `await auth.protect({ unauthenticatedUrl: "/sign-in" })` 改为 `await auth.protect()`，以避免中间件参数导致的未授权访问异常。 
- 将以下组件的外层从 `Card` 组件替换为设置页风格的容器并调整内部标题/说明为 `h2`/`p` 等： `components/app/analytics/time-analytics.tsx`, `components/app/analytics/events-calendar.tsx`, `components/app/analytics/share-management.tsx`, `components/app/analytics/import-export.tsx`, `components/app/analytics/build-info-card.tsx`。 
- 在替换过程中保留原有功能逻辑和事件/弹窗实现，仅更改外层容器与局部布局类名以匹配 `rounded-lg border p-4` 的视觉样式。

### Testing
- 已运行 `git status --short` 和 `git diff` 查看变更并成功生成补丁，命令执行成功。 
- 已执行 `git add` + `git commit -m "fix: prevent unauth route 500 and restyle settings analytics panels"` 并成功提交修改。 
- 已通过脚本创建 PR（title/body 已生成）；未运行 `eslint` 或单元/集成测试（按要求跳过）。

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69d2f48f7130832688d37f8785314737)

## Summary by Sourcery

修复认证中间件行为，并使分析界面容器与设置风格的面板保持一致。

Bug 修复：
- 通过调整代理中间件中的 Clerk 认证保护调用，防止未认证访问受保护路由时导致 500 错误。

增强改进：
- 重新设计分析面板（时间分析、事件日历、分享管理、导入/导出和构建信息），使用与设置页面设计相匹配的一致描边和圆角容器布局。
- 统一分析面板的标题和描述，使其使用语义化的 h2/p 排版，同时保留现有功能。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Fix authentication middleware behavior and align analytics UI containers with settings-style panels.

Bug Fixes:
- Prevent unauthenticated access to protected routes from causing 500 errors by adjusting the Clerk auth protection call in the proxy middleware.

Enhancements:
- Restyle analytics panels (time analytics, events calendar, share management, import/export, and build info) to use a consistent bordered, rounded container layout matching the settings page design.
- Standardize analytics panel headings and descriptions to use semantic h2/p typography while preserving existing functionality.

</details>