### PR TITLE
fix: make /share/[id] OG image title dynamic from share data

### DIFF
--- a/app/(app)/share/[id]/opengraph-image.tsx
+++ b/app/(app)/share/[id]/opengraph-image.tsx
@@ -1,5 +1,5 @@
 import { ImageResponse } from "next/og"
-import { APP_TITLE } from "@/app/layout"
+import { headers } from "next/headers"
 
 export const size = {
   width: 1200,
@@ -7,6 +7,8 @@ export const size = {
 }
 
 export const contentType = "image/png"
+
+export const revalidate = 0
 
 const instrumentSansPromises = new Map<number, Promise<ArrayBuffer>>()
 
@@ -35,7 +37,47 @@ async function loadInstrumentSans(weight: 400 | 500) {
   return promise
 }
 
-export default async function OpenGraphImage() {
+async function getShareTitle(id: string) {
+  const fallbackTitle = "One Calendar"
+
+  try {
+    const headerStore = await headers()
+    const forwardedHost = headerStore.get("x-forwarded-host")
+    const host = forwardedHost || headerStore.get("host")
+    const protocol = headerStore.get("x-forwarded-proto") || "https"
+    const baseUrl = process.env.NEXT_PUBLIC_BASE_URL || (host ? `${protocol}://${host}` : "http://localhost:3000")
+    const res = await fetch(`${baseUrl}/api/share?id=${id}`, {
+      cache: "no-store",
+    })
+
+    if (res.status === 401) {
+      const result = await res.json().catch(() => null)
+      if (result?.requiresPassword) {
+        return "Protected"
+      }
+
+      return fallbackTitle
+    }
+
+    if (!res.ok) {
+      return fallbackTitle
+    }
+
+    const result = await res.json()
+
+    if (!result.success || !result.data) {
+      return fallbackTitle
+    }
+
+    const event = typeof result.data === "object" ? result.data : JSON.parse(result.data)
+    return typeof event.title === "string" ? event.title : "Untitled"
+  } catch {
+    return fallbackTitle
+  }
+}
+
+export default async function OpenGraphImage({ params }: { params: { id: string } }) {
+  const eventTitle = await getShareTitle(params.id)
   const [instrumentSans400, instrumentSans500] = await Promise.all([
     loadInstrumentSans(400),
     loadInstrumentSans(500),
@@ -89,7 +131,7 @@ export default async function OpenGraphImage() {
               lineHeight: 1.1,
             }}
           >
-            {APP_TITLE}
+            {eventTitle}
           </div>
         </div>
       </div>


### PR DESCRIPTION
### Motivation
- The Open Graph image for `/share/[id]` previously used a static `APP_TITLE` causing the image title to be fixed at deploy time instead of reflecting the shared event's title.
- The intent is to derive the OG title from the same runtime share data used by the page layout so the image title matches the dynamic page title.

### Description
- Update `app/(app)/share/[id]/opengraph-image.tsx` to fetch share data at request time via `GET /api/share?id=...` and parse the event `title`.
- Add a helper `getShareTitle(id)` that implements the same fallbacks as the layout (`Protected`, `Untitled`, `One Calendar`) and use it to compute `eventTitle`.
- Replace `APP_TITLE` with the dynamic `eventTitle` and make the route accept `params.id` so the image is generated per-request.
- Set `export const revalidate = 0` and use `fetch(..., { cache: "no-store" })` to avoid build-time/static title generation.

### Testing
- No automated tests were executed for this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69d2fbad253c83269ccafa6946a56a3f)

## Summary by Sourcery

使 `/share/[id]` 的 Open Graph 图像标题根据分享的事件数据动态生成，而不是使用静态的应用标题。

New Features:
- 在请求时获取对应的分享数据，并从中派生 `/share/[id]` 的 Open Graph 图像标题。

Enhancements:
- 使 Open Graph 标题的回退策略与分享页面布局行为保持一致，包括受保护状态和无标题状态。
- 通过禁用重新验证并使用 `no-store` 的 fetch 语义，使 Open Graph 图像路由完全动态且不缓存。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Make the /share/[id] Open Graph image title dynamic based on the shared event data instead of a static app title.

New Features:
- Derive the Open Graph image title for /share/[id] from the corresponding share data fetched at request time.

Enhancements:
- Align Open Graph title fallbacks with the share layout behavior, including protected and untitled states.
- Make the Open Graph image route fully dynamic and non-cached by disabling revalidation and using no-store fetch semantics.

</details>