### PR TITLE
fix: disable runtime caching and force service worker updates

### DIFF
--- a/components/providers/pwa-provider.tsx
+++ b/components/providers/pwa-provider.tsx
@@ -6,18 +6,64 @@ export function PwaProvider() {
   useEffect(() => {
     if (!('serviceWorker' in navigator)) return
 
+    const clearCaches = async () => {
+      if (!('caches' in window)) return
+      const keys = await caches.keys()
+      await Promise.all(keys.map((key) => caches.delete(key)))
+    }
+
     const registerServiceWorker = async () => {
       try {
-        await navigator.serviceWorker.register('/sw.js', {
+        const registration = await navigator.serviceWorker.register('/sw.js', {
           scope: '/',
           updateViaCache: 'none',
         })
+
+        await clearCaches()
+
+        if (registration.waiting) {
+          registration.waiting.postMessage({ type: 'SKIP_WAITING' })
+        }
+
+        registration.addEventListener('updatefound', () => {
+          const worker = registration.installing
+          if (!worker) return
+
+          worker.addEventListener('statechange', () => {
+            if (
+              worker.state === 'installed' &&
+              navigator.serviceWorker.controller
+            ) {
+              worker.postMessage({ type: 'SKIP_WAITING' })
+            }
+          })
+        })
+
+        navigator.serviceWorker.addEventListener('controllerchange', () => {
+          window.location.reload()
+        })
+
+        const updateTimer = window.setInterval(() => {
+          registration.update().catch(() => undefined)
+        }, 60 * 1000)
+
+        return () => {
+          window.clearInterval(updateTimer)
+        }
       } catch {
-        // Silent fail to avoid breaking the app on unsupported browsers.
+        return undefined
       }
     }
 
-    registerServiceWorker()
+    let cleanup: (() => void) | undefined
+
+    registerServiceWorker().then((fn) => {
+      cleanup = fn
+    })
+
+    return () => {
+      cleanup?.()
+    }
   }, [])
 
   return null

--- a/public/sw.js
+++ b/public/sw.js
@@ -1,45 +1,29 @@
-const CACHE_NAME = 'one-calendar-shell-v3'
-const OFFLINE_URLS = ['/app', '/icon.svg']
-const STATIC_PATH_PREFIXES = ['/_next/static/', '/_next/image/', '/icons/']
-const STATIC_FILE_PATTERN =
-  /\.(?:js|css|png|jpg|jpeg|gif|svg|webp|ico|woff|woff2|ttf|otf|eot|json|txt|xml|webmanifest)$/i
+const SW_VERSION = self.registration?.scope
 
-function shouldCacheRequest(requestUrl) {
-  if (requestUrl.origin !== self.location.origin) return false
-  if (OFFLINE_URLS.includes(requestUrl.pathname)) return true
-  if (
-    STATIC_PATH_PREFIXES.some((prefix) =>
-      requestUrl.pathname.startsWith(prefix),
-    )
-  ) {
-    return true
-  }
-  return STATIC_FILE_PATTERN.test(requestUrl.pathname)
+const clearAllCaches = async () => {
+  const keys = await caches.keys()
+  await Promise.all(keys.map((key) => caches.delete(key)))
 }
 
 self.addEventListener('install', (event) => {
-  event.waitUntil(
-    caches
-      .open(CACHE_NAME)
-      .then((cache) => cache.addAll(OFFLINE_URLS))
-      .then(() => self.skipWaiting()),
-  )
+  event.waitUntil(self.skipWaiting())
 })
 
 self.addEventListener('activate', (event) => {
   event.waitUntil(
-    caches
-      .keys()
-      .then((keys) =>
-        Promise.all(
-          keys
-            .filter((key) => key !== CACHE_NAME)
-            .map((key) => caches.delete(key)),
+    clearAllCaches().then(async () => {
+      await self.clients.claim()
+      const clients = await self.clients.matchAll({
+        type: 'window',
+        includeUncontrolled: true,
+      })
+      await Promise.all(
+        clients.map((client) =>
+          client.postMessage({ type: 'SW_ACTIVATED', version: SW_VERSION }),
         ),
-      ),
+      )
+    }),
   )
-
-  self.clients.claim()
 })
 
 self.addEventListener('message', (event) => {
@@ -55,41 +39,8 @@ self.addEventListener('fetch', (event) => {
   if (requestUrl.protocol !== 'http:' && requestUrl.protocol !== 'https:') {
     return
   }
-  if (requestUrl.pathname.startsWith('/api/')) {
-    event.respondWith(fetch(event.request))
-    return
-  }
-  if (!shouldCacheRequest(requestUrl)) {
-    event.respondWith(fetch(event.request))
-    return
-  }
 
-  event.respondWith(
-    caches.match(event.request).then((cachedResponse) => {
-      if (cachedResponse) {
-        return cachedResponse
-      }
-
-      return fetch(event.request)
-        .then((networkResponse) => {
-          if (!networkResponse || networkResponse.status !== 200) {
-            return networkResponse
-          }
-
-          if (networkResponse.type !== 'basic') {
-            return networkResponse
-          }
-
-          const responseToCache = networkResponse.clone()
-          caches.open(CACHE_NAME).then((cache) => {
-            cache.put(event.request, responseToCache).catch(() => undefined)
-          })
-
-          return networkResponse
-        })
-        .catch(() => caches.match('/app'))
-    }),
-  )
+  event.respondWith(fetch(event.request))
 })
 
 self.addEventListener('notificationclick', (event) => {


### PR DESCRIPTION
### Motivation
- Users requested that the app avoid serving stale cached assets and that new versions apply immediately without relying on old caches.  
- The goal is the equivalent of “no cache”: keep the service worker for PWA features but stop runtime Cache Storage reads/writes.  
- Ensure new SW versions are detected and activated quickly so clients see the latest code without manual cache clearing.

### Description
- Rewrote the service worker at `public/sw.js` to use a network-only `fetch` strategy and removed runtime caching and offline asset pre-caching.  
- Added aggressive cache cleanup in the SW `activate` handler via `clearAllCaches()` and broadcast `SW_ACTIVATED` to clients with `version` metadata.  
- Updated `components/providers/pwa-provider.tsx` to clear browser caches on registration, force waiting/installed workers to `SKIP_WAITING`, and reload on `controllerchange`.  
- Started periodic `registration.update()` polling (every 60s) and added a cleanup handler to stop the timer when the component unmounts.

### Testing
- Repository pre-commit tasks ran `prettier --write` and `eslint --fix` on changed files and completed successfully.  
- The modified files were staged and packaged into the PR after automated formatting/lint steps passed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e19061be7c8326a42dcc662ea1ac3f)

## Summary by Sourcery

在 service worker 中禁用运行时缓存，并确保新版本能够快速激活并传播到各个客户端。

Bug Fixes（错误修复）:
- 通过移除对 Cache Storage 的使用并仅依赖网络请求的 fetch 处理，防止提供过期的静态资源。

Enhancements（增强功能）:
- 在 service worker 激活期间以及客户端注册时进行强制缓存清理，以移除遗留缓存。
- 当新的 service worker 激活时，通过广播消息通知受控客户端，并在消息中包含当前版本信息。
- 强制处于 waiting 状态和新安装的 service worker 跳过等待阶段，并在 controller 发生变化时触发页面刷新，以便更新可以立即生效。
- 从 PWA provider 端引入定期的 service worker 更新检查，以便及时检测并应用新版本。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Disable runtime caching in the service worker and ensure new versions activate and propagate to clients quickly.

Bug Fixes:
- Prevent stale assets from being served by removing Cache Storage usage and relying on network-only fetch handling.

Enhancements:
- Add aggressive cache cleanup during service worker activation and on client registration to remove legacy caches.
- Notify controlled clients when a new service worker activates via a broadcast message including the current version.
- Force waiting and newly installed service workers to skip the waiting phase and trigger a page reload on controller changes so updates apply immediately.
- Introduce periodic service worker update checks from the PWA provider to detect and apply new versions promptly.

</details>