### PR TITLE
fix: avoid React hook mismatch in event preview

### DIFF
--- a/components/app/event/event-preview.tsx
+++ b/components/app/event/event-preview.tsx
@@ -6,7 +6,7 @@ import {
   subscribeEncryptionState,
   writeEncryptedLocalStorage,
 } from "@/hooks/useLocalStorage";
-import React, { useState, useRef, useEffect, useCallback } from "react";
+import React, { useState, useRef, useEffect } from "react";
 import {
   Edit2,
   Trash2,
@@ -268,7 +268,7 @@ export default function EventPreview({
     setQRCodeDataURL(qrURL);
   };
 
-  const openShareDialog = useCallback(async () => {
+  const openShareDialog = async () => {
     if (!event) return;
 
     setPasswordEnabled(false);
@@ -299,7 +299,7 @@ export default function EventPreview({
     }
 
     setShareDialogOpen(true);
-  }, [event]);
+  };
 
   const toggleBookmark = async () => {
     if (!event) return;


### PR DESCRIPTION
### Motivation
- 修复点击日程打开 event preview 时可能触发 React 310 错误，因为组件在早期返回路径与正常路径之间导致 Hook 调用顺序不一致。

### Description
- 将 `components/app/event/event-preview.tsx` 中的 `openShareDialog` 从 `useCallback(async ...)` 改为普通 `async` 函数，并移除对 `useCallback` 的引入以确保组件的 Hook 执行顺序稳定。

### Testing
- 未运行自动化测试。

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69d31218a20483269122b8fb6669f6e9)

## Summary by Sourcery

错误修复：
- 通过使用常规的 async 函数而不是 memoized 回调函数，防止在打开事件预览分享对话框时出现潜在的 React Hook 调用顺序不匹配错误。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Bug Fixes:
- Prevent potential React hook order mismatch errors when opening the event preview share dialog by using a regular async function instead of a memoized callback.

</details>