### PR TITLE
fix: move share page legal links to fixed bottom-right outside card

### DIFF
--- a/components/app/profile/shared-event.tsx
+++ b/components/app/profile/shared-event.tsx
@@ -59,34 +59,23 @@ interface SharedEventViewProps {
   handle?: string;
 }
 
-const APP_VERSION = process.env.NEXT_PUBLIC_APP_VERSION ?? "unknown";
-
-function SharePageFooter({ isZh }: { isZh: boolean }) {
+function SharePageLegalLinks({ isZh }: { isZh: boolean }) {
   return (
-    <footer className="fixed inset-x-0 bottom-0 z-20 px-4 pb-[calc(0.75rem+env(safe-area-inset-bottom))] pt-3">
-      <div className="mx-auto w-full max-w-5xl">
-        <div className="flex items-center justify-between rounded-2xl border border-border/60 bg-background/80 px-3 py-2 text-xs text-muted-foreground shadow-lg shadow-black/5 backdrop-blur-md supports-[backdrop-filter]:bg-background/65">
-          <span className="rounded-full bg-muted px-2 py-1 font-mono text-[11px] tracking-wide text-foreground/80">
-            v{APP_VERSION}
-          </span>
-          <div className="flex items-center gap-1">
-            <Link
-              href="/privacy"
-              className="rounded-md px-2 py-1 transition-colors hover:bg-muted hover:text-foreground"
-            >
-              {isZh ? "隐私政策" : "Privacy Policy"}
-            </Link>
-            <span className="text-muted-foreground/50">•</span>
-            <Link
-              href="/terms"
-              className="rounded-md px-2 py-1 transition-colors hover:bg-muted hover:text-foreground"
-            >
-              {isZh ? "服务条款" : "Terms of Service"}
-            </Link>
-          </div>
-        </div>
-      </div>
-    </footer>
+    <div className="fixed bottom-4 right-4 z-20 flex items-center gap-1 rounded-full border border-border/60 bg-background/80 px-3 py-1.5 text-xs text-muted-foreground shadow-lg shadow-black/5 backdrop-blur-md supports-[backdrop-filter]:bg-background/65">
+      <Link
+        href="/privacy"
+        className="rounded-md px-2 py-1 transition-colors hover:bg-muted hover:text-foreground"
+      >
+        {isZh ? "隐私政策" : "Privacy Policy"}
+      </Link>
+      <span className="text-muted-foreground/50">•</span>
+      <Link
+        href="/terms"
+        className="rounded-md px-2 py-1 transition-colors hover:bg-muted hover:text-foreground"
+      >
+        {isZh ? "服务条款" : "Terms of Service"}
+      </Link>
+    </div>
   );
 }
 
@@ -362,7 +351,7 @@ export default function SharedEventView({
         <p className="mt-6 text-lg font-medium text-gray-600 dark:text-gray-300">
           {isZh ? "加载中..." : "Loading..."}
         </p>
-        <SharePageFooter isZh={isZh} />
+        <SharePageLegalLinks isZh={isZh} />
       </div>
     );
   }
@@ -494,7 +483,7 @@ export default function SharedEventView({
             </Card>
           </motion.div>
         </div>
-        <SharePageFooter isZh={isZh} />
+        <SharePageLegalLinks isZh={isZh} />
       </div>
     );
   }
@@ -562,7 +551,7 @@ export default function SharedEventView({
             </Card>
           </motion.div>
         </div>
-        <SharePageFooter isZh={isZh} />
+        <SharePageLegalLinks isZh={isZh} />
       </div>
     );
   }
@@ -763,7 +752,7 @@ export default function SharedEventView({
           </Card>
         </motion.div>
       </div>
-      <SharePageFooter isZh={isZh} />
+      <SharePageLegalLinks isZh={isZh} />
     </div>
   );
 }


### PR DESCRIPTION
### Motivation
- The share page previously showed a full-width footer with the app version and legal links which should be removed to keep the share card visually focused.
- Legal links still must be accessible, but placed outside the card and pinned in a compact fixed position at the bottom-right as requested.

### Description
- Removed the old footer and the `APP_VERSION` pill from `components/app/profile/shared-event.tsx` and introduced a compact `SharePageLegalLinks` component.
- `SharePageLegalLinks` renders only the `Privacy Policy` and `Terms of Service` links and uses `fixed bottom-4 right-4` to pin the links to the bottom-right outside the card.
- Replaced all instances of the old footer with `SharePageLegalLinks` so the links are visible across loading, password-protected, error, and event-detail states in the share page.
- Changes are limited to `components/app/profile/shared-event.tsx` and preserve existing translations and styles for the two links.

### Testing
- No automated tests were executed for this change.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69da596cffb0832c999b5a69f34b0a4f)

## Summary by Sourcery

将分享页面中的法律链接移入主卡片之外的一个紧凑的固定位置控件中。

Bug Fixes:
- 在移除全宽页脚后，确保在所有共享事件状态下，隐私政策和服务条款链接仍然可访问。

Enhancements:
- 将分享页面的全宽页脚和应用版本标签替换为右下角的精简法律链接小控件，同时保留现有翻译。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Move share page legal links into a compact fixed-position control outside the main card.

Bug Fixes:
- Ensure privacy policy and terms of service links remain accessible across all shared event states after removing the full-width footer.

Enhancements:
- Replace the full-width share page footer and app version pill with a minimal bottom-right legal links chip that preserves existing translations.

</details>