### PR TITLE
fix: refine sidebar spacing and fix keyboard/share/bookmark edge cases

### DIFF
--- a/components/app/calendar.tsx
+++ b/components/app/calendar.tsx
@@ -350,7 +350,7 @@ export default function Calendar({ className, ...props }: CalendarProps) {
     return () => {
       window.removeEventListener("keydown", handleKeyDown);
     };
-  }, [enableShortcuts, t.searchEvents]);
+  }, [enableShortcuts, t.searchEvents, view]);
 
   const toggleSidebar = () => {
     setIsSidebarCollapsed((prev) => {

--- a/components/app/event/event-preview.tsx
+++ b/components/app/event/event-preview.tsx
@@ -6,7 +6,7 @@ import {
   subscribeEncryptionState,
   writeEncryptedLocalStorage,
 } from "@/hooks/useLocalStorage";
-import React, { useState, useRef, useEffect } from "react";
+import React, { useState, useRef, useEffect, useCallback } from "react";
 import {
   Edit2,
   Trash2,
@@ -117,10 +117,16 @@ export default function EventPreview({
           description: t.shareSignInRequiredDescription,
         });
       } else {
-        setShareDialogOpen(true);
+        void openShareDialog();
       }
     }
-  }, [open, openShareImmediately, isSignedIn, atprotoSignedIn, language]);
+  }, [
+    open,
+    openShareImmediately,
+    isSignedIn,
+    atprotoSignedIn,
+    language,
+  ]);
 
   useEffect(() => {
     if (open && !modal) {
@@ -159,6 +165,15 @@ export default function EventPreview({
       unsubscribe();
     };
   }, []);
+
+  useEffect(() => {
+    if (!open || !event) return;
+    readEncryptedLocalStorage<any[]>("bookmarked-events", []).then(
+      (storedBookmarks) => {
+        setBookmarks(storedBookmarks);
+      },
+    );
+  }, [open, event]);
 
   useEffect(() => {
     return () => {
@@ -252,6 +267,39 @@ export default function EventPreview({
     qrCodeObjectURLRef.current = qrURL;
     setQRCodeDataURL(qrURL);
   };
+
+  const openShareDialog = useCallback(async () => {
+    if (!event) return;
+
+    setPasswordEnabled(false);
+    setSharePassword("");
+    setBurnAfterRead(false);
+    setShareLink("");
+    setQRCodeDataURL("");
+    if (qrCodeObjectURLRef.current) {
+      URL.revokeObjectURL(qrCodeObjectURLRef.current);
+      qrCodeObjectURLRef.current = null;
+    }
+
+    const storedShares = await readEncryptedLocalStorage<any[]>(
+      "shared-events",
+      [],
+    );
+    const existingShare = storedShares
+      .filter((share) => share?.eventId === event.id && !!share?.shareLink)
+      .sort(
+        (a, b) =>
+          new Date(b.shareDate || 0).getTime() -
+          new Date(a.shareDate || 0).getTime(),
+      )[0];
+
+    if (existingShare) {
+      setShareLink(existingShare.shareLink);
+      await generateStyledQRCode(existingShare.shareLink);
+    }
+
+    setShareDialogOpen(true);
+  }, [event]);
 
   const toggleBookmark = async () => {
     if (!event) return;
@@ -562,7 +610,7 @@ export default function EventPreview({
                       });
                       return;
                     }
-                    handleShareDialogChange(true);
+                    void openShareDialog();
                   }}
                   className="h-8 w-8"
                 >

--- a/components/app/sidebar/sidebar.tsx
+++ b/components/app/sidebar/sidebar.tsx
@@ -252,7 +252,7 @@ export default function Sidebar({
           />
         </div>
 
-        <div className="mt-8 space-y-4">
+        <div className="mt-8 space-y-3">
           <div className="flex items-center justify-between">
             <span className="text-sm font-medium">{t.myCalendars}</span>
           </div>


### PR DESCRIPTION
### Motivation
- Make the left sidebar category list denser by reducing vertical spacing between categories for a tighter layout.
- Fix keyboard period navigation that used a stale view closure so navigating periods after switching views behaves according to the active view.
- Ensure event preview bookmark state stays in sync with the bookmarks sheet after removals.
- When an event was already shared, reuse the existing share instead of creating a new one and immediately show the share link/QR.

### Description
- Reduced sidebar category row spacing by changing `space-y-4` to `space-y-3` in `components/app/sidebar/sidebar.tsx`.
- Made the global keyboard handler in `components/app/calendar.tsx` respond to the current `view` by adding `view` to the `useEffect` dependency array so `handleNext`/`handlePrevious` operate based on the active view.
- Reload bookmarks when an event preview is opened by adding a `useEffect` in `components/app/event/event-preview.tsx` that reads `bookmarked-events` when `open` or `event` changes.
- Added `openShareDialog` logic in `components/app/event/event-preview.tsx` to detect an existing share in local `shared-events` and, if present, set `shareLink` and generate the QR code instead of creating a new share; wired the share button and open-on-mount flow to use this logic.

### Testing
- No automated tests or `eslint` were executed for this change per request.
- Changes were committed locally and files modified are `components/app/sidebar/sidebar.tsx`, `components/app/calendar.tsx`, and `components/app/event/event-preview.tsx`.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69d30d519ecc832693daf082528c087b)

## Summary by Sourcery

收紧侧边栏布局间距，并解决事件预览在键盘操作、书签和分享方面的边缘情况。

Bug Fixes:
- 更新全局键盘导航逻辑，以尊重当前激活的日历视图。
- 在事件预览打开或事件变更时，从已存储数据中刷新事件预览书签，以保持书签状态同步。
- 在可用时复用已有的事件分享记录，使分享对话框能立即显示当前链接和二维码，而不是总是创建新的分享。

Enhancements:
- 减少侧边栏中日历分类之间的垂直间距，使布局更为紧凑。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Tighten sidebar layout spacing and address event preview keyboard, bookmark, and sharing edge cases.

Bug Fixes:
- Update global keyboard navigation to respect the currently active calendar view.
- Refresh event preview bookmarks from stored data whenever the preview opens or the event changes to keep bookmark state in sync.
- Reuse existing event shares when available so the share dialog immediately shows the current link and QR code instead of always creating a new share.

Enhancements:
- Reduce vertical spacing between sidebar calendar categories for a denser layout.

</details>