### PR TITLE
fix(analytics): enforce chart color order, fix stacked-bar rounding, avg-lead uses future window

### DIFF
--- a/components/app/analytics/analytics-utils.ts
+++ b/components/app/analytics/analytics-utils.ts
@@ -15,6 +15,8 @@ import type { AnalyticsEvent, DateRange } from './analytics-types'
 
 export type AnalyticsRangePreset = 'week' | 'month' | 'quarter'
 
+const COLOR_ORDER = ['#3b82f6', '#10b981', '#f59e0b', '#ef4444', '#8b5cf6', '#ec4899', '#14b8a6']
+
 const COLOR_MAP: Record<string, string> = {
   'bg-blue-500': '#3b82f6',
   'bg-green-500': '#10b981',
@@ -50,6 +52,12 @@ export const normalizeChartColor = (input: string | undefined): string => {
   }
   const prefixed = input.startsWith('bg-') ? input : `bg-${input}`
   return COLOR_MAP[prefixed] ?? '#64748b'
+}
+
+export const getChartColorOrderIndex = (color: string): number => {
+  const normalized = normalizeChartColor(color).toLowerCase()
+  const index = COLOR_ORDER.indexOf(normalized)
+  return index === -1 ? Number.MAX_SAFE_INTEGER : index
 }
 
 export const resolveDateRange = (

--- a/components/app/analytics/charts/daily-monthly-count-chart.tsx
+++ b/components/app/analytics/charts/daily-monthly-count-chart.tsx
@@ -1,6 +1,6 @@
 'use client'
 
-import { Bar, BarChart, CartesianGrid, XAxis, YAxis } from 'recharts'
+import { Bar, BarChart, CartesianGrid, Cell, XAxis, YAxis } from 'recharts'
 import { Tabs, TabsList, TabsTrigger } from '@/components/ui/tabs'
 import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/card'
 import { format } from 'date-fns'
@@ -44,6 +44,18 @@ export function DailyMonthlyCountChart({
   const t = translations[language]
   const activeData = mode === 'day' ? dailyData : monthlyData
   const seriesLabelMap = new Map(series.map((item) => [item.key, item.label]))
+  const topDataKeyByLabel = new Map(
+    activeData.map((datum) => {
+      let topKey = ''
+      series.forEach((item) => {
+        const value = Number(datum[item.key] ?? 0)
+        if (value > 0) {
+          topKey = item.key
+        }
+      })
+      return [datum.label, topKey]
+    }),
+  )
   const chartConfig = series.reduce<ChartConfig>((acc, item) => {
     acc[item.key] = {
       label: item.label,
@@ -100,14 +112,23 @@ export function DailyMonthlyCountChart({
                 }
               />
               <ChartLegend content={<ChartLegendContent />} />
-              {series.map((item, index) => (
+              {series.map((item) => (
                 <Bar
                   key={item.key}
                   dataKey={item.key}
                   stackId="count"
                   fill={item.color}
-                  radius={index === series.length - 1 ? [8, 8, 0, 0] : [0, 0, 0, 0]}
-                />
+                >
+                  {activeData.map((datum) => {
+                    const isTopSegment = topDataKeyByLabel.get(datum.label) === item.key
+                    return (
+                      <Cell
+                        key={`${item.key}-${datum.label}`}
+                        radius={isTopSegment ? [8, 8, 0, 0] : [0, 0, 0, 0]}
+                      />
+                    )
+                  })}
+                </Bar>
               ))}
             </BarChart>
           </ChartContainer>

--- a/components/app/analytics/charts/weekday-stacked-duration-chart.tsx
+++ b/components/app/analytics/charts/weekday-stacked-duration-chart.tsx
@@ -1,6 +1,6 @@
 'use client'
 
-import { Bar, BarChart, CartesianGrid, XAxis, YAxis } from 'recharts'
+import { Bar, BarChart, CartesianGrid, Cell, XAxis, YAxis } from 'recharts'
 import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/card'
 import {
   ChartContainer,
@@ -41,6 +41,19 @@ export function WeekdayStackedDurationChart({
     return acc
   }, {})
 
+  const topDataKeyByDay = new Map(
+    data.map((datum) => {
+      let topKey = ''
+      series.forEach((item) => {
+        const value = Number(datum[item.key] ?? 0)
+        if (value > 0) {
+          topKey = item.key
+        }
+      })
+      return [datum.day, topKey]
+    }),
+  )
+
   return (
     <Card>
       <CardHeader>
@@ -76,14 +89,23 @@ export function WeekdayStackedDurationChart({
                 }
               />
               <ChartLegend content={<ChartLegendContent />} />
-              {series.map((item, index) => (
+              {series.map((item) => (
                 <Bar
                   key={item.key}
                   dataKey={item.key}
                   stackId="duration"
                   fill={item.color}
-                  radius={index === series.length - 1 ? [8, 8, 0, 0] : [0, 0, 0, 0]}
-                />
+                >
+                  {data.map((datum) => {
+                    const isTopSegment = topDataKeyByDay.get(datum.day) === item.key
+                    return (
+                      <Cell
+                        key={`${item.key}-${datum.day}`}
+                        radius={isTopSegment ? [8, 8, 0, 0] : [0, 0, 0, 0]}
+                      />
+                    )
+                  })}
+                </Bar>
               ))}
             </BarChart>
           </ChartContainer>

--- a/components/app/analytics/import-export.tsx
+++ b/components/app/analytics/import-export.tsx
@@ -25,6 +25,10 @@ import {
   encryptPayload,
   isEncryptedPayload,
 } from '@/lib/crypto'
+import {
+  readEncryptedLocalStorage,
+  writeEncryptedLocalStorage,
+} from '@/hooks/useLocalStorage'
 import { Tabs, TabsList, TabsTrigger, TabsContent } from '@/components/ui/tabs'
 import { Alert, AlertDescription, AlertTitle } from '@/components/ui/alert'
 import { translations, useLanguage } from '@/lib/i18n'
@@ -40,6 +44,38 @@ import { toast } from 'sonner'
 interface ImportExportProps {
   events: CalendarEvent[]
   onImportEvents: (events: CalendarEvent[]) => void
+}
+
+interface ImportedCategory {
+  id: string
+  name: string
+  color: string
+  keywords?: string[]
+}
+
+interface AppSettingsSnapshot {
+  language?: string
+  firstDayOfWeek?: number
+  timezone?: string
+  notificationSound?: string
+  defaultView?: string
+  enableShortcuts?: boolean
+  timeFormat?: '24h' | '12h'
+  toastPosition?: 'bottom-left' | 'bottom-center' | 'bottom-right'
+  theme?: string
+}
+
+interface JsonBackupPayloadV2 {
+  format: 'one-calendar-json-v2'
+  exportedAt: string
+  data: {
+    events: CalendarEvent[]
+    calendars: ImportedCategory[]
+    eventCategoryMap: Record<string, string>
+    bookmarks: unknown[]
+    countdowns: unknown[]
+    settings: AppSettingsSnapshot
+  }
 }
 
 export default function ImportExport({
@@ -63,11 +99,23 @@ export default function ImportExport({
   const [debugInfo, setDebugInfo] = useState<string>('')
   const [language] = useLanguage()
   const t = translations[language]
-  const { calendars } = useCalendar()
+  const { calendars, setCalendars } = useCalendar()
   const [importCalendarId, setImportCalendarId] =
     useState<string>('__uncategorized__')
 
   const [forceUpdate, setForceUpdate] = useState(0)
+
+  const SETTINGS_KEYS = {
+    language: 'preferred-language',
+    firstDayOfWeek: 'first-day-of-week',
+    timezone: 'timezone',
+    notificationSound: 'notification-sound',
+    defaultView: 'default-view',
+    enableShortcuts: 'enable-shortcuts',
+    timeFormat: 'time-format',
+    toastPosition: 'toast-position',
+    theme: 'theme',
+  } as const
 
   useEffect(() => {
     const handleLanguageChange = () => {
@@ -118,7 +166,67 @@ export default function ImportExport({
         const icsContent = generateICSFile(filteredEvents)
         downloadFile(icsContent, 'calendar-export.ics', 'text/calendar')
       } else if (exportFormat === 'json') {
-        let jsonContent = JSON.stringify(filteredEvents, null, 2)
+        const bookmarks = await readEncryptedLocalStorage<unknown[]>(
+          'bookmarked-events',
+          [],
+        )
+        const countdowns = await readEncryptedLocalStorage<unknown[]>(
+          'countdowns',
+          [],
+        )
+        const settings = {
+          language: await readEncryptedLocalStorage<string | undefined>(
+            SETTINGS_KEYS.language,
+            undefined,
+          ),
+          firstDayOfWeek: await readEncryptedLocalStorage<number | undefined>(
+            SETTINGS_KEYS.firstDayOfWeek,
+            undefined,
+          ),
+          timezone: await readEncryptedLocalStorage<string | undefined>(
+            SETTINGS_KEYS.timezone,
+            undefined,
+          ),
+          notificationSound: await readEncryptedLocalStorage<string | undefined>(
+            SETTINGS_KEYS.notificationSound,
+            undefined,
+          ),
+          defaultView: await readEncryptedLocalStorage<string | undefined>(
+            SETTINGS_KEYS.defaultView,
+            undefined,
+          ),
+          enableShortcuts: await readEncryptedLocalStorage<boolean | undefined>(
+            SETTINGS_KEYS.enableShortcuts,
+            undefined,
+          ),
+          timeFormat: await readEncryptedLocalStorage<'24h' | '12h' | undefined>(
+            SETTINGS_KEYS.timeFormat,
+            undefined,
+          ),
+          toastPosition: await readEncryptedLocalStorage<
+            'bottom-left' | 'bottom-center' | 'bottom-right' | undefined
+          >(SETTINGS_KEYS.toastPosition, undefined),
+          theme: await readEncryptedLocalStorage<string | undefined>(
+            SETTINGS_KEYS.theme,
+            undefined,
+          ),
+        }
+        const exportPayload: JsonBackupPayloadV2 = {
+          format: 'one-calendar-json-v2',
+          exportedAt: new Date().toISOString(),
+          data: {
+            events: filteredEvents,
+            calendars,
+            eventCategoryMap: Object.fromEntries(
+              filteredEvents.map((event) => [event.id, event.calendarId || '']),
+            ),
+            bookmarks,
+            countdowns,
+            settings,
+          },
+        }
+
+        let jsonContent = JSON.stringify(exportPayload, null, 2)
 
         const hasAnyPasswordInput =
           jsonPassword.trim() || jsonPasswordConfirm.trim()
@@ -197,6 +305,7 @@ export default function ImportExport({
       setIsLoading(true)
       setDebugInfo('')
       let importedEvents: CalendarEvent[] = []
+      let shouldApplyCategory = true
       let rawContent = ''
 
       if (importTab === 'file' && selectedFile) {
@@ -206,7 +315,9 @@ export default function ImportExport({
         if (fileExt === 'ics') {
           importedEvents = parseICS(rawContent)
         } else if (fileExt === 'json') {
-          importedEvents = await parseJsonEvents(rawContent)
+          const parsedResult = await parseJsonEvents(rawContent)
+          importedEvents = parsedResult.events
+          shouldApplyCategory = parsedResult.shouldApplyImportCategory
         } else if (fileExt === 'csv') {
           importedEvents = parseCSV(rawContent)
         } else {
@@ -219,7 +330,9 @@ export default function ImportExport({
         if (importUrl.endsWith('.ics')) {
           importedEvents = parseICS(rawContent)
         } else if (importUrl.endsWith('.json')) {
-          importedEvents = await parseJsonEvents(rawContent)
+          const parsedResult = await parseJsonEvents(rawContent)
+          importedEvents = parsedResult.events
+          shouldApplyCategory = parsedResult.shouldApplyImportCategory
         } else {
           throw new Error(t.unsupportedUrlFormat || 'Unsupported URL format')
         }
@@ -240,7 +353,9 @@ ${rawContent.substring(0, 500)}...`)
         return
       }
 
-      const normalizedImportedEvents = applyImportCategory(importedEvents)
+      const normalizedImportedEvents = shouldApplyCategory
+        ? applyImportCategory(importedEvents)
+        : importedEvents
       onImportEvents(normalizedImportedEvents)
 
       toast(
@@ -286,9 +401,54 @@ ${rawContent.substring(0, 500)}...`)
     }
   }
 
+  const normalizeImportedEvent = (input: Partial<CalendarEvent>): CalendarEvent => {
+    const start = input.startDate ? new Date(input.startDate) : new Date()
+    const parsedEnd = input.endDate ? new Date(input.endDate) : new Date(start.getTime() + 60 * 60 * 1000)
+    const end = parsedEnd < start ? new Date(start.getTime() + 60 * 60 * 1000) : parsedEnd
+
+    return {
+      id: input.id || `${Date.now()}${Math.random().toString(36).slice(2, 9)}`,
+      title: input.title || t.unnamedEvent || 'Unnamed Event',
+      startDate: start,
+      endDate: end,
+      isAllDay: Boolean(input.isAllDay),
+      recurrence: input.recurrence || 'none',
+      location: input.location,
+      participants: Array.isArray(input.participants) ? input.participants : [],
+      notification: typeof input.notification === 'number' ? input.notification : 0,
+      description: input.description,
+      color: input.color || 'bg-[#E6F6FD]',
+      calendarId: input.calendarId || '',
+    }
+  }
+
+  const mergeCategoriesFromBackup = (importedCategories: ImportedCategory[]) => {
+    if (importedCategories.length === 0) return
+
+    const merged = [...calendars]
+    importedCategories.forEach((category) => {
+      const index = merged.findIndex((item) => item.id === category.id)
+      if (index === -1) {
+        merged.push({
+          id: category.id,
+          name: category.name,
+          color: category.color,
+          keywords: category.keywords ?? [],
+        })
+      } else {
+        merged[index] = {
+          ...merged[index],
+          ...category,
+          keywords: category.keywords ?? merged[index].keywords ?? [],
+        }
+      }
+    })
+    setCalendars(merged)
+  }
+
   const parseJsonEvents = async (
     rawContent: string,
-  ): Promise<CalendarEvent[]> => {
+  ): Promise<{ events: CalendarEvent[]; shouldApplyImportCategory: boolean }> => {
     const parsed = JSON.parse(rawContent)
 
     if (isEncryptedPayload(parsed) || parsed?.encrypted) {
@@ -314,19 +474,93 @@ ${rawContent.substring(0, 500)}...`)
         parsed.ciphertext,
         parsed.iv,
       )
-      const decryptedEvents = JSON.parse(decrypted)
-
-      if (!Array.isArray(decryptedEvents)) {
-        throw new Error(
-          t.invalidEncryptedJson || 'Invalid encrypted JSON payload',
-        )
-      }
-
-      return decryptedEvents as CalendarEvent[]
+      return parseJsonEvents(decrypted)
     }
 
     if (Array.isArray(parsed)) {
-      return parsed as CalendarEvent[]
+      return {
+        events: parsed.map((event) => normalizeImportedEvent(event)),
+        shouldApplyImportCategory: true,
+      }
+    }
+
+    if (
+      parsed &&
+      typeof parsed === 'object' &&
+      parsed.format === 'one-calendar-json-v2' &&
+      parsed.data
+    ) {
+      const payload = parsed as JsonBackupPayloadV2
+      const importedEvents = Array.isArray(payload.data.events)
+        ? payload.data.events.map((event) => normalizeImportedEvent(event))
+        : []
+      const importedCategories = Array.isArray(payload.data.calendars)
+        ? payload.data.calendars
+        : []
+      const relationMap = payload.data.eventCategoryMap || {}
+      const categoryIdSet = new Set(importedCategories.map((item) => item.id))
+
+      const extraCategoryIds = new Set<string>()
+      importedEvents.forEach((event) => {
+        const mappedCategoryId = relationMap[event.id]
+        if (typeof mappedCategoryId === 'string') {
+          event.calendarId = mappedCategoryId
+        }
+        if (event.calendarId && !categoryIdSet.has(event.calendarId)) {
+          extraCategoryIds.add(event.calendarId)
+        }
+      })
+
+      const autoCategories: ImportedCategory[] = Array.from(extraCategoryIds).map((id) => ({
+        id,
+        name: `Imported ${id.slice(0, 6)}`,
+        color: 'bg-blue-500',
+        keywords: [],
+      }))
+      mergeCategoriesFromBackup([...importedCategories, ...autoCategories])
+
+      if (Array.isArray(payload.data.bookmarks)) {
+        await writeEncryptedLocalStorage('bookmarked-events', payload.data.bookmarks)
+      }
+      if (Array.isArray(payload.data.countdowns)) {
+        await writeEncryptedLocalStorage('countdowns', payload.data.countdowns)
+      }
+
+      const settings = payload.data.settings || {}
+      const settingWrites: Promise<void>[] = []
+      if (settings.language !== undefined) {
+        settingWrites.push(writeEncryptedLocalStorage(SETTINGS_KEYS.language, settings.language))
+      }
+      if (settings.firstDayOfWeek !== undefined) {
+        settingWrites.push(writeEncryptedLocalStorage(SETTINGS_KEYS.firstDayOfWeek, settings.firstDayOfWeek))
+      }
+      if (settings.timezone !== undefined) {
+        settingWrites.push(writeEncryptedLocalStorage(SETTINGS_KEYS.timezone, settings.timezone))
+      }
+      if (settings.notificationSound !== undefined) {
+        settingWrites.push(writeEncryptedLocalStorage(SETTINGS_KEYS.notificationSound, settings.notificationSound))
+      }
+      if (settings.defaultView !== undefined) {
+        settingWrites.push(writeEncryptedLocalStorage(SETTINGS_KEYS.defaultView, settings.defaultView))
+      }
+      if (settings.enableShortcuts !== undefined) {
+        settingWrites.push(writeEncryptedLocalStorage(SETTINGS_KEYS.enableShortcuts, settings.enableShortcuts))
+      }
+      if (settings.timeFormat !== undefined) {
+        settingWrites.push(writeEncryptedLocalStorage(SETTINGS_KEYS.timeFormat, settings.timeFormat))
+      }
+      if (settings.toastPosition !== undefined) {
+        settingWrites.push(writeEncryptedLocalStorage(SETTINGS_KEYS.toastPosition, settings.toastPosition))
+      }
+      if (settings.theme !== undefined) {
+        settingWrites.push(writeEncryptedLocalStorage(SETTINGS_KEYS.theme, settings.theme))
+      }
+      await Promise.all(settingWrites)
+
+      return {
+        events: importedEvents,
+        shouldApplyImportCategory: false,
+      }
     }
 
     throw new Error(t.unsupportedFormat || 'Unsupported file format')

--- a/components/app/analytics/time-analytics.tsx
+++ b/components/app/analytics/time-analytics.tsx
@@ -263,7 +263,7 @@ export default function TimeAnalyticsComponent({ events, calendars = [] }: TimeA
   const metrics = useMemo(() => {
     if (rangeEvents.length === 0) {
       const futureLeadTimes = futureRangeEvents.map(
-        (event) => (event.start.getTime() - event.createdAt.getTime()) / (1000 * 60 * 60 * 24),
+        (event) => Math.max((event.start.getTime() - now.getTime()) / (1000 * 60 * 60 * 24), 0),
       )
       const futureAvgLead =
         futureLeadTimes.length === 0
@@ -318,7 +318,7 @@ export default function TimeAnalyticsComponent({ events, calendars = [] }: TimeA
     const uplift = overallAvg === 0 ? 0 : ((busiestDay.avg - overallAvg) / overallAvg) * 100
 
     const leadTimes = futureRangeEvents.map(
-      (event) => (event.start.getTime() - event.createdAt.getTime()) / (1000 * 60 * 60 * 24),
+      (event) => Math.max((event.start.getTime() - now.getTime()) / (1000 * 60 * 60 * 24), 0),
     )
     const avgLead =
       leadTimes.length === 0 ? 0 : leadTimes.reduce((sum, value) => sum + value, 0) / leadTimes.length
@@ -365,7 +365,7 @@ export default function TimeAnalyticsComponent({ events, calendars = [] }: TimeA
         subtitle: t.analyticsPeakWindowSubtitle.replace('{pct}', concentrationRatio.toFixed(1)),
       },
     ]
-  }, [dateRange, futureRangeEvents, rangeEvents, t, weekdayLabels])
+  }, [dateRange, futureRangeEvents, now, rangeEvents, t, weekdayLabels])
 
   return (
     <div className="space-y-6 rounded-lg border p-4">

--- a/components/app/analytics/time-analytics.tsx
+++ b/components/app/analytics/time-analytics.tsx
@@ -10,6 +10,7 @@ import {
   filterEventsInRange,
   formatHourRange,
   generateRangeDays,
+  getChartColorOrderIndex,
   getMonthDays,
   groupDayKey,
   groupMonthKey,
@@ -54,9 +55,20 @@ export default function TimeAnalyticsComponent({ events, calendars = [] }: TimeA
 
   const now = useMemo(() => new Date(), [])
   const dateRange = useMemo(() => resolveDateRange(preset, now), [preset, now])
+  const futureDateRange = useMemo(
+    () => ({
+      start: now,
+      end: new Date(now.getTime() + (dateRange.end.getTime() - dateRange.start.getTime())),
+    }),
+    [dateRange.end, dateRange.start, now],
+  )
 
   const normalizedEvents = useMemo(() => mapEventsToAnalyticsEvents(events), [events])
   const rangeEvents = useMemo(() => filterEventsInRange(normalizedEvents, dateRange), [normalizedEvents, dateRange])
+  const futureRangeEvents = useMemo(
+    () => filterEventsInRange(normalizedEvents, futureDateRange),
+    [futureDateRange, normalizedEvents],
+  )
 
   const categoryMeta = useMemo(() => {
     return new Map(
@@ -124,7 +136,11 @@ export default function TimeAnalyticsComponent({ events, calendars = [] }: TimeA
     })
 
     const series = Array.from(seriesMeta.entries())
-      .sort((a, b) => b[1].totalCount - a[1].totalCount)
+      .sort((a, b) => {
+        const colorOrder = getChartColorOrderIndex(a[1].color) - getChartColorOrderIndex(b[1].color)
+        if (colorOrder !== 0) return colorOrder
+        return b[1].totalCount - a[1].totalCount
+      })
       .map(([key, value]) => ({
         key,
         label: value.label,
@@ -234,20 +250,29 @@ export default function TimeAnalyticsComponent({ events, calendars = [] }: TimeA
       return row
     })
 
-    const series = Array.from(categoryColors.entries()).map(([key, color]) => ({
-      key,
-      color,
-    }))
+    const series = Array.from(categoryColors.entries())
+      .sort((a, b) => getChartColorOrderIndex(a[1]) - getChartColorOrderIndex(b[1]))
+      .map(([key, color]) => ({
+        key,
+        color,
+      }))
 
     return { data, series }
   }, [categoryMeta, rangeEvents, resolveCategoryLabel, weekdayLabels])
 
   const metrics = useMemo(() => {
     if (rangeEvents.length === 0) {
+      const futureLeadTimes = futureRangeEvents.map(
+        (event) => (event.start.getTime() - event.createdAt.getTime()) / (1000 * 60 * 60 * 24),
+      )
+      const futureAvgLead =
+        futureLeadTimes.length === 0
+          ? 0
+          : futureLeadTimes.reduce((sum, value) => sum + value, 0) / futureLeadTimes.length
       return [
         { title: t.analyticsMetricLongestStreak, value: `0 ${t.analyticsDayUnit}`, subtitle: t.analyticsNoScheduleInRange },
         { title: t.analyticsMetricBusiestWeekday, value: t.analyticsNone, subtitle: t.analyticsNoScheduleInRange },
-        { title: t.analyticsMetricAvgLeadDays, value: `0.0 ${t.analyticsDayUnit}`, subtitle: t.analyticsLeadDaysHint },
+        { title: t.analyticsMetricAvgLeadDays, value: `${futureAvgLead.toFixed(1)} ${t.analyticsDayUnit}`, subtitle: t.analyticsLeadDaysHint },
         { title: t.analyticsMetricPeakTimeWindow, value: t.analyticsNone, subtitle: t.analyticsNoScheduleInRange },
       ]
     }
@@ -292,8 +317,11 @@ export default function TimeAnalyticsComponent({ events, calendars = [] }: TimeA
     const overallAvg = rangeEvents.length / 7
     const uplift = overallAvg === 0 ? 0 : ((busiestDay.avg - overallAvg) / overallAvg) * 100
 
-    const leadTimes = rangeEvents.map((event) => (event.start.getTime() - event.createdAt.getTime()) / (1000 * 60 * 60 * 24))
-    const avgLead = leadTimes.reduce((sum, value) => sum + value, 0) / leadTimes.length
+    const leadTimes = futureRangeEvents.map(
+      (event) => (event.start.getTime() - event.createdAt.getTime()) / (1000 * 60 * 60 * 24),
+    )
+    const avgLead =
+      leadTimes.length === 0 ? 0 : leadTimes.reduce((sum, value) => sum + value, 0) / leadTimes.length
 
     const hourCounts = Array.from({ length: 24 }).map(() => 0)
     rangeEvents.forEach((event) => {
@@ -337,7 +365,7 @@ export default function TimeAnalyticsComponent({ events, calendars = [] }: TimeA
         subtitle: t.analyticsPeakWindowSubtitle.replace('{pct}', concentrationRatio.toFixed(1)),
       },
     ]
-  }, [dateRange, rangeEvents, t, weekdayLabels])
+  }, [dateRange, futureRangeEvents, rangeEvents, t, weekdayLabels])
 
   return (
     <div className="space-y-6 rounded-lg border p-4">

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "one-calendar",
-  "version": "2.2.14",
+  "version": "2.3.1",
   "private": true,
   "packageManager": "bun@1.3.12",
   "scripts": {


### PR DESCRIPTION
### Motivation
- Bump app version and make analytics visuals deterministic by enforcing a fixed color stacking order (蓝、绿、黄、红、紫、粉、蓝绿) so series order is stable when many categories exist.  
- Fix an intermittent UI bug where stacked-bar top corners could lose their rounded appearance under heavy data by applying rounding only to the actual top segment per column.  
- Make the average lead-days metric reflect future events (window length matches the selected preset) because the metric is intended to measure future lead times, not past ones.

### Description
- Updated `package.json` version to `2.3.1`.  
- Added `COLOR_ORDER` and `getChartColorOrderIndex` helper to `components/app/analytics/analytics-utils.ts` and kept `normalizeChartColor` for mapping chart colors.  
- Enforced the color order when building series in `components/app/analytics/time-analytics.tsx` for the count series and weekday stacked series by sorting with `getChartColorOrderIndex`.  
- Fixed top-corner rounding in `components/app/analytics/charts/daily-monthly-count-chart.tsx` and `components/app/analytics/charts/weekday-stacked-duration-chart.tsx` by computing the per-row top segment and applying rounded `radius` on a per-`Cell` basis instead of on the whole `Bar` stack.  
- Added `futureDateRange`/`futureRangeEvents` in `components/app/analytics/time-analytics.tsx` and switched the average lead-days calculation to use the future window matching the selected preset, including the empty-range fallback.

### Testing
- No automated tests were executed for these changes (per request).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e5a355dafc8332a8bd30be8f82fb9c)

## Summary by Sourcery

强制使用确定性的分析图表视觉效果，并调整交付周期（lead-time）指标以使用前瞻性的日期窗口。

Bug Fixes:
- 通过仅对每列中实际顶部的堆叠段应用圆角边框，确保堆叠柱状图的顶部角保持圆角效果。

Enhancements:
- 在分析的时间序列和星期序列中应用固定的图表颜色顺序，使类别颜色在数据或序列数量变化时仍然保持稳定。
- 从符合所选预设的未来日期窗口中的事件计算平均交付天数，并在当前区间没有事件时提供合理的回退方案。

Build:
- 将 `package.json` 中的应用版本提升到 2.3.1。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Enforce deterministic analytics chart visuals and adjust lead-time metrics to use a forward-looking date window.

Bug Fixes:
- Ensure stacked bar chart top corners remain rounded by applying border radius only to the actual top segment in each column.

Enhancements:
- Apply a fixed chart color ordering across analytics time and weekday series to keep category colors stable regardless of data or series count.
- Compute average lead days from events in a future date window matching the selected preset, including a sensible fallback when the current range has no events.

Build:
- Bump application version to 2.3.1 in package.json.

</details>