### PR TITLE
fix: bump to 2.2.13 and remove daily toast/update suffix

### DIFF
--- a/components/app/analytics/build-info-card.tsx
+++ b/components/app/analytics/build-info-card.tsx
@@ -175,9 +175,7 @@ export default function BuildInfoCard({ language }: BuildInfoCardProps) {
         );
       }
 
-      const url = new URL(window.location.href);
-      url.searchParams.set("updated", Date.now().toString());
-      window.location.assign(url.toString());
+      window.location.reload();
     } finally {
       setIsUpdating(false);
     }

--- a/components/app/calendar.tsx
+++ b/components/app/calendar.tsx
@@ -43,7 +43,6 @@ import RightSidebar from "@/components/app/sidebar/right-sidebar";
 import { addDays, addYears, subDays, subYears } from "date-fns";
 import EventPreview from "@/components/app/event/event-preview";
 import EventDialog from "@/components/app/event/event-dialog";
-import DailyToast from "@/components/app/profile/daily-toast";
 import { ScrollArea } from "@/components/ui/scroll-area";
 import Sidebar from "@/components/app/sidebar/sidebar";
 import { translations, useLanguage } from "@/lib/i18n";
@@ -1102,7 +1101,6 @@ export default function Calendar({ className, ...props }: CalendarProps) {
           timezone={timezone}
         />
 
-        <DailyToast />
 
         <AlertDialog
           open={deleteConfirmOpen}

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "one-calendar",
-  "version": "2.2.12",
+  "version": "2.2.13",
   "private": true,
   "packageManager": "bun@1.3.8",
   "scripts": {


### PR DESCRIPTION
### Motivation
- Bump the app version to `2.2.13` for the release. 
- Remove the daily welcome toast integration from the main calendar to stop showing the daily toast UI there. 
- Avoid appending an update query parameter to the URL when applying updates so the page reload no longer leaves a `?updated...` suffix.

### Description
- Updated `package.json` to set `version` to `2.2.13`.
- Removed the `DailyToast` import from `components/app/calendar.tsx` and removed the rendered `<DailyToast />` node from the calendar layout.
- Replaced the navigation that appended `?updated=...` with a plain `window.location.reload()` in `components/app/analytics/build-info-card.tsx` so the update button triggers a direct reload.

### Testing
- No automated tests were run for this change per request.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69daef2c38a0832cbf3eec3ad170336e)

## Summary by Sourcery

提升应用版本并调整更新和日历界面的行为。

Bug 修复：
- 触发应用内更新时，停止向 URL 添加 `?updated=...` 查询参数，改为使用简单的页面重新加载。

增强功能：
- 将应用版本提升到 2.2.13 以用于发布。
- 从主日历视图中移除每日 toast 组件，以停止在该视图中显示每日欢迎 toast。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Bump the application version and adjust update and calendar UI behavior.

Bug Fixes:
- Stop adding an `?updated=...` query parameter to the URL when triggering an in-app update, using a simple page reload instead.

Enhancements:
- Bump the app version to 2.2.13 for release.
- Remove the daily toast component from the main calendar view to stop showing the daily welcome toast there.

</details>