### PR TITLE
feat(share): improve share page footer

### DIFF
--- a/components/app/profile/shared-event.tsx
+++ b/components/app/profile/shared-event.tsx
@@ -63,16 +63,27 @@ const APP_VERSION = process.env.NEXT_PUBLIC_APP_VERSION ?? "unknown";
 
 function SharePageFooter({ isZh }: { isZh: boolean }) {
   return (
-    <footer className="fixed bottom-0 inset-x-0 z-20 px-4 py-3">
-      <div className="mx-auto flex w-full max-w-5xl items-center justify-between text-xs text-muted-foreground">
-        <span className="font-mono">v{APP_VERSION}</span>
-        <div className="flex items-center gap-4">
-          <Link href="/privacy" className="transition-colors hover:text-foreground">
-            {isZh ? "隐私政策" : "Privacy Policy"}
-          </Link>
-          <Link href="/terms" className="transition-colors hover:text-foreground">
-            {isZh ? "服务条款" : "Terms of Service"}
-          </Link>
+    <footer className="fixed inset-x-0 bottom-0 z-20 px-4 pb-[calc(0.75rem+env(safe-area-inset-bottom))] pt-3">
+      <div className="mx-auto w-full max-w-5xl">
+        <div className="flex items-center justify-between rounded-2xl border border-border/60 bg-background/80 px-3 py-2 text-xs text-muted-foreground shadow-lg shadow-black/5 backdrop-blur-md supports-[backdrop-filter]:bg-background/65">
+          <span className="rounded-full bg-muted px-2 py-1 font-mono text-[11px] tracking-wide text-foreground/80">
+            v{APP_VERSION}
+          </span>
+          <div className="flex items-center gap-1">
+            <Link
+              href="/privacy"
+              className="rounded-md px-2 py-1 transition-colors hover:bg-muted hover:text-foreground"
+            >
+              {isZh ? "隐私政策" : "Privacy Policy"}
+            </Link>
+            <span className="text-muted-foreground/50">•</span>
+            <Link
+              href="/terms"
+              className="rounded-md px-2 py-1 transition-colors hover:bg-muted hover:text-foreground"
+            >
+              {isZh ? "服务条款" : "Terms of Service"}
+            </Link>
+          </div>
         </div>
       </div>
     </footer>


### PR DESCRIPTION
### Motivation
- Improve the visual presentation and usability of the share page footer so the app version, privacy policy, and terms links feel more elegant and are easier to tap on mobile devices.
- Make the footer visually distinct and safer for devices with bottom insets by adding safe-area-aware spacing.
- Keep the change purely presentational without altering share data or behavior logic.

### Description
- Replace the flat footer in `components/app/profile/shared-event.tsx` with a floating, rounded container featuring border, shadow, and subtle glassmorphism styling.
- Render the version as a compact badge using `APP_VERSION` and convert the privacy/terms links into tappable chip-like elements with hover feedback and a dot separator.
- Add bottom padding that respects `env(safe-area-inset-bottom)` to improve display on devices with bottom safe areas.
- Changes are markup/CSS-only and do not modify share fetching, decryption, or other business logic.

### Testing
- No automated tests were run (per request).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69da571fec38832cb493aeae9f0896ea)

## Summary by Sourcery

重新设计共享事件页面的页脚，使应用版本和法律相关链接以更醒目、适配移动端的浮动容器形式展示。

增强内容：
- 更新分享页面页脚，使用圆角、带浮起效果的容器，并采用玻璃拟态风格来展示版本信息和法律相关链接。
- 将应用版本渲染为紧凑的徽章，并将隐私/条款条目转换为类似“芯片”的可点击链接，同时使用圆点分隔符以提升可用性。
- 添加考虑设备安全区域（safe area）内边距的底部留白，以改善在现代移动设备上的页脚布局。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Restyle the shared event page footer to present the app version and legal links in a more prominent, mobile-friendly floating container.

Enhancements:
- Update the share page footer to use a rounded, elevated container with glassmorphism-inspired styling for version and legal links.
- Render the app version as a compact badge and convert privacy/terms entries into chip-like, tappable links with a dot separator for better usability.
- Add bottom padding that respects device safe-area insets to improve footer layout on modern mobile devices.

</details>