### PR TITLE
Introduce APP_CONFIG and dynamic OAuth provider support; centralize contact/status links and tidy auth flows

### DIFF
--- a/app/(auth)/sign-in/page.tsx
+++ b/app/(auth)/sign-in/page.tsx
@@ -1,19 +1,34 @@
-import { LoginForm } from "@/components/auth/login-form"
-import { AuthBrand } from "@/components/auth/auth-brand"
+import { LoginForm } from "@/components/auth/login-form";
+import { AuthBrand } from "@/components/auth/auth-brand";
+import { currentUser } from "@clerk/nextjs/server";
+import { redirect } from "next/navigation";
 
-export default function LoginPage() {
+export default async function LoginPage() {
+  const user = await currentUser();
+  if (user) {
+    redirect("/app");
+  }
+
   return (
     <div className="relative flex min-h-svh flex-col items-center justify-center overflow-hidden from-blue-500 via-indigo-500 to-purple-500 p-6 md:p-10">
       <div className="fixed -z-10 inset-0">
         <div className="absolute inset-0 bg-white dark:bg-black">
-          <div className="absolute inset-0" style={{
-            backgroundImage: `radial-gradient(circle at 1px 1px, rgba(0, 0, 0, 0.1) 1px, transparent 0)`,
-            backgroundSize: '24px 24px'
-          }} />
-          <div className="absolute inset-0 dark:block hidden" style={{
-            backgroundImage: `radial-gradient(circle at 1px 1px, rgba(255, 255, 255, 0.15) 1px, transparent 0)`,
-            backgroundSize: '24px 24px'
-          }} />
+          <div
+            className="absolute inset-0"
+            style={{
+              backgroundImage:
+                "radial-gradient(circle at 1px 1px, rgba(0, 0, 0, 0.1) 1px, transparent 0)",
+              backgroundSize: "24px 24px",
+            }}
+          />
+          <div
+            className="absolute inset-0 hidden dark:block"
+            style={{
+              backgroundImage:
+                "radial-gradient(circle at 1px 1px, rgba(255, 255, 255, 0.15) 1px, transparent 0)",
+              backgroundSize: "24px 24px",
+            }}
+          />
         </div>
       </div>
       <div className="relative z-10 flex w-full max-w-sm flex-col gap-6">
@@ -21,5 +36,5 @@ export default function LoginPage() {
         <LoginForm />
       </div>
     </div>
-  )
+  );
 }

--- a/app/(auth)/sign-up/page.tsx
+++ b/app/(auth)/sign-up/page.tsx
@@ -1,19 +1,34 @@
-import { SignUpForm } from "@/components/auth/sign-up-form"
-import { AuthBrand } from "@/components/auth/auth-brand"
+import { SignUpForm } from "@/components/auth/sign-up-form";
+import { AuthBrand } from "@/components/auth/auth-brand";
+import { currentUser } from "@clerk/nextjs/server";
+import { redirect } from "next/navigation";
 
-export default function SignUpPage() {
+export default async function SignUpPage() {
+  const user = await currentUser();
+  if (user) {
+    redirect("/app");
+  }
+
   return (
     <div className="flex min-h-svh flex-col items-center justify-center from-blue-500 via-indigo-500 to-purple-500 gap-6 p-6 md:p-10">
       <div className="fixed -z-10 inset-0">
         <div className="absolute inset-0 bg-white dark:bg-black">
-          <div className="absolute inset-0" style={{
-            backgroundImage: `radial-gradient(circle at 1px 1px, rgba(0, 0, 0, 0.1) 1px, transparent 0)`,
-            backgroundSize: '24px 24px'
-          }} />
-          <div className="absolute inset-0 dark:block hidden" style={{
-            backgroundImage: `radial-gradient(circle at 1px 1px, rgba(255, 255, 255, 0.15) 1px, transparent 0)`,
-            backgroundSize: '24px 24px'
-          }} />
+          <div
+            className="absolute inset-0"
+            style={{
+              backgroundImage:
+                "radial-gradient(circle at 1px 1px, rgba(0, 0, 0, 0.1) 1px, transparent 0)",
+              backgroundSize: "24px 24px",
+            }}
+          />
+          <div
+            className="absolute inset-0 hidden dark:block"
+            style={{
+              backgroundImage:
+                "radial-gradient(circle at 1px 1px, rgba(255, 255, 255, 0.15) 1px, transparent 0)",
+              backgroundSize: "24px 24px",
+            }}
+          />
         </div>
       </div>
       <div className="flex w-full max-w-sm flex-col gap-6">
@@ -21,5 +36,5 @@ export default function SignUpPage() {
         <SignUpForm />
       </div>
     </div>
-  )
+  );
 }

--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -5,7 +5,6 @@ import "./globals.css"
 import { Toaster } from "@/components/ui/sonner"
 import { CalendarProvider } from "@/components/providers/calendar-context"
 import { ClerkProvider } from '@clerk/nextjs'
-import { enUS } from '@clerk/localizations'
 import { GeistSans } from "geist/font/sans"
 import { ThemeProvider } from "@/components/providers/theme-provider"
 import { PwaProvider } from "@/components/providers/pwa-provider"
@@ -65,7 +64,6 @@ export default function RootLayout({
       >
         <ClerkProvider
           publishableKey={clerkPublishableKey}
-          localization={enUS}
           signInFallbackRedirectUrl="/app"
           signUpFallbackRedirectUrl="/app"
           signInForceRedirectUrl="/"

--- a/components/app/analytics/import-export.tsx
+++ b/components/app/analytics/import-export.tsx
@@ -729,6 +729,18 @@ END:VEVENT
     URL.revokeObjectURL(url);
   };
 
+  const handleImportDialogOpenChange = (open: boolean) => {
+    setImportDialogOpen(open);
+    if (open) {
+      setImportTab("file");
+      setSelectedFile(null);
+      setImportUrl("");
+      setDebugInfo("");
+      setJsonImportEncrypted(false);
+      setJsonImportPassword("");
+    }
+  };
+
   return (
     <div className="w-full rounded-lg border p-4 space-y-6">
       <div>
@@ -774,7 +786,10 @@ END:VEVENT
       </div>
 
       {}
-      <Dialog open={importDialogOpen} onOpenChange={setImportDialogOpen}>
+      <Dialog
+        open={importDialogOpen}
+        onOpenChange={handleImportDialogOpenChange}
+      >
         <DialogContent className="max-w-md max-h-[90vh] overflow-y-auto">
           <DialogHeader>
             <DialogTitle>{t.importCalendar}</DialogTitle>

--- a/components/app/analytics/share-management.tsx
+++ b/components/app/analytics/share-management.tsx
@@ -16,6 +16,13 @@ import { useEffect, useState } from "react";
 import { format } from "date-fns";
 import { toast } from "sonner";
 import { fetchJson } from "@/lib/fetch-json";
+import {
+  Empty,
+  EmptyDescription,
+  EmptyHeader,
+  EmptyMedia,
+  EmptyTitle,
+} from "@/components/ui/empty";
 
 interface SharedEvent {
   id: string;
@@ -153,9 +160,15 @@ export default function ShareManagement() {
 
       <div>
         {sharedEvents.length === 0 ? (
-          <div className="text-center py-8 text-muted-foreground">
-            {t.noShares}
-          </div>
+          <Empty className="border-0 py-8">
+            <EmptyHeader>
+              <EmptyMedia variant="icon">
+                <ExternalLink className="h-4 w-4" />
+              </EmptyMedia>
+              <EmptyTitle>{t.shareManagementTitle}</EmptyTitle>
+              <EmptyDescription>{t.noShares}</EmptyDescription>
+            </EmptyHeader>
+          </Empty>
         ) : (
           <div className="space-y-4">
             {sharedEvents.map((share) => (

--- a/components/app/calendar.tsx
+++ b/components/app/calendar.tsx
@@ -50,6 +50,7 @@ import { translations, useLanguage } from "@/lib/i18n";
 import { Button } from "@/components/ui/button";
 import { Input } from "@/components/ui/input";
 import { cn } from "@/lib/utils";
+import { APP_CONFIG } from "@/lib/config";
 import { toast } from "sonner";
 import {
   DropdownMenu,
@@ -879,7 +880,7 @@ export default function Calendar({ className, ...props }: CalendarProps) {
                   <DropdownMenuItem
                     onClick={() =>
                       window.open(
-                        "https://calendarstatus.xyehr.cn",
+                        APP_CONFIG.contact.statusPageUrl,
                         "_blank",
                         "noopener,noreferrer",
                       )
@@ -890,7 +891,7 @@ export default function Calendar({ className, ...props }: CalendarProps) {
                   </DropdownMenuItem>
                   <DropdownMenuItem
                     onClick={() => {
-                      window.location.href = "mailto:evan.huang000@proton.me";
+                      window.location.href = `mailto:${APP_CONFIG.contact.feedbackEmail}`;
                     }}
                   >
                     <MessageSquare className="mr-2 h-4 w-4" />

--- a/components/app/sidebar/countdown.tsx
+++ b/components/app/sidebar/countdown.tsx
@@ -510,7 +510,7 @@ export function CountdownTool({ open, onOpenChange }: CountdownToolProps) {
             </Button>
             <Button
               variant="destructive"
-              className="flex-1 text-destructive-foreground hover:text-destructive-foreground"
+              className="flex-1"
               onClick={() => deleteCountdown(selectedCountdown.id)}
             >
               <Trash2 className="mr-2 h-4 w-4" />
@@ -714,7 +714,6 @@ export function CountdownTool({ open, onOpenChange }: CountdownToolProps) {
         {selectedCountdown && (
           <Button
             variant="destructive"
-            className="text-destructive-foreground hover:text-destructive-foreground"
             onClick={() => deleteCountdown(selectedCountdown.id)}
           >
             {t.countdownDelete}

--- a/components/auth/login-form.tsx
+++ b/components/auth/login-form.tsx
@@ -15,6 +15,11 @@ import { useSignIn } from "@clerk/nextjs";
 import { useState, useRef } from "react";
 import { useRouter } from "next/navigation";
 import { Turnstile } from "@marsidev/react-turnstile";
+import {
+  getEnabledOAuthProviderKeys,
+  OAUTH_PROVIDER_CONFIG,
+  type OAuthStrategy,
+} from "@/lib/clerk-oauth";
 
 export function LoginForm({
   className,
@@ -111,7 +116,7 @@ export function LoginForm({
     }
   };
 
-  const handleOAuthLogin = (strategy: "oauth_google" | "oauth_microsoft" | "oauth_github") => {
+  const handleOAuthLogin = (strategy: OAuthStrategy) => {
     const siteKey = process.env.NEXT_PUBLIC_TURNSTILE_SITE_KEY;
     if (siteKey && !isCaptchaCompleted) {
       setError("Please complete the CAPTCHA verification.");
@@ -126,6 +131,8 @@ export function LoginForm({
 
   const siteKey = process.env.NEXT_PUBLIC_TURNSTILE_SITE_KEY;
   const hasCaptcha = Boolean(siteKey);
+  const enabledOAuthProviders = getEnabledOAuthProviderKeys();
+  const hasOAuthProviders = enabledOAuthProviders.length > 0;
 
   return (
     <div className={cn("flex flex-col gap-6", className)} {...props}>
@@ -133,62 +140,39 @@ export function LoginForm({
         <CardHeader className="text-center">
           <CardTitle className="text-xl">Welcome back</CardTitle>
           <CardDescription>
-            Login with your Microsoft, Google or GitHub account
+            {hasOAuthProviders
+              ? "Login with your OAuth provider account"
+              : "Login with your email and password"}
           </CardDescription>
         </CardHeader>
         <CardContent>
           <form onSubmit={handleEmailLogin}>
             <div className="grid gap-6">
-              <div className="flex flex-col gap-4">
-                <Button
-                  variant="outline"
-                  className="w-full"
-                  type="button"
-                  onClick={() => handleOAuthLogin("oauth_microsoft")}
-                >
-                  <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 23 23" width="20" height="20">
-                    <path fill="#f25022" d="M1 1h10v10H1z"/>
-                    <path fill="#00a4ef" d="M12 1h10v10H12z"/>
-                    <path fill="#7fba00" d="M1 12h10v10H1z"/>
-                    <path fill="#ffb900" d="M12 12h10v10H12z"/>
-                  </svg>
-                  <span className="ml-2">Login with Microsoft</span>
-                </Button>
-                <Button
-                  variant="outline"
-                  className="w-full"
-                  type="button"
-                  onClick={() => handleOAuthLogin("oauth_google")}
-                >
-                  <svg xmlns="http://www.w3.org/2000/svg" height="24" viewBox="0 0 24 24" width="24">
-                    <path d="M22.56 12.25c0-.78-.07-1.53-.2-2.25H12v4.26h5.92c-.26 1.37-1.04 2.53-2.21 3.31v2.77h3.57c2.08-1.92 3.28-4.74 3.28-8.09z" fill="#4285F4"/>
-                    <path d="M12 23c2.97 0 5.46-.98 7.28-2.66l-3.57-2.77c-.98.66-2.23 1.06-3.71 1.06-2.86 0-5.29-1.93-6.16-4.53H2.18v2.84C3.99 20.53 7.7 23 12 23z" fill="#34A853"/>
-                    <path d="M5.84 14.09c-.22-.66-.35-1.36-.35-2.09s.13-1.43.35-2.09V7.07H2.18C1.43 8.55 1 10.22 1 12s.43 3.45 1.18 4.93l2.85-2.22.81-.62z" fill="#FBBC05"/>
-                    <path d="M12 5.38c1.62 0 3.06.56 4.21 1.64l3.15-3.15C17.45 2.09 14.97 1 12 1 7.7 1 3.99 3.47 2.18 7.07l3.66 2.84c.87-2.6 3.3-4.53 6.16-4.53z" fill="#EA4335"/>
-                    <path d="M1 1h22v22H1z" fill="none"/>
-                  </svg>
-                  <span className="ml-2">Login with Google</span>
-                </Button>
-                <Button
-                  variant="outline"
-                  className="w-full"
-                  type="button"
-                  onClick={() => handleOAuthLogin("oauth_github")}
-                >
-                  <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" width="20" height="20">
-                    <path
-                      d="M12 .297c-6.63 0-12 5.373-12 12 0 5.303 3.438 9.8 8.205 11.385.6.113.82-.258.82-.577 0-.285-.01-1.04-.015-2.04-3.338.724-4.042-1.61-4.042-1.61C4.422 18.07 3.633 17.7 3.633 17.7c-1.087-.744.084-.729.084-.729 1.205.084 1.838 1.236 1.838 1.236 1.07 1.835 2.809 1.305 3.495.998.108-.776.417-1.305.76-1.605-2.665-.3-5.466-1.332-5.466-5.93 0-1.31.465-2.38 1.235-3.22-.135-.303-.54-1.523.105-3.176 0 0 1.005-.322 3.3 1.23.96-.267 1.98-.399 3-.405 1.02.006 2.04.138 3 .405 2.28-1.552 3.285-1.23 3.285-1.23.645 1.653.24 2.873.12 3.176.765.84 1.23 1.91 1.23 3.22 0 4.61-2.805 5.625-5.475 5.92.42.36.81 1.096.81 2.22 0 1.606-.015 2.896-.015 3.286 0 .315.21.69.825.57C20.565 22.092 24 17.592 24 12.297c0-6.627-5.373-12-12-12"
-                      fill="currentColor"
-                    />
-                  </svg>
-                  <span className="ml-2">Login with GitHub</span>
-                </Button>
-              </div>
-              <div className="relative text-center text-sm after:absolute after:inset-0 after:top-1/2 after:z-0 after:flex after:items-center after:border-t after:border-border">
-                <span className="relative z-10 bg-background px-2 text-muted-foreground">
-                  Or continue with
-                </span>
-              </div>
+              {hasOAuthProviders && (
+                <>
+                  <div className="flex flex-col gap-4">
+                    {enabledOAuthProviders.map((providerKey) => {
+                      const provider = OAUTH_PROVIDER_CONFIG[providerKey];
+                      return (
+                        <Button
+                          key={provider.strategy}
+                          variant="outline"
+                          className="w-full"
+                          type="button"
+                          onClick={() => handleOAuthLogin(provider.strategy)}
+                        >
+                          <span>Login with {provider.label}</span>
+                        </Button>
+                      );
+                    })}
+                  </div>
+                  <div className="relative text-center text-sm after:absolute after:inset-0 after:top-1/2 after:z-0 after:flex after:items-center after:border-t after:border-border">
+                    <span className="relative z-10 bg-background px-2 text-muted-foreground">
+                      Or continue with
+                    </span>
+                  </div>
+                </>
+              )}
               <div className="grid gap-6">
                 <div className="grid gap-2">
                   <Label htmlFor="email">Email</Label>

--- a/components/auth/sign-up-form.tsx
+++ b/components/auth/sign-up-form.tsx
@@ -9,6 +9,11 @@ import { useSignUp } from "@clerk/nextjs";
 import { useRouter } from "next/navigation";
 import { useState, useRef } from "react";
 import { Turnstile } from "@marsidev/react-turnstile";
+import {
+  getEnabledOAuthProviderKeys,
+  OAUTH_PROVIDER_CONFIG,
+  type OAuthStrategy,
+} from "@/lib/clerk-oauth";
 
 export function SignUpForm({
   className,
@@ -127,9 +132,7 @@ export function SignUpForm({
     );
   };
 
-  const handleOAuthSignUp = (
-    strategy: "oauth_google" | "oauth_microsoft" | "oauth_github",
-  ) => {
+  const handleOAuthSignUp = (strategy: OAuthStrategy) => {
     const siteKey = process.env.NEXT_PUBLIC_TURNSTILE_SITE_KEY;
     if (siteKey && !isCaptchaCompleted) {
       setError("Please complete the CAPTCHA verification.");
@@ -290,6 +293,8 @@ export function SignUpForm({
 
   const siteKey = process.env.NEXT_PUBLIC_TURNSTILE_SITE_KEY;
   const hasCaptcha = Boolean(siteKey);
+  const enabledOAuthProviders = getEnabledOAuthProviderKeys();
+  const hasOAuthProviders = enabledOAuthProviders.length > 0;
 
   return (
     <div className={cn("flex flex-col gap-6", className)} {...props}>
@@ -300,84 +305,32 @@ export function SignUpForm({
         <CardContent>
           <form onSubmit={handleSubmit}>
             <div className="grid gap-6">
-              <div className="flex flex-col gap-4">
-                <Button
-                  variant="outline"
-                  className="w-full"
-                  type="button"
-                  onClick={() => handleOAuthSignUp("oauth_microsoft")}
-                >
-                  <svg
-                    xmlns="http://www.w3.org/2000/svg"
-                    viewBox="0 0 23 23"
-                    width="20"
-                    height="20"
-                  >
-                    <path fill="#f25022" d="M1 1h10v10H1z" />
-                    <path fill="#00a4ef" d="M12 1h10v10H12z" />
-                    <path fill="#7fba00" d="M1 12h10v10H1z" />
-                    <path fill="#ffb900" d="M12 12h10v10H12z" />
-                  </svg>
-                  <span className="ml-2">Continue with Microsoft</span>
-                </Button>
-                <Button
-                  variant="outline"
-                  className="w-full"
-                  type="button"
-                  onClick={() => handleOAuthSignUp("oauth_google")}
-                >
-                  <svg
-                    xmlns="http://www.w3.org/2000/svg"
-                    height="24"
-                    viewBox="0 0 24 24"
-                    width="24"
-                  >
-                    <path
-                      d="M22.56 12.25c0-.78-.07-1.53-.2-2.25H12v4.26h5.92c-.26 1.37-1.04 2.53-2.21 3.31v2.77h3.57c2.08-1.92 3.28-4.74 3.28-8.09z"
-                      fill="#4285F4"
-                    />
-                    <path
-                      d="M12 23c2.97 0 5.46-.98 7.28-2.66l-3.57-2.77c-.98.66-2.23 1.06-3.71 1.06-2.86 0-5.29-1.93-6.16-4.53H2.18v2.84C3.99 20.53 7.7 23 12 23z"
-                      fill="#34A853"
-                    />
-                    <path
-                      d="M5.84 14.09c-.22-.66-.35-1.36-.35-2.09s.13-1.43.35-2.09V7.07H2.18C1.43 8.55 1 10.22 1 12s.43 3.45 1.18 4.93l2.85-2.22.81-.62z"
-                      fill="#FBBC05"
-                    />
-                    <path
-                      d="M12 5.38c1.62 0 3.06.56 4.21 1.64l3.15-3.15C17.45 2.09 14.97 1 12 1 7.7 1 3.99 3.47 2.18 7.07l3.66 2.84c.87-2.6 3.3-4.53 6.16-4.53z"
-                      fill="#EA4335"
-                    />
-                    <path d="M1 1h22v22H1z" fill="none" />
-                  </svg>
-                  <span className="ml-2">Continue with Google</span>
-                </Button>
-                <Button
-                  variant="outline"
-                  className="w-full"
-                  type="button"
-                  onClick={() => handleOAuthSignUp("oauth_github")}
-                >
-                  <svg
-                    xmlns="http://www.w3.org/2000/svg"
-                    viewBox="0 0 24 24"
-                    width="20"
-                    height="20"
-                  >
-                    <path
-                      d="M12 .297c-6.63 0-12 5.373-12 12 0 5.303 3.438 9.8 8.205 11.385.6.113.82-.258.82-.577 0-.285-.01-1.04-.015-2.04-3.338.724-4.042-1.61-4.042-1.61C4.422 18.07 3.633 17.7 3.633 17.7c-1.087-.744.084-.729.084-.729 1.205.084 1.838 1.236 1.838 1.236 1.07 1.835 2.809 1.305 3.495.998.108-.776.417-1.305.76-1.605-2.665-.3-5.466-1.332-5.466-5.93 0-1.31.465-2.38 1.235-3.22-.135-.303-.54-1.523.105-3.176 0 0 1.005-.322 3.3 1.23.96-.267 1.98-.399 3-.405 1.02.006 2.04.138 3 .405 2.28-1.552 3.285-1.23 3.285-1.23.645 1.653.24 2.873.12 3.176.765.84 1.23 1.91 1.23 3.22 0 4.61-2.805 5.625-5.475 5.92.42.36.81 1.096.81 2.22 0 1.606-.015 2.896-.015 3.286 0 .315.21.69.825.57C20.565 22.092 24 17.592 24 12.297c0-6.627-5.373-12-12-12"
-                      fill="currentColor"
-                    />
-                  </svg>
-                  <span className="ml-2">Continue with GitHub</span>
-                </Button>
-              </div>
+              {hasOAuthProviders && (
+                <>
+                  <div className="flex flex-col gap-4">
+                    {enabledOAuthProviders.map((providerKey) => {
+                      const provider = OAUTH_PROVIDER_CONFIG[providerKey];
+                      return (
+                        <Button
+                          key={provider.strategy}
+                          variant="outline"
+                          className="w-full"
+                          type="button"
+                          onClick={() => handleOAuthSignUp(provider.strategy)}
+                        >
+                          <span>Continue with {provider.label}</span>
+                        </Button>
+                      );
+                    })}
+                  </div>
 
-              <div className="relative text-center text-sm after:absolute after:inset-0 after:top-1/2 after:z-0 after:flex after:items-center after:border-t after:border-border">
-                <span className="relative z-10 bg-background px-2 text-muted-foreground">
-                  Or continue with
-                </span>
-              </div>
+                  <div className="relative text-center text-sm after:absolute after:inset-0 after:top-1/2 after:z-0 after:flex after:items-center after:border-t after:border-border">
+                    <span className="relative z-10 bg-background px-2 text-muted-foreground">
+                      Or continue with
+                    </span>
+                  </div>
+                </>
+              )}
 
               <div className="grid gap-6">
                 <div className="grid grid-cols-2 gap-4">

--- a/components/landing/footer-section.tsx
+++ b/components/landing/footer-section.tsx
@@ -2,34 +2,7 @@
 
 import { ArrowUpRight } from "lucide-react";
 import { AnimatedWave } from "./animated-wave";
-
-const footerSections = [
-  {
-    title: "Product",
-    links: [
-      { label: "Overview", href: "#features" },
-      { label: "Privacy", href: "/privacy" },
-      { label: "Terms", href: "/terms" },
-    ],
-  },
-  {
-    title: "Resources",
-    links: [
-      { label: "Documentation", href: "https://docs.xyehr.cn/docs/one-calendar" },
-      { label: "Status", href: "https://calendarstatus.xyehr.cn" },
-      { label: "Support", href: "mailto:evan.huang000@proton.me" },
-    ],
-  },
-  {
-    title: "Connect",
-    links: [
-      { label: "Contact", href: "mailto:evan.huang000@proton.me" },
-      { label: "Bluesky", href: "https://bsky.app/profile/calendar.xyehr.cn" },
-      { label: "Tangled", href: "https://tangled.org/e.xyehr.cn/One-Calendar" },
-      { label: "GitHub", href: "https://github.com/EvanTechDev/One-Calendar" },
-    ],
-  },
-];
+import { APP_CONFIG } from "@/lib/config";
 
 export function FooterSection() {
   const currentYear = new Date().getFullYear();
@@ -53,7 +26,7 @@ export function FooterSection() {
               </p>
             </div>
 
-            {footerSections.map((section) => (
+            {APP_CONFIG.landing.footerSections.map((section) => (
               <div key={section.title}>
                 <h3 className="text-sm font-medium mb-6">{section.title}</h3>
                 <ul className="space-y-4">
@@ -79,7 +52,10 @@ export function FooterSection() {
             {currentYear} One Calendar. All rights reserved.
           </p>
 
-          <a className="text-sm text-muted-foreground hover:text-foreground" href="https://calendarstatus.xyehr.cn">
+          <a
+            className="text-sm text-muted-foreground hover:text-foreground"
+            href={APP_CONFIG.contact.statusPageUrl}
+          >
             Status page available
           </a>
         </div>

--- a/components/landing/navigation.tsx
+++ b/components/landing/navigation.tsx
@@ -4,6 +4,7 @@ import Link from "next/link";
 import { useState, useEffect } from "react";
 import { Button } from "@/components/ui/button";
 import { Menu, X } from "lucide-react";
+import { useUser } from "@clerk/nextjs";
 
 const navLinks = [
   { name: "Features", href: "#features" },
@@ -13,6 +14,7 @@ const navLinks = [
 ];
 
 export function Navigation() {
+  const { isSignedIn } = useUser();
   const [isScrolled, setIsScrolled] = useState(false);
   const [isMobileMenuOpen, setIsMobileMenuOpen] = useState(false);
 
@@ -62,16 +64,28 @@ export function Navigation() {
           </div>
 
           <div className="hidden md:flex items-center gap-4">
-            <Link href="/sign-in" className={`text-foreground/70 hover:text-foreground transition-all duration-500 ${isScrolled ? "text-xs" : "text-sm"}`}>
-              Sign in
-            </Link>
-            <Button
-              size="sm"
-              asChild
-              className={`bg-foreground hover:bg-foreground/90 text-background rounded-full transition-all duration-500 ${isScrolled ? "px-4 h-8 text-xs" : "px-6"}`}
-            >
-              <Link href="/sign-up">Start free</Link>
-            </Button>
+            {isSignedIn ? (
+              <Button
+                size="sm"
+                asChild
+                className={`bg-foreground hover:bg-foreground/90 text-background rounded-full transition-all duration-500 ${isScrolled ? "px-4 h-8 text-xs" : "px-6"}`}
+              >
+                <Link href="/app">Calendar App</Link>
+              </Button>
+            ) : (
+              <>
+                <Link href="/sign-in" className={`text-foreground/70 hover:text-foreground transition-all duration-500 ${isScrolled ? "text-xs" : "text-sm"}`}>
+                  Sign in
+                </Link>
+                <Button
+                  size="sm"
+                  asChild
+                  className={`bg-foreground hover:bg-foreground/90 text-background rounded-full transition-all duration-500 ${isScrolled ? "px-4 h-8 text-xs" : "px-6"}`}
+                >
+                  <Link href="/sign-up">Start free</Link>
+                </Button>
+              </>
+            )}
           </div>
 
           <button
@@ -123,19 +137,32 @@ export function Navigation() {
           }`}
           style={{ transitionDelay: isMobileMenuOpen ? "300ms" : "0ms" }}
           >
-            <Button
-              variant="outline"
-              asChild
-              className="flex-1 rounded-full h-14 text-base"
-            >
-              <Link href="/sign-in" onClick={() => setIsMobileMenuOpen(false)}>Sign in</Link>
-            </Button>
-            <Button
-              asChild
-              className="flex-1 bg-foreground text-background rounded-full h-14 text-base"
-            >
-              <Link href="/sign-up" onClick={() => setIsMobileMenuOpen(false)}>Start free</Link>
-            </Button>
+            {isSignedIn ? (
+              <Button
+                asChild
+                className="flex-1 bg-foreground text-background rounded-full h-14 text-base"
+              >
+                <Link href="/app" onClick={() => setIsMobileMenuOpen(false)}>
+                  Calendar App
+                </Link>
+              </Button>
+            ) : (
+              <>
+                <Button
+                  variant="outline"
+                  asChild
+                  className="flex-1 rounded-full h-14 text-base"
+                >
+                  <Link href="/sign-in" onClick={() => setIsMobileMenuOpen(false)}>Sign in</Link>
+                </Button>
+                <Button
+                  asChild
+                  className="flex-1 bg-foreground text-background rounded-full h-14 text-base"
+                >
+                  <Link href="/sign-up" onClick={() => setIsMobileMenuOpen(false)}>Start free</Link>
+                </Button>
+              </>
+            )}
           </div>
         </div>
       </div>

--- a/lib/clerk-oauth.ts
+++ b/lib/clerk-oauth.ts
@@ -1,0 +1,29 @@
+import { APP_CONFIG } from "@/lib/config";
+
+export const OAUTH_PROVIDER_CONFIG = {
+  microsoft: {
+    strategy: "oauth_microsoft",
+    label: "Microsoft",
+  },
+  google: {
+    strategy: "oauth_google",
+    label: "Google",
+  },
+  github: {
+    strategy: "oauth_github",
+    label: "GitHub",
+  },
+} as const;
+
+export type OAuthProviderKey = keyof typeof OAUTH_PROVIDER_CONFIG;
+export type OAuthStrategy =
+  (typeof OAUTH_PROVIDER_CONFIG)[OAuthProviderKey]["strategy"];
+
+export function getEnabledOAuthProviderKeys(): OAuthProviderKey[] {
+  const parsed = APP_CONFIG.auth.enabledOAuthProviders
+    .map((provider) => provider.trim().toLowerCase())
+    .filter((provider): provider is OAuthProviderKey =>
+      provider in OAUTH_PROVIDER_CONFIG,
+    );
+  return [...new Set(parsed)];
+}

--- a/lib/config.ts
+++ b/lib/config.ts
@@ -1,0 +1,51 @@
+type ConfigurableOAuthProvider = "microsoft" | "google" | "github";
+
+const FEEDBACK_EMAIL = "evan.huang000@proton.me";
+const STATUS_PAGE_URL = "https://calendarstatus.xyehr.cn";
+const GITHUB_URL = "https://github.com/EvanTechDev/One-Calendar";
+
+export const APP_CONFIG = {
+  contact: {
+    feedbackEmail: FEEDBACK_EMAIL,
+    statusPageUrl: STATUS_PAGE_URL,
+  },
+  auth: {
+    enabledOAuthProviders: [
+      "microsoft",
+      "google",
+      "github",
+    ] as ConfigurableOAuthProvider[],
+  },
+  landing: {
+    footerSections: [
+      {
+        title: "Product",
+        links: [
+          { label: "Overview", href: "#features" },
+          { label: "Privacy", href: "/privacy" },
+          { label: "Terms", href: "/terms" },
+        ],
+      },
+      {
+        title: "Resources",
+        links: [
+          {
+            label: "Documentation",
+            href: "https://docs.xyehr.cn/docs/one-calendar",
+          },
+          { label: "Status", href: STATUS_PAGE_URL },
+          { label: "Support", href: `mailto:${FEEDBACK_EMAIL}` },
+        ],
+      },
+      {
+        title: "Connect",
+        links: [
+          { label: "Contact", href: `mailto:${FEEDBACK_EMAIL}` },
+          { label: "Bluesky", href: "https://bsky.app/profile/calendar.xyehr.cn" },
+          { label: "Tangled", href: "https://tangled.org/e.xyehr.cn/One-Calendar" },
+          { label: "GitHub", href: GITHUB_URL },
+        ],
+      },
+    ],
+  },
+} as const;

--- a/package.json
+++ b/package.json
@@ -11,16 +11,11 @@
     "generate:oauth-metadata": "bun lib/gen-oauth-metadata.mjs"
   },
   "dependencies": {
-    "@clerk/localizations": "4.3.0",
     "@clerk/nextjs": "^7.0.0",
     "@marsidev/react-turnstile": "latest",
     "@radix-ui/react-avatar": "^1.1.2",
-    "@radix-ui/react-collapsible": "^1.1.2",
-    "@radix-ui/react-context-menu": "^2.2.4",
     "@radix-ui/react-dialog": "latest",
-    "@radix-ui/react-separator": "^1.1.1",
     "@radix-ui/react-slot": "^1.2.0",
-    "@radix-ui/react-tabs": "^1.1.2",
     "@radix-ui/react-toast": "latest",
     "class-variance-authority": "^0.7.1",
     "clsx": "^2.1.1",


### PR DESCRIPTION
### Motivation

- Centralize environment/config values (status page, contact, landing links, enabled OAuth providers) to avoid hard-coded strings across the UI. 
- Support selectively enabling OAuth providers and render buttons dynamically instead of hardcoding provider buttons. 
- Improve auth UX by redirecting signed-in users away from sign-in/sign-up pages and cleaning up dialog/component state handling. 

### Description

- Added `lib/config.ts` exporting `APP_CONFIG` to house contact, auth, and landing footer configuration. 
- Added `lib/clerk-oauth.ts` with `OAUTH_PROVIDER_CONFIG` and `getEnabledOAuthProviderKeys()` to map configured provider keys to Clerk strategies. 
- Updated `components/auth/login-form.tsx` and `components/auth/sign-up-form.tsx` to render OAuth provider buttons dynamically using the new helper and to use typed `OAuthStrategy`. 
- Updated `app/(auth)/sign-in/page.tsx` and `app/(auth)/sign-up/page.tsx` to check `currentUser()` server-side and `redirect()` to `/app` when already signed in. 
- Replaced hard-coded contact/status links and landing footer sections with values from `APP_CONFIG` in multiple components (`components/landing/footer-section.tsx`, `components/app/calendar.tsx`). 
- Replaced a plain empty message with the `Empty` component in `components/app/analytics/share-management.tsx`. 
- Added import dialog reset handler in `components/app/analytics/import-export.tsx` to clear import state when opening. 
- Minor UI/style tweaks and cleanup (string/style normalization, removal of some destructive text classes). 
- Updated `components/landing/navigation.tsx` to use `useUser()` to show different CTA when signed in. 
- Updated `package.json` to remove the `@clerk/localizations` dependency (and a few other unused entries shown in the diff). 

### Testing

- No automated tests were executed as part of this change.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69d9a5d91494832ca2f6b120c533c1bb)

## Summary by Sourcery

集中管理应用在联系信息、落地页和认证设置方面的配置，同时简化并改进认证和分析相关的用户体验。

New Features:
- 引入共享的 `APP_CONFIG` 和 OAuth 提供方映射，通过单一配置源驱动联系信息、落地页页脚内容以及启用的 OAuth 提供方。
- 基于启用的提供方动态渲染登录和注册的 OAuth 按钮，而不是使用硬编码的策略。
- 在落地页导航中为已登录用户展示特定的号召性用语（CTA），并直接链接到应用。

Bug Fixes:
- 在每次打开导入对话框时重置其状态，以避免在日历导入过程中出现陈旧数据。

Enhancements:
- 将已通过认证的用户从登录和注册页面重定向到主应用。
- 改进分享管理中的空状态用户体验，用标准化的 `Empty` 组件替换简单的文本消息。
- 在整个应用中使用集中配置的状态页和反馈邮箱，而不是硬编码的 URL。
- 简化倒计时工具中的破坏性按钮样式，以获得更一致的外观。

Build:
- 从 `package.json` 中移除未使用的依赖，例如 `@clerk/localizations` 和相关的 Radix UI 包。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Centralize app configuration for contact, landing, and auth settings while simplifying and improving authentication and analytics UX.

New Features:
- Introduce a shared APP_CONFIG and OAuth provider mapping to drive contact info, landing footer content, and enabled OAuth providers from a single configuration source.
- Render login and signup OAuth buttons dynamically based on enabled providers instead of hardcoded strategies.
- Show a signed-in specific call-to-action in the landing navigation that links directly to the app.

Bug Fixes:
- Reset import dialog state whenever it is opened to avoid stale data during calendar imports.

Enhancements:
- Redirect already authenticated users away from sign-in and sign-up pages to the main app.
- Improve empty state UX in share management by replacing a plain message with the standardized Empty component.
- Use centralized status page and feedback email configuration throughout the app instead of hardcoded URLs.
- Simplify destructive button styling in the countdown tool for more consistent appearance.

Build:
- Remove unused dependencies such as @clerk/localizations and related Radix UI packages from package.json.

</details>