### PR TITLE
refactor: migrate calendar state to zustand and postgres access to prisma

### DIFF
--- a/app/api/account/route.ts
+++ b/app/api/account/route.ts
@@ -11,31 +11,25 @@ export async function DELETE() {
       return NextResponse.json({ error: 'Unauthorized' }, { status: 401 })
 
     await prisma.$transaction(async (tx) => {
-      const hasCalendarEventsTable = await tx.$queryRawUnsafe<Array<{ ok: number }>>(
-        `SELECT 1 as ok FROM information_schema.tables WHERE table_schema = 'public' AND table_name = 'calendar_events' LIMIT 1`,
-      )
+      const hasCalendarEventsTable = await tx.$queryRaw<Array<{ ok: number }>>`
+        SELECT 1 as ok FROM information_schema.tables WHERE table_schema = 'public' AND table_name = 'calendar_events' LIMIT 1
+      `
       if (hasCalendarEventsTable.length > 0) {
-        await tx.$executeRawUnsafe(
-          `DELETE FROM calendar_events WHERE user_id = $1`,
-          user.id,
-        )
+        await tx.$executeRaw`DELETE FROM calendar_events WHERE user_id = ${user.id}`
       }
 
-      const hasSharesTable = await tx.$queryRawUnsafe<Array<{ ok: number }>>(
-        `SELECT 1 as ok FROM information_schema.tables WHERE table_schema = 'public' AND table_name = 'shares' LIMIT 1`,
-      )
+      const hasSharesTable = await tx.$queryRaw<Array<{ ok: number }>>`
+        SELECT 1 as ok FROM information_schema.tables WHERE table_schema = 'public' AND table_name = 'shares' LIMIT 1
+      `
       if (hasSharesTable.length > 0) {
-        await tx.$executeRawUnsafe(`DELETE FROM shares WHERE user_id = $1`, user.id)
+        await tx.$executeRaw`DELETE FROM shares WHERE user_id = ${user.id}`
       }
 
-      const hasBackupsTable = await tx.$queryRawUnsafe<Array<{ ok: number }>>(
-        `SELECT 1 as ok FROM information_schema.tables WHERE table_schema = 'public' AND table_name = 'calendar_backups' LIMIT 1`,
-      )
+      const hasBackupsTable = await tx.$queryRaw<Array<{ ok: number }>>`
+        SELECT 1 as ok FROM information_schema.tables WHERE table_schema = 'public' AND table_name = 'calendar_backups' LIMIT 1
+      `
       if (hasBackupsTable.length > 0) {
-        await tx.$executeRawUnsafe(
-          `DELETE FROM calendar_backups WHERE user_id = $1`,
-          user.id,
-        )
+        await tx.$executeRaw`DELETE FROM calendar_backups WHERE user_id = ${user.id}`
       }
     })
 

--- a/app/api/account/route.ts
+++ b/app/api/account/route.ts
@@ -1,13 +1,8 @@
 import { NextResponse } from 'next/server'
 import { currentUser } from '@clerk/nextjs/server'
-import { Pool } from 'pg'
+import { prisma } from '@/lib/prisma'
 
 export const runtime = 'nodejs'
-
-const pool = new Pool({
-  connectionString: process.env.POSTGRES_URL,
-  ssl: { rejectUnauthorized: false },
-})
 
 export async function DELETE() {
   try {
@@ -15,43 +10,36 @@ export async function DELETE() {
     if (!user)
       return NextResponse.json({ error: 'Unauthorized' }, { status: 401 })
 
-    const client = await pool.connect()
-    try {
-      await client.query('BEGIN')
-
-      const hasCalendarEventsTable = await client.query(
-        `SELECT 1 FROM information_schema.tables WHERE table_schema = 'public' AND table_name = 'calendar_events' LIMIT 1`,
+    await prisma.$transaction(async (tx) => {
+      const hasCalendarEventsTable = await tx.$queryRawUnsafe<Array<{ ok: number }>>(
+        `SELECT 1 as ok FROM information_schema.tables WHERE table_schema = 'public' AND table_name = 'calendar_events' LIMIT 1`,
       )
-      if (hasCalendarEventsTable.rowCount) {
-        await client.query(`DELETE FROM calendar_events WHERE user_id = $1`, [
+      if (hasCalendarEventsTable.length > 0) {
+        await tx.$executeRawUnsafe(
+          `DELETE FROM calendar_events WHERE user_id = $1`,
           user.id,
-        ])
+        )
       }
 
-      const hasSharesTable = await client.query(
-        `SELECT 1 FROM information_schema.tables WHERE table_schema = 'public' AND table_name = 'shares' LIMIT 1`,
+      const hasSharesTable = await tx.$queryRawUnsafe<Array<{ ok: number }>>(
+        `SELECT 1 as ok FROM information_schema.tables WHERE table_schema = 'public' AND table_name = 'shares' LIMIT 1`,
       )
-      if (hasSharesTable.rowCount) {
-        await client.query(`DELETE FROM shares WHERE user_id = $1`, [user.id])
+      if (hasSharesTable.length > 0) {
+        await tx.$executeRawUnsafe(`DELETE FROM shares WHERE user_id = $1`, user.id)
       }
 
-      const hasBackupsTable = await client.query(
-        `SELECT 1 FROM information_schema.tables WHERE table_schema = 'public' AND table_name = 'calendar_backups' LIMIT 1`,
+      const hasBackupsTable = await tx.$queryRawUnsafe<Array<{ ok: number }>>(
+        `SELECT 1 as ok FROM information_schema.tables WHERE table_schema = 'public' AND table_name = 'calendar_backups' LIMIT 1`,
       )
-      if (hasBackupsTable.rowCount) {
-        await client.query(`DELETE FROM calendar_backups WHERE user_id = $1`, [
+      if (hasBackupsTable.length > 0) {
+        await tx.$executeRawUnsafe(
+          `DELETE FROM calendar_backups WHERE user_id = $1`,
           user.id,
-        ])
+        )
       }
+    })
 
-      await client.query('COMMIT')
-      return NextResponse.json({ success: true })
-    } catch (error) {
-      await client.query('ROLLBACK')
-      throw error
-    } finally {
-      client.release()
-    }
+    return NextResponse.json({ success: true })
   } catch (e: any) {
     return NextResponse.json(
       { error: e?.message || 'Internal error' },

--- a/app/api/blob/check/route.ts
+++ b/app/api/blob/check/route.ts
@@ -1,10 +1,5 @@
 import { NextResponse } from 'next/server'
-import { Pool } from 'pg'
-
-const pool = new Pool({
-  connectionString: process.env.POSTGRES_URL,
-  ssl: { rejectUnauthorized: false },
-})
+import { prisma } from '@/lib/prisma'
 
 export async function GET(request: Request) {
   try {
@@ -22,23 +17,15 @@ export async function GET(request: Request) {
       return NextResponse.json({ error: 'Unauthorized' }, { status: 401 })
     }
 
-    const client = await pool.connect()
+    const tables = await prisma.$queryRawUnsafe<Array<{ table_name: string }>>(
+      `SELECT table_name
+       FROM information_schema.tables
+       WHERE table_schema = 'public'
+         AND table_type = 'BASE TABLE'
+       ORDER BY table_name ASC`,
+    )
 
-    try {
-      const result = await client.query<{ table_name: string }>(
-        `SELECT table_name
-         FROM information_schema.tables
-         WHERE table_schema = 'public'
-           AND table_type = 'BASE TABLE'
-         ORDER BY table_name ASC`,
-      )
-
-      const tables = result.rows.map((row) => row.table_name)
-
-      return NextResponse.json({ tables })
-    } finally {
-      client.release()
-    }
+    return NextResponse.json({ tables: tables.map((row) => row.table_name) })
   } catch (error) {
     return NextResponse.json(
       {

--- a/app/api/blob/check/route.ts
+++ b/app/api/blob/check/route.ts
@@ -1,6 +1,8 @@
 import { NextResponse } from 'next/server'
 import { prisma } from '@/lib/prisma'
 
+export const runtime = 'nodejs'
+
 export async function GET(request: Request) {
   try {
     const authHeader = request.headers.get('authorization')
@@ -17,13 +19,13 @@ export async function GET(request: Request) {
       return NextResponse.json({ error: 'Unauthorized' }, { status: 401 })
     }
 
-    const tables = await prisma.$queryRawUnsafe<Array<{ table_name: string }>>(
-      `SELECT table_name
-       FROM information_schema.tables
-       WHERE table_schema = 'public'
-         AND table_type = 'BASE TABLE'
-       ORDER BY table_name ASC`,
-    )
+    const tables = await prisma.$queryRaw<Array<{ table_name: string }>>`
+      SELECT table_name
+      FROM information_schema.tables
+      WHERE table_schema = 'public'
+        AND table_type = 'BASE TABLE'
+      ORDER BY table_name ASC
+    `
 
     return NextResponse.json({ tables: tables.map((row) => row.table_name) })
   } catch (error) {

--- a/app/api/blob/route.ts
+++ b/app/api/blob/route.ts
@@ -1,23 +1,13 @@
 import { NextRequest, NextResponse } from 'next/server'
 import { currentUser } from '@clerk/nextjs/server'
-import { Pool } from 'pg'
 import { getAtprotoSession } from '@/lib/atproto-auth'
 import { deleteRecord, getRecord, putRecord } from '@/lib/atproto'
+import { prisma } from '@/lib/prisma'
 
 export const runtime = 'nodejs'
 export const dynamic = 'force-dynamic'
 
 const postgresUrl = process.env.POSTGRES_URL
-const useSsl =
-  postgresUrl &&
-  !/localhost|127\.0\.0\.1/.test(postgresUrl) &&
-  !/sslmode=disable/.test(postgresUrl)
-
-const pool = new Pool({
-  connectionString: postgresUrl,
-  ssl: useSsl ? { rejectUnauthorized: false } : undefined,
-})
-
 let inited = false
 
 async function initDB() {
@@ -25,20 +15,15 @@ async function initDB() {
     throw new Error('POSTGRES_URL is not configured')
   }
   if (inited) return
-  const client = await pool.connect()
-  try {
-    await client.query(`
-      CREATE TABLE IF NOT EXISTS calendar_backups (
-        user_id TEXT PRIMARY KEY,
-        encrypted_data TEXT NOT NULL,
-        iv TEXT NOT NULL,
-        timestamp TIMESTAMP NOT NULL
-      )
-    `)
-    inited = true
-  } finally {
-    client.release()
-  }
+  await prisma.$executeRawUnsafe(`
+    CREATE TABLE IF NOT EXISTS calendar_backups (
+      user_id TEXT PRIMARY KEY,
+      encrypted_data TEXT NOT NULL,
+      iv TEXT NOT NULL,
+      timestamp TIMESTAMP NOT NULL
+    )
+  `)
+  inited = true
 }
 
 const ATPROTO_BACKUP_COLLECTION = 'app.onecalendar.backup'
@@ -88,24 +73,22 @@ export async function POST(req: NextRequest) {
 
     await initDB()
 
-    const client = await pool.connect()
-    try {
-      await client.query(
-        `
-        INSERT INTO calendar_backups (user_id, encrypted_data, iv, timestamp)
-        VALUES ($1, $2, $3, $4)
-        ON CONFLICT (user_id)
-        DO UPDATE SET
-          encrypted_data = EXCLUDED.encrypted_data,
-          iv = EXCLUDED.iv,
-          timestamp = EXCLUDED.timestamp
-        `,
-        [user.id, encrypted_data, iv, new Date().toISOString()],
-      )
-      return NextResponse.json({ success: true, backend: 'postgres' })
-    } finally {
-      client.release()
-    }
+    await prisma.$executeRawUnsafe(
+      `
+      INSERT INTO calendar_backups (user_id, encrypted_data, iv, timestamp)
+      VALUES ($1, $2, $3, $4)
+      ON CONFLICT (user_id)
+      DO UPDATE SET
+        encrypted_data = EXCLUDED.encrypted_data,
+        iv = EXCLUDED.iv,
+        timestamp = EXCLUDED.timestamp
+      `,
+      user.id,
+      encrypted_data,
+      iv,
+      new Date().toISOString(),
+    )
+    return NextResponse.json({ success: true, backend: 'postgres' })
   } catch (e: unknown) {
     const message = e instanceof Error ? e.message : 'Internal error'
     return NextResponse.json({ error: message }, { status: 500 })
@@ -143,24 +126,22 @@ export async function GET() {
 
     await initDB()
 
-    const client = await pool.connect()
-    try {
-      const result = await client.query(
-        `SELECT encrypted_data, iv, timestamp FROM calendar_backups WHERE user_id = $1`,
-        [user.id],
-      )
-      if (result.rowCount === 0)
-        return jsonNoStore({ error: 'Not found' }, { status: 404 })
+    const result = await prisma.$queryRawUnsafe<
+      Array<{ encrypted_data: string; iv: string; timestamp: Date }>
+    >(
+      `SELECT encrypted_data, iv, timestamp FROM calendar_backups WHERE user_id = $1`,
+      user.id,
+    )
 
-      return jsonNoStore({
-        ciphertext: result.rows[0].encrypted_data,
-        iv: result.rows[0].iv,
-        timestamp: result.rows[0].timestamp,
-        backend: 'postgres',
-      })
-    } finally {
-      client.release()
-    }
+    if (result.length === 0)
+      return jsonNoStore({ error: 'Not found' }, { status: 404 })
+
+    return jsonNoStore({
+      ciphertext: result[0].encrypted_data,
+      iv: result[0].iv,
+      timestamp: result[0].timestamp,
+      backend: 'postgres',
+    })
   } catch (e: unknown) {
     const message = e instanceof Error ? e.message : 'Internal error'
     return jsonNoStore({ error: message }, { status: 500 })
@@ -189,15 +170,12 @@ export async function DELETE() {
 
     await initDB()
 
-    const client = await pool.connect()
-    try {
-      await client.query(`DELETE FROM calendar_backups WHERE user_id = $1`, [
-        user.id,
-      ])
-      return NextResponse.json({ success: true, backend: 'postgres' })
-    } finally {
-      client.release()
-    }
+    await prisma.$executeRawUnsafe(
+      `DELETE FROM calendar_backups WHERE user_id = $1`,
+      user.id,
+    )
+
+    return NextResponse.json({ success: true, backend: 'postgres' })
   } catch (e: unknown) {
     const message = e instanceof Error ? e.message : 'Internal error'
     return NextResponse.json({ error: message }, { status: 500 })

--- a/app/api/blob/route.ts
+++ b/app/api/blob/route.ts
@@ -15,14 +15,14 @@ async function initDB() {
     throw new Error('POSTGRES_URL is not configured')
   }
   if (inited) return
-  await prisma.$executeRawUnsafe(`
+  await prisma.$executeRaw`
     CREATE TABLE IF NOT EXISTS calendar_backups (
       user_id TEXT PRIMARY KEY,
       encrypted_data TEXT NOT NULL,
       iv TEXT NOT NULL,
       timestamp TIMESTAMP NOT NULL
     )
-  `)
+  `
   inited = true
 }
 
@@ -73,21 +73,15 @@ export async function POST(req: NextRequest) {
 
     await initDB()
 
-    await prisma.$executeRawUnsafe(
-      `
+    await prisma.$executeRaw`
       INSERT INTO calendar_backups (user_id, encrypted_data, iv, timestamp)
-      VALUES ($1, $2, $3, $4)
+      VALUES (${user.id}, ${encrypted_data}, ${iv}, ${new Date().toISOString()})
       ON CONFLICT (user_id)
       DO UPDATE SET
         encrypted_data = EXCLUDED.encrypted_data,
         iv = EXCLUDED.iv,
         timestamp = EXCLUDED.timestamp
-      `,
-      user.id,
-      encrypted_data,
-      iv,
-      new Date().toISOString(),
-    )
+      `
     return NextResponse.json({ success: true, backend: 'postgres' })
   } catch (e: unknown) {
     const message = e instanceof Error ? e.message : 'Internal error'
@@ -126,12 +120,9 @@ export async function GET() {
 
     await initDB()
 
-    const result = await prisma.$queryRawUnsafe<
+    const result = await prisma.$queryRaw<
       Array<{ encrypted_data: string; iv: string; timestamp: Date }>
-    >(
-      `SELECT encrypted_data, iv, timestamp FROM calendar_backups WHERE user_id = $1`,
-      user.id,
-    )
+    >`SELECT encrypted_data, iv, timestamp FROM calendar_backups WHERE user_id = ${user.id}`
 
     if (result.length === 0)
       return jsonNoStore({ error: 'Not found' }, { status: 404 })
@@ -170,10 +161,7 @@ export async function DELETE() {
 
     await initDB()
 
-    await prisma.$executeRawUnsafe(
-      `DELETE FROM calendar_backups WHERE user_id = $1`,
-      user.id,
-    )
+    await prisma.$executeRaw`DELETE FROM calendar_backups WHERE user_id = ${user.id}`
 
     return NextResponse.json({ success: true, backend: 'postgres' })
   } catch (e: unknown) {

--- a/app/api/share/list/route.ts
+++ b/app/api/share/list/route.ts
@@ -6,6 +6,8 @@ import { deleteRecord, listRecords } from '@/lib/atproto'
 import type { DpopPublicJwk } from '@/lib/dpop'
 import { prisma } from '@/lib/prisma'
 
+export const runtime = 'nodejs'
+
 const ALGORITHM = 'aes-256-gcm'
 const ATPROTO_SHARE_COLLECTION = 'app.onecalendar.share'
 
@@ -13,7 +15,7 @@ let burnTableReady = false
 
 async function ensureBurnTable() {
   if (burnTableReady) return
-  await prisma.$executeRawUnsafe(`
+  await prisma.$executeRaw`
     CREATE TABLE IF NOT EXISTS atproto_share_burn_reads (
       handle TEXT NOT NULL,
       owner_did TEXT,
@@ -22,16 +24,10 @@ async function ensureBurnTable() {
       pds_delete_synced BOOLEAN NOT NULL DEFAULT FALSE,
       PRIMARY KEY (share_id, handle)
     )
-  `)
-  await prisma.$executeRawUnsafe(
-    `ALTER TABLE atproto_share_burn_reads ADD COLUMN IF NOT EXISTS owner_did TEXT`,
-  )
-  await prisma.$executeRawUnsafe(
-    `ALTER TABLE atproto_share_burn_reads ADD COLUMN IF NOT EXISTS pds_delete_synced BOOLEAN NOT NULL DEFAULT FALSE`,
-  )
-  await prisma.$executeRawUnsafe(
-    `CREATE UNIQUE INDEX IF NOT EXISTS idx_atproto_share_burn_reads_owner_share ON atproto_share_burn_reads(owner_did, share_id) WHERE owner_did IS NOT NULL`,
-  )
+  `
+  await prisma.$executeRaw`ALTER TABLE atproto_share_burn_reads ADD COLUMN IF NOT EXISTS owner_did TEXT`
+  await prisma.$executeRaw`ALTER TABLE atproto_share_burn_reads ADD COLUMN IF NOT EXISTS pds_delete_synced BOOLEAN NOT NULL DEFAULT FALSE`
+  await prisma.$executeRaw`CREATE UNIQUE INDEX IF NOT EXISTS idx_atproto_share_burn_reads_owner_share ON atproto_share_burn_reads(owner_did, share_id) WHERE owner_did IS NOT NULL`
   burnTableReady = true
 }
 
@@ -45,11 +41,11 @@ async function syncBurnedAtprotoShares(
 ) {
   await ensureBurnTable()
 
-  const pending = await prisma.$queryRawUnsafe<Array<{ share_id: string }>>(
-    'SELECT share_id FROM atproto_share_burn_reads WHERE (owner_did = $1 OR (owner_did IS NULL AND handle = $2)) AND pds_delete_synced = FALSE',
-    ownerDid,
-    handle,
-  )
+  const pending = await prisma.$queryRaw<Array<{ share_id: string }>`
+    SELECT share_id FROM atproto_share_burn_reads
+    WHERE (owner_did = ${ownerDid} OR (owner_did IS NULL AND handle = ${handle}))
+    AND pds_delete_synced = FALSE
+  `
 
   if (!pending.length) return
 
@@ -72,12 +68,11 @@ async function syncBurnedAtprotoShares(
   }
 
   if (syncedIds.length > 0) {
-    await prisma.$executeRawUnsafe(
-      'DELETE FROM atproto_share_burn_reads WHERE (owner_did = $1 OR (owner_did IS NULL AND handle = $2)) AND share_id = ANY($3::text[])',
-      ownerDid,
-      handle,
-      syncedIds,
-    )
+    await prisma.$executeRaw`
+      DELETE FROM atproto_share_burn_reads
+      WHERE (owner_did = ${ownerDid} OR (owner_did IS NULL AND handle = ${handle}))
+      AND share_id = ANY(${syncedIds}::text[])
+    `
   }
 }
 
@@ -163,7 +158,7 @@ export async function GET() {
   if (!user)
     return NextResponse.json({ error: 'Unauthorized' }, { status: 401 })
 
-  const result = await prisma.$queryRawUnsafe<
+  const result = await prisma.$queryRaw<
     Array<{
       share_id: string
       encrypted_data: string
@@ -172,10 +167,7 @@ export async function GET() {
       timestamp: Date
       is_protected: boolean
     }>
-  >(
-    `SELECT share_id, encrypted_data, iv, auth_tag, timestamp, is_protected FROM shares WHERE user_id = $1 ORDER BY timestamp DESC`,
-    user.id,
-  )
+  >`SELECT share_id, encrypted_data, iv, auth_tag, timestamp, is_protected FROM shares WHERE user_id = ${user.id} ORDER BY timestamp DESC`
 
   const shares = result.map((row) => {
     let eventId = ''

--- a/app/api/share/list/route.ts
+++ b/app/api/share/list/route.ts
@@ -1,15 +1,11 @@
 import { NextResponse } from 'next/server'
-import { Pool } from 'pg'
 import { currentUser } from '@clerk/nextjs/server'
 import crypto from 'crypto'
 import { getAtprotoSession } from '@/lib/atproto-auth'
 import { deleteRecord, listRecords } from '@/lib/atproto'
 import type { DpopPublicJwk } from '@/lib/dpop'
+import { prisma } from '@/lib/prisma'
 
-const pool = new Pool({
-  connectionString: process.env.POSTGRES_URL,
-  ssl: { rejectUnauthorized: false },
-})
 const ALGORITHM = 'aes-256-gcm'
 const ATPROTO_SHARE_COLLECTION = 'app.onecalendar.share'
 
@@ -17,31 +13,26 @@ let burnTableReady = false
 
 async function ensureBurnTable() {
   if (burnTableReady) return
-  const client = await pool.connect()
-  try {
-    await client.query(`
-      CREATE TABLE IF NOT EXISTS atproto_share_burn_reads (
-        handle TEXT NOT NULL,
-        owner_did TEXT,
-        share_id TEXT NOT NULL,
-        burned_at TIMESTAMPTZ NOT NULL DEFAULT NOW(),
-        pds_delete_synced BOOLEAN NOT NULL DEFAULT FALSE,
-        PRIMARY KEY (share_id, handle)
-      )
-    `)
-    await client.query(
-      `ALTER TABLE atproto_share_burn_reads ADD COLUMN IF NOT EXISTS owner_did TEXT`,
+  await prisma.$executeRawUnsafe(`
+    CREATE TABLE IF NOT EXISTS atproto_share_burn_reads (
+      handle TEXT NOT NULL,
+      owner_did TEXT,
+      share_id TEXT NOT NULL,
+      burned_at TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+      pds_delete_synced BOOLEAN NOT NULL DEFAULT FALSE,
+      PRIMARY KEY (share_id, handle)
     )
-    await client.query(
-      `ALTER TABLE atproto_share_burn_reads ADD COLUMN IF NOT EXISTS pds_delete_synced BOOLEAN NOT NULL DEFAULT FALSE`,
-    )
-    await client.query(
-      `CREATE UNIQUE INDEX IF NOT EXISTS idx_atproto_share_burn_reads_owner_share ON atproto_share_burn_reads(owner_did, share_id) WHERE owner_did IS NOT NULL`,
-    )
-    burnTableReady = true
-  } finally {
-    client.release()
-  }
+  `)
+  await prisma.$executeRawUnsafe(
+    `ALTER TABLE atproto_share_burn_reads ADD COLUMN IF NOT EXISTS owner_did TEXT`,
+  )
+  await prisma.$executeRawUnsafe(
+    `ALTER TABLE atproto_share_burn_reads ADD COLUMN IF NOT EXISTS pds_delete_synced BOOLEAN NOT NULL DEFAULT FALSE`,
+  )
+  await prisma.$executeRawUnsafe(
+    `CREATE UNIQUE INDEX IF NOT EXISTS idx_atproto_share_burn_reads_owner_share ON atproto_share_burn_reads(owner_did, share_id) WHERE owner_did IS NOT NULL`,
+  )
+  burnTableReady = true
 }
 
 async function syncBurnedAtprotoShares(
@@ -54,42 +45,39 @@ async function syncBurnedAtprotoShares(
 ) {
   await ensureBurnTable()
 
-  const client = await pool.connect()
-  try {
-    const pending = await client.query(
-      'SELECT share_id FROM atproto_share_burn_reads WHERE (owner_did = $1 OR (owner_did IS NULL AND handle = $2)) AND pds_delete_synced = FALSE',
-      [ownerDid, handle],
+  const pending = await prisma.$queryRawUnsafe<Array<{ share_id: string }>>(
+    'SELECT share_id FROM atproto_share_burn_reads WHERE (owner_did = $1 OR (owner_did IS NULL AND handle = $2)) AND pds_delete_synced = FALSE',
+    ownerDid,
+    handle,
+  )
+
+  if (!pending.length) return
+
+  const syncedIds: string[] = []
+  for (const row of pending) {
+    const shareId = String(row.share_id)
+    try {
+      await deleteRecord({
+        pds,
+        repo: ownerDid,
+        collection: ATPROTO_SHARE_COLLECTION,
+        rkey: shareId,
+        accessToken,
+        dpopPrivateKeyPem,
+        dpopPublicJwk,
+      })
+      syncedIds.push(shareId)
+    } catch {
+    }
+  }
+
+  if (syncedIds.length > 0) {
+    await prisma.$executeRawUnsafe(
+      'DELETE FROM atproto_share_burn_reads WHERE (owner_did = $1 OR (owner_did IS NULL AND handle = $2)) AND share_id = ANY($3::text[])',
+      ownerDid,
+      handle,
+      syncedIds,
     )
-
-    if (!pending.rows.length) return
-
-    const syncedIds: string[] = []
-    for (const row of pending.rows) {
-      const shareId = String(row.share_id)
-      try {
-        await deleteRecord({
-          pds,
-          repo: ownerDid,
-          collection: ATPROTO_SHARE_COLLECTION,
-          rkey: shareId,
-          accessToken,
-          dpopPrivateKeyPem,
-          dpopPublicJwk,
-        })
-        syncedIds.push(shareId)
-      } catch {
-        // Keep pending rows for retry on next share management open.
-      }
-    }
-
-    if (syncedIds.length > 0) {
-      await client.query(
-        'DELETE FROM atproto_share_burn_reads WHERE (owner_did = $1 OR (owner_did IS NULL AND handle = $2)) AND share_id = ANY($3::text[])',
-        [ownerDid, handle, syncedIds],
-      )
-    }
-  } finally {
-    client.release()
   }
 }
 
@@ -175,45 +163,49 @@ export async function GET() {
   if (!user)
     return NextResponse.json({ error: 'Unauthorized' }, { status: 401 })
 
-  const client = await pool.connect()
-  try {
-    const result = await client.query(
-      `SELECT share_id, encrypted_data, iv, auth_tag, timestamp, is_protected FROM shares WHERE user_id = $1 ORDER BY timestamp DESC`,
-      [user.id],
-    )
+  const result = await prisma.$queryRawUnsafe<
+    Array<{
+      share_id: string
+      encrypted_data: string
+      iv: string
+      auth_tag: string
+      timestamp: Date
+      is_protected: boolean
+    }>
+  >(
+    `SELECT share_id, encrypted_data, iv, auth_tag, timestamp, is_protected FROM shares WHERE user_id = $1 ORDER BY timestamp DESC`,
+    user.id,
+  )
 
-    const shares = result.rows.map((row) => {
-      let eventId = ''
-      let eventTitle = ''
-      if (!row.is_protected) {
-        try {
-          const decrypted = decryptWithKey(
-            row.encrypted_data,
-            row.iv,
-            row.auth_tag,
-            keyV2Unprotected(row.share_id),
-          )
-          const dataObj = JSON.parse(decrypted)
-          eventId = dataObj.id ?? ''
-          eventTitle = dataObj.title ?? ''
-        } catch {}
-      } else {
-        eventId = '受保护'
-        eventTitle = '受保护'
-      }
-      return {
-        id: row.share_id,
-        eventId,
-        eventTitle,
-        sharedBy: user.id,
-        shareDate: row.timestamp.toISOString(),
-        shareLink: `/share/${row.share_id}`,
-        isProtected: row.is_protected,
-      }
-    })
+  const shares = result.map((row) => {
+    let eventId = ''
+    let eventTitle = ''
+    if (!row.is_protected) {
+      try {
+        const decrypted = decryptWithKey(
+          row.encrypted_data,
+          row.iv,
+          row.auth_tag,
+          keyV2Unprotected(row.share_id),
+        )
+        const dataObj = JSON.parse(decrypted)
+        eventId = dataObj.id ?? ''
+        eventTitle = dataObj.title ?? ''
+      } catch {}
+    } else {
+      eventId = '受保护'
+      eventTitle = '受保护'
+    }
+    return {
+      id: row.share_id,
+      eventId,
+      eventTitle,
+      sharedBy: user.id,
+      shareDate: row.timestamp.toISOString(),
+      shareLink: `/share/${row.share_id}`,
+      isProtected: row.is_protected,
+    }
+  })
 
-    return NextResponse.json({ shares })
-  } finally {
-    client.release()
-  }
+  return NextResponse.json({ shares })
 }

--- a/app/api/share/public/route.ts
+++ b/app/api/share/public/route.ts
@@ -1,51 +1,40 @@
 import { NextRequest, NextResponse } from 'next/server'
 import crypto from 'crypto'
-import { Pool } from 'pg'
 import { getRecord, resolveHandle } from '@/lib/atproto'
 import {
   ATPROTO_DISABLED,
   atprotoDisabledResponse,
 } from '@/lib/atproto-feature'
+import { prisma } from '@/lib/prisma'
 
 const ALGORITHM = 'aes-256-gcm'
 const ATPROTO_SHARE_COLLECTION = 'app.onecalendar.share'
 
-const burnPool = process.env.POSTGRES_URL
-  ? new Pool({
-      connectionString: process.env.POSTGRES_URL,
-      ssl: { rejectUnauthorized: false },
-    })
-  : null
-
+const hasPostgres = !!process.env.POSTGRES_URL
 let burnTableReady = false
 
 async function ensureBurnTable() {
-  if (!burnPool || burnTableReady) return
-  const client = await burnPool.connect()
-  try {
-    await client.query(`
-      CREATE TABLE IF NOT EXISTS atproto_share_burn_reads (
-        handle TEXT NOT NULL,
-        owner_did TEXT,
-        share_id TEXT NOT NULL,
-        burned_at TIMESTAMPTZ NOT NULL DEFAULT NOW(),
-        pds_delete_synced BOOLEAN NOT NULL DEFAULT FALSE,
-        PRIMARY KEY (share_id, handle)
-      )
-    `)
-    await client.query(
-      `ALTER TABLE atproto_share_burn_reads ADD COLUMN IF NOT EXISTS owner_did TEXT`,
+  if (!hasPostgres || burnTableReady) return
+  await prisma.$executeRawUnsafe(`
+    CREATE TABLE IF NOT EXISTS atproto_share_burn_reads (
+      handle TEXT NOT NULL,
+      owner_did TEXT,
+      share_id TEXT NOT NULL,
+      burned_at TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+      pds_delete_synced BOOLEAN NOT NULL DEFAULT FALSE,
+      PRIMARY KEY (share_id, handle)
     )
-    await client.query(
-      `ALTER TABLE atproto_share_burn_reads ADD COLUMN IF NOT EXISTS pds_delete_synced BOOLEAN NOT NULL DEFAULT FALSE`,
-    )
-    await client.query(
-      `CREATE UNIQUE INDEX IF NOT EXISTS idx_atproto_share_burn_reads_owner_share ON atproto_share_burn_reads(owner_did, share_id) WHERE owner_did IS NOT NULL`,
-    )
-    burnTableReady = true
-  } finally {
-    client.release()
-  }
+  `)
+  await prisma.$executeRawUnsafe(
+    `ALTER TABLE atproto_share_burn_reads ADD COLUMN IF NOT EXISTS owner_did TEXT`,
+  )
+  await prisma.$executeRawUnsafe(
+    `ALTER TABLE atproto_share_burn_reads ADD COLUMN IF NOT EXISTS pds_delete_synced BOOLEAN NOT NULL DEFAULT FALSE`,
+  )
+  await prisma.$executeRawUnsafe(
+    `CREATE UNIQUE INDEX IF NOT EXISTS idx_atproto_share_burn_reads_owner_share ON atproto_share_burn_reads(owner_did, share_id) WHERE owner_did IS NOT NULL`,
+  )
+  burnTableReady = true
 }
 
 async function wasPublicBurnConsumed(
@@ -53,13 +42,15 @@ async function wasPublicBurnConsumed(
   handle: string,
   shareId: string,
 ) {
-  if (!burnPool) return false
+  if (!hasPostgres) return false
   await ensureBurnTable()
-  const result = await burnPool.query(
-    'SELECT 1 FROM atproto_share_burn_reads WHERE (owner_did = $1 OR (owner_did IS NULL AND handle = $2)) AND share_id = $3 LIMIT 1',
-    [ownerDid, handle, shareId],
+  const result = await prisma.$queryRawUnsafe<Array<{ found: number }>>(
+    'SELECT 1 as found FROM atproto_share_burn_reads WHERE (owner_did = $1 OR (owner_did IS NULL AND handle = $2)) AND share_id = $3 LIMIT 1',
+    ownerDid,
+    handle,
+    shareId,
   )
-  return result.rowCount > 0
+  return result.length > 0
 }
 
 async function markPublicBurnConsumed(
@@ -67,16 +58,18 @@ async function markPublicBurnConsumed(
   handle: string,
   shareId: string,
 ) {
-  if (!burnPool) return
+  if (!hasPostgres) return
   await ensureBurnTable()
-  await burnPool.query(
+  await prisma.$executeRawUnsafe(
     `
       INSERT INTO atproto_share_burn_reads (handle, owner_did, share_id, pds_delete_synced)
       VALUES ($1, $2, $3, FALSE)
       ON CONFLICT (share_id, handle)
       DO UPDATE SET owner_did = EXCLUDED.owner_did, pds_delete_synced = FALSE, burned_at = NOW()
     `,
-    [handle, ownerDid, shareId],
+    handle,
+    ownerDid,
+    shareId,
   )
 }
 

--- a/app/api/share/public/route.ts
+++ b/app/api/share/public/route.ts
@@ -7,6 +7,8 @@ import {
 } from '@/lib/atproto-feature'
 import { prisma } from '@/lib/prisma'
 
+export const runtime = 'nodejs'
+
 const ALGORITHM = 'aes-256-gcm'
 const ATPROTO_SHARE_COLLECTION = 'app.onecalendar.share'
 
@@ -15,7 +17,7 @@ let burnTableReady = false
 
 async function ensureBurnTable() {
   if (!hasPostgres || burnTableReady) return
-  await prisma.$executeRawUnsafe(`
+  await prisma.$executeRaw`
     CREATE TABLE IF NOT EXISTS atproto_share_burn_reads (
       handle TEXT NOT NULL,
       owner_did TEXT,
@@ -24,16 +26,10 @@ async function ensureBurnTable() {
       pds_delete_synced BOOLEAN NOT NULL DEFAULT FALSE,
       PRIMARY KEY (share_id, handle)
     )
-  `)
-  await prisma.$executeRawUnsafe(
-    `ALTER TABLE atproto_share_burn_reads ADD COLUMN IF NOT EXISTS owner_did TEXT`,
-  )
-  await prisma.$executeRawUnsafe(
-    `ALTER TABLE atproto_share_burn_reads ADD COLUMN IF NOT EXISTS pds_delete_synced BOOLEAN NOT NULL DEFAULT FALSE`,
-  )
-  await prisma.$executeRawUnsafe(
-    `CREATE UNIQUE INDEX IF NOT EXISTS idx_atproto_share_burn_reads_owner_share ON atproto_share_burn_reads(owner_did, share_id) WHERE owner_did IS NOT NULL`,
-  )
+  `
+  await prisma.$executeRaw`ALTER TABLE atproto_share_burn_reads ADD COLUMN IF NOT EXISTS owner_did TEXT`
+  await prisma.$executeRaw`ALTER TABLE atproto_share_burn_reads ADD COLUMN IF NOT EXISTS pds_delete_synced BOOLEAN NOT NULL DEFAULT FALSE`
+  await prisma.$executeRaw`CREATE UNIQUE INDEX IF NOT EXISTS idx_atproto_share_burn_reads_owner_share ON atproto_share_burn_reads(owner_did, share_id) WHERE owner_did IS NOT NULL`
   burnTableReady = true
 }
 
@@ -44,12 +40,12 @@ async function wasPublicBurnConsumed(
 ) {
   if (!hasPostgres) return false
   await ensureBurnTable()
-  const result = await prisma.$queryRawUnsafe<Array<{ found: number }>>(
-    'SELECT 1 as found FROM atproto_share_burn_reads WHERE (owner_did = $1 OR (owner_did IS NULL AND handle = $2)) AND share_id = $3 LIMIT 1',
-    ownerDid,
-    handle,
-    shareId,
-  )
+  const result = await prisma.$queryRaw<Array<{ found: number }>`
+    SELECT 1 as found FROM atproto_share_burn_reads
+    WHERE (owner_did = ${ownerDid} OR (owner_did IS NULL AND handle = ${handle}))
+    AND share_id = ${shareId}
+    LIMIT 1
+  `
   return result.length > 0
 }
 
@@ -60,17 +56,12 @@ async function markPublicBurnConsumed(
 ) {
   if (!hasPostgres) return
   await ensureBurnTable()
-  await prisma.$executeRawUnsafe(
-    `
+  await prisma.$executeRaw`
       INSERT INTO atproto_share_burn_reads (handle, owner_did, share_id, pds_delete_synced)
-      VALUES ($1, $2, $3, FALSE)
+      VALUES (${handle}, ${ownerDid}, ${shareId}, FALSE)
       ON CONFLICT (share_id, handle)
       DO UPDATE SET owner_did = EXCLUDED.owner_did, pds_delete_synced = FALSE, burned_at = NOW()
-    `,
-    handle,
-    ownerDid,
-    shareId,
-  )
+    `
 }
 
 function keyV2Unprotected(shareId: string) {

--- a/app/api/share/route.ts
+++ b/app/api/share/route.ts
@@ -1,54 +1,48 @@
 import { type NextRequest, NextResponse } from 'next/server'
 import { currentUser } from '@clerk/nextjs/server'
-import { Pool } from 'pg'
 import crypto from 'crypto'
 import { deleteRecord, getRecord, putRecord } from '@/lib/atproto'
 import { getAtprotoSession } from '@/lib/atproto-auth'
+import { prisma } from '@/lib/prisma'
 
-const pool = new Pool({
-  connectionString: process.env.POSTGRES_URL,
-  ssl: { rejectUnauthorized: false },
-})
+let initialized = false
 
 async function initializeDatabase() {
-  const client = await pool.connect()
-  try {
-    await client.query(`
-      CREATE TABLE IF NOT EXISTS shares (
-        id SERIAL PRIMARY KEY,
-        user_id TEXT NOT NULL,
-        share_id VARCHAR(255) NOT NULL,
-        encrypted_data TEXT NOT NULL,
-        iv TEXT NOT NULL,
-        auth_tag TEXT NOT NULL,
-        timestamp TIMESTAMP NOT NULL,
-        is_protected BOOLEAN DEFAULT FALSE,
-        is_burn BOOLEAN DEFAULT FALSE,
-        enc_version INTEGER,
-        UNIQUE(share_id)
-      )
-    `)
-    await client.query(
-      `ALTER TABLE shares ADD COLUMN IF NOT EXISTS user_id TEXT`,
+  if (initialized) return
+  await prisma.$executeRawUnsafe(`
+    CREATE TABLE IF NOT EXISTS shares (
+      id SERIAL PRIMARY KEY,
+      user_id TEXT NOT NULL,
+      share_id VARCHAR(255) NOT NULL,
+      encrypted_data TEXT NOT NULL,
+      iv TEXT NOT NULL,
+      auth_tag TEXT NOT NULL,
+      timestamp TIMESTAMP NOT NULL,
+      is_protected BOOLEAN DEFAULT FALSE,
+      is_burn BOOLEAN DEFAULT FALSE,
+      enc_version INTEGER,
+      UNIQUE(share_id)
     )
-    await client.query(
-      `ALTER TABLE shares ADD COLUMN IF NOT EXISTS is_protected BOOLEAN DEFAULT FALSE`,
-    )
-    await client.query(
-      `ALTER TABLE shares ADD COLUMN IF NOT EXISTS is_burn BOOLEAN DEFAULT FALSE`,
-    )
-    await client.query(
-      `ALTER TABLE shares ADD COLUMN IF NOT EXISTS enc_version INTEGER`,
-    )
-    await client.query(
-      `UPDATE shares SET enc_version = 1 WHERE enc_version IS NULL`,
-    )
-    await client.query(
-      `CREATE INDEX IF NOT EXISTS idx_shares_user_id ON shares(user_id)`,
-    )
-  } finally {
-    client.release()
-  }
+  `)
+  await prisma.$executeRawUnsafe(
+    `ALTER TABLE shares ADD COLUMN IF NOT EXISTS user_id TEXT`,
+  )
+  await prisma.$executeRawUnsafe(
+    `ALTER TABLE shares ADD COLUMN IF NOT EXISTS is_protected BOOLEAN DEFAULT FALSE`,
+  )
+  await prisma.$executeRawUnsafe(
+    `ALTER TABLE shares ADD COLUMN IF NOT EXISTS is_burn BOOLEAN DEFAULT FALSE`,
+  )
+  await prisma.$executeRawUnsafe(
+    `ALTER TABLE shares ADD COLUMN IF NOT EXISTS enc_version INTEGER`,
+  )
+  await prisma.$executeRawUnsafe(
+    `UPDATE shares SET enc_version = 1 WHERE enc_version IS NULL`,
+  )
+  await prisma.$executeRawUnsafe(
+    `CREATE INDEX IF NOT EXISTS idx_shares_user_id ON shares(user_id)`,
+  )
+  initialized = true
 }
 
 const ALGORITHM = 'aes-256-gcm'
@@ -155,40 +149,33 @@ export async function POST(request: NextRequest) {
 
     await initializeDatabase()
 
-    const client = await pool.connect()
-    try {
-      await client.query(
-        `
-        INSERT INTO shares (user_id, share_id, encrypted_data, iv, auth_tag, timestamp, is_protected, is_burn, enc_version)
-        VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9)
-        ON CONFLICT (share_id)
-        DO UPDATE SET encrypted_data = EXCLUDED.encrypted_data, iv = EXCLUDED.iv, auth_tag = EXCLUDED.auth_tag,
-          timestamp = EXCLUDED.timestamp, is_protected = EXCLUDED.is_protected, is_burn = EXCLUDED.is_burn,
-          enc_version = EXCLUDED.enc_version, user_id = EXCLUDED.user_id
-        `,
-        [
-          user.id,
-          id,
-          encryptedData,
-          iv,
-          authTag,
-          new Date().toISOString(),
-          hasPassword,
-          burn,
-          hasPassword ? 3 : 2,
-        ],
-      )
+    await prisma.$executeRawUnsafe(
+      `
+      INSERT INTO shares (user_id, share_id, encrypted_data, iv, auth_tag, timestamp, is_protected, is_burn, enc_version)
+      VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9)
+      ON CONFLICT (share_id)
+      DO UPDATE SET encrypted_data = EXCLUDED.encrypted_data, iv = EXCLUDED.iv, auth_tag = EXCLUDED.auth_tag,
+        timestamp = EXCLUDED.timestamp, is_protected = EXCLUDED.is_protected, is_burn = EXCLUDED.is_burn,
+        enc_version = EXCLUDED.enc_version, user_id = EXCLUDED.user_id
+      `,
+      user.id,
+      id,
+      encryptedData,
+      iv,
+      authTag,
+      new Date().toISOString(),
+      hasPassword,
+      burn,
+      hasPassword ? 3 : 2,
+    )
 
-      return NextResponse.json({
-        success: true,
-        id,
-        protected: hasPassword,
-        burnAfterRead: burn,
-        shareLink: `/share/${id}`,
-      })
-    } finally {
-      client.release()
-    }
+    return NextResponse.json({
+      success: true,
+      id,
+      protected: hasPassword,
+      burnAfterRead: burn,
+      shareLink: `/share/${id}`,
+    })
   } catch (error) {
     return NextResponse.json(
       {
@@ -283,68 +270,87 @@ export async function GET(request: NextRequest) {
     if (atprotoResult) return atprotoResult
 
     await initializeDatabase()
-    const client = await pool.connect()
-    try {
-      await client.query('BEGIN')
-      const result = await client.query(
+
+    const result = await prisma.$transaction(async (tx) => {
+      const rows = await tx.$queryRawUnsafe<
+        Array<{
+          encrypted_data: string
+          iv: string
+          auth_tag: string
+          timestamp: Date
+          is_protected: boolean
+          is_burn: boolean
+        }>
+      >(
         'SELECT encrypted_data, iv, auth_tag, timestamp, is_protected, is_burn FROM shares WHERE share_id = $1 FOR UPDATE',
-        [id],
+        id,
       )
-      if (result.rows.length === 0) {
-        await client.query('ROLLBACK')
-        return NextResponse.json({ error: 'Share not found' }, { status: 404 })
+
+      if (!rows.length) {
+        return { status: 404 as const }
       }
-      const row = result.rows[0]
+
+      const row = rows[0]
       if (row.is_protected && !password) {
-        await client.query('COMMIT')
-        return NextResponse.json(
-          {
-            error: 'Password required',
-            requiresPassword: true,
-            burnAfterRead: row.is_burn,
-          },
-          { status: 401 },
-        )
+        return { status: 401 as const, burnAfterRead: row.is_burn }
       }
+
       const key = row.is_protected
         ? keyV3Password(password, id)
         : keyV2Unprotected(id)
       let decryptedData: string
       try {
-        decryptedData = decryptWithKey(
-          row.encrypted_data,
-          row.iv,
-          row.auth_tag,
-          key,
-        )
+        decryptedData = decryptWithKey(row.encrypted_data, row.iv, row.auth_tag, key)
       } catch {
-        await client.query('COMMIT')
-        return NextResponse.json(
-          {
-            error: row.is_protected
-              ? 'Invalid password'
-              : 'Failed to decrypt share data.',
-          },
-          { status: 403 },
-        )
+        return { status: 403 as const, protected: row.is_protected }
       }
+
       if (row.is_burn) {
-        await client.query('DELETE FROM shares WHERE share_id = $1', [id])
+        await tx.$executeRawUnsafe('DELETE FROM shares WHERE share_id = $1', id)
       }
-      await client.query('COMMIT')
-      return NextResponse.json({
-        success: true,
+
+      return {
+        status: 200 as const,
         data: decryptedData,
         timestamp: row.timestamp.toISOString(),
         protected: row.is_protected,
         burnAfterRead: row.is_burn,
-      })
-    } catch (e) {
-      await client.query('ROLLBACK')
-      throw e
-    } finally {
-      client.release()
+      }
+    })
+
+    if (result.status === 404) {
+      return NextResponse.json({ error: 'Share not found' }, { status: 404 })
     }
+
+    if (result.status === 401) {
+      return NextResponse.json(
+        {
+          error: 'Password required',
+          requiresPassword: true,
+          burnAfterRead: result.burnAfterRead,
+        },
+        { status: 401 },
+      )
+    }
+
+    if (result.status === 403) {
+      return NextResponse.json(
+        {
+          error: result.protected
+            ? 'Invalid password'
+            : 'Failed to decrypt share data.',
+        },
+        { status: 403 },
+      )
+    }
+
+    return NextResponse.json({
+      success: true,
+      data: result.data,
+      timestamp: result.timestamp,
+      protected: result.protected,
+      burnAfterRead: result.burnAfterRead,
+    })
   } catch (error) {
     return NextResponse.json(
       {
@@ -381,14 +387,12 @@ export async function DELETE(request: NextRequest) {
     return NextResponse.json({ error: 'Unauthorized' }, { status: 401 })
 
   await initializeDatabase()
-  const client = await pool.connect()
-  try {
-    await client.query(
-      'DELETE FROM shares WHERE share_id = $1 AND user_id = $2',
-      [id, user.id],
-    )
-    return NextResponse.json({ success: true })
-  } finally {
-    client.release()
-  }
+
+  await prisma.$executeRawUnsafe(
+    'DELETE FROM shares WHERE share_id = $1 AND user_id = $2',
+    id,
+    user.id,
+  )
+
+  return NextResponse.json({ success: true })
 }

--- a/app/api/share/route.ts
+++ b/app/api/share/route.ts
@@ -5,11 +5,13 @@ import { deleteRecord, getRecord, putRecord } from '@/lib/atproto'
 import { getAtprotoSession } from '@/lib/atproto-auth'
 import { prisma } from '@/lib/prisma'
 
+export const runtime = 'nodejs'
+
 let initialized = false
 
 async function initializeDatabase() {
   if (initialized) return
-  await prisma.$executeRawUnsafe(`
+  await prisma.$executeRaw`
     CREATE TABLE IF NOT EXISTS shares (
       id SERIAL PRIMARY KEY,
       user_id TEXT NOT NULL,
@@ -23,25 +25,13 @@ async function initializeDatabase() {
       enc_version INTEGER,
       UNIQUE(share_id)
     )
-  `)
-  await prisma.$executeRawUnsafe(
-    `ALTER TABLE shares ADD COLUMN IF NOT EXISTS user_id TEXT`,
-  )
-  await prisma.$executeRawUnsafe(
-    `ALTER TABLE shares ADD COLUMN IF NOT EXISTS is_protected BOOLEAN DEFAULT FALSE`,
-  )
-  await prisma.$executeRawUnsafe(
-    `ALTER TABLE shares ADD COLUMN IF NOT EXISTS is_burn BOOLEAN DEFAULT FALSE`,
-  )
-  await prisma.$executeRawUnsafe(
-    `ALTER TABLE shares ADD COLUMN IF NOT EXISTS enc_version INTEGER`,
-  )
-  await prisma.$executeRawUnsafe(
-    `UPDATE shares SET enc_version = 1 WHERE enc_version IS NULL`,
-  )
-  await prisma.$executeRawUnsafe(
-    `CREATE INDEX IF NOT EXISTS idx_shares_user_id ON shares(user_id)`,
-  )
+  `
+  await prisma.$executeRaw`ALTER TABLE shares ADD COLUMN IF NOT EXISTS user_id TEXT`
+  await prisma.$executeRaw`ALTER TABLE shares ADD COLUMN IF NOT EXISTS is_protected BOOLEAN DEFAULT FALSE`
+  await prisma.$executeRaw`ALTER TABLE shares ADD COLUMN IF NOT EXISTS is_burn BOOLEAN DEFAULT FALSE`
+  await prisma.$executeRaw`ALTER TABLE shares ADD COLUMN IF NOT EXISTS enc_version INTEGER`
+  await prisma.$executeRaw`UPDATE shares SET enc_version = 1 WHERE enc_version IS NULL`
+  await prisma.$executeRaw`CREATE INDEX IF NOT EXISTS idx_shares_user_id ON shares(user_id)`
   initialized = true
 }
 
@@ -149,25 +139,14 @@ export async function POST(request: NextRequest) {
 
     await initializeDatabase()
 
-    await prisma.$executeRawUnsafe(
-      `
+    await prisma.$executeRaw`
       INSERT INTO shares (user_id, share_id, encrypted_data, iv, auth_tag, timestamp, is_protected, is_burn, enc_version)
-      VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9)
+      VALUES (${user.id}, ${id}, ${encryptedData}, ${iv}, ${authTag}, ${new Date().toISOString()}, ${hasPassword}, ${burn}, ${hasPassword ? 3 : 2})
       ON CONFLICT (share_id)
       DO UPDATE SET encrypted_data = EXCLUDED.encrypted_data, iv = EXCLUDED.iv, auth_tag = EXCLUDED.auth_tag,
         timestamp = EXCLUDED.timestamp, is_protected = EXCLUDED.is_protected, is_burn = EXCLUDED.is_burn,
         enc_version = EXCLUDED.enc_version, user_id = EXCLUDED.user_id
-      `,
-      user.id,
-      id,
-      encryptedData,
-      iv,
-      authTag,
-      new Date().toISOString(),
-      hasPassword,
-      burn,
-      hasPassword ? 3 : 2,
-    )
+      `
 
     return NextResponse.json({
       success: true,
@@ -272,7 +251,7 @@ export async function GET(request: NextRequest) {
     await initializeDatabase()
 
     const result = await prisma.$transaction(async (tx) => {
-      const rows = await tx.$queryRawUnsafe<
+      const rows = await tx.$queryRaw<
         Array<{
           encrypted_data: string
           iv: string
@@ -281,10 +260,7 @@ export async function GET(request: NextRequest) {
           is_protected: boolean
           is_burn: boolean
         }>
-      >(
-        'SELECT encrypted_data, iv, auth_tag, timestamp, is_protected, is_burn FROM shares WHERE share_id = $1 FOR UPDATE',
-        id,
-      )
+      >`SELECT encrypted_data, iv, auth_tag, timestamp, is_protected, is_burn FROM shares WHERE share_id = ${id} FOR UPDATE`
 
       if (!rows.length) {
         return { status: 404 as const }
@@ -306,7 +282,7 @@ export async function GET(request: NextRequest) {
       }
 
       if (row.is_burn) {
-        await tx.$executeRawUnsafe('DELETE FROM shares WHERE share_id = $1', id)
+        await tx.$executeRaw`DELETE FROM shares WHERE share_id = ${id}`
       }
 
       return {
@@ -388,11 +364,7 @@ export async function DELETE(request: NextRequest) {
 
   await initializeDatabase()
 
-  await prisma.$executeRawUnsafe(
-    'DELETE FROM shares WHERE share_id = $1 AND user_id = $2',
-    id,
-    user.id,
-  )
+  await prisma.$executeRaw`DELETE FROM shares WHERE share_id = ${id} AND user_id = ${user.id}`
 
   return NextResponse.json({ success: true })
 }

--- a/components/providers/calendar-context.tsx
+++ b/components/providers/calendar-context.tsx
@@ -1,13 +1,9 @@
 'use client'
 
-import { useLocalStorage } from '@/hooks/useLocalStorage'
-import {
-  createContext,
-  useContext,
-  type Dispatch,
-  type SetStateAction,
-} from 'react'
+import type { Dispatch, SetStateAction } from 'react'
 import type React from 'react'
+import { create } from 'zustand'
+import { createJSONStorage, persist } from 'zustand/middleware'
 
 export interface CalendarCategory {
   id: string
@@ -43,9 +39,17 @@ interface CalendarContextType {
   addEvent: (newEvent: CalendarEvent) => void
 }
 
-const CalendarContext = createContext<CalendarContextType | undefined>(
-  undefined,
-)
+interface CalendarState {
+  calendars: CalendarCategory[]
+  events: CalendarEvent[]
+  setCalendars: (value: SetStateAction<CalendarCategory[]>) => void
+  setEvents: (value: SetStateAction<CalendarEvent[]>) => void
+  addCategory: (category: CalendarCategory) => void
+  removeCategory: (id: string) => void
+  updateCategory: (id: string, category: Partial<CalendarCategory>) => void
+  moveCategory: (id: string, direction: 'up' | 'down') => void
+  addEvent: (newEvent: CalendarEvent) => void
+}
 
 const defaultCalendars: CalendarCategory[] = [
   {
@@ -62,89 +66,82 @@ const defaultCalendars: CalendarCategory[] = [
   },
 ]
 
+const useCalendarStore = create<CalendarState>()(
+  persist(
+    (set) => ({
+      calendars: defaultCalendars,
+      events: [],
+      setCalendars: (value) =>
+        set((state) => ({
+          calendars:
+            typeof value === 'function' ? value(state.calendars) : value,
+        })),
+      setEvents: (value) =>
+        set((state) => ({
+          events: typeof value === 'function' ? value(state.events) : value,
+        })),
+      addCategory: (category) =>
+        set((state) => ({ calendars: [...state.calendars, category] })),
+      removeCategory: (id) =>
+        set((state) => ({
+          calendars: state.calendars.filter((cal) => cal.id !== id),
+        })),
+      updateCategory: (id, category) =>
+        set((state) => ({
+          calendars: state.calendars.map((cal) =>
+            cal.id === id ? { ...cal, ...category } : cal,
+          ),
+        })),
+      moveCategory: (id, direction) =>
+        set((state) => {
+          const currentIndex = state.calendars.findIndex((cal) => cal.id === id)
+          if (currentIndex === -1) return { calendars: state.calendars }
+
+          const targetIndex =
+            direction === 'up' ? currentIndex - 1 : currentIndex + 1
+
+          if (targetIndex < 0 || targetIndex >= state.calendars.length) {
+            return { calendars: state.calendars }
+          }
+
+          const nextCalendars = [...state.calendars]
+          const [movedCalendar] = nextCalendars.splice(currentIndex, 1)
+          nextCalendars.splice(targetIndex, 0, movedCalendar)
+
+          return { calendars: nextCalendars }
+        }),
+      addEvent: (newEvent) =>
+        set((state) => {
+          const eventExists = state.events.some((event) => event.id === newEvent.id)
+
+          if (eventExists) {
+            return {
+              events: state.events.map((event) =>
+                event.id === newEvent.id ? newEvent : event,
+              ),
+            }
+          }
+
+          return { events: [...state.events, newEvent] }
+        }),
+    }),
+    {
+      name: 'calendar-store',
+      storage: createJSONStorage(() => localStorage),
+      partialize: (state) => ({
+        calendars: state.calendars,
+        events: state.events,
+      }),
+    },
+  ),
+)
+
 export function CalendarProvider({ children }: { children: React.ReactNode }) {
-  const [calendars, setCalendars] = useLocalStorage<CalendarCategory[]>(
-    'calendar-categories',
-    [],
-  )
-
-  const [events, setEvents] = useLocalStorage<CalendarEvent[]>(
-    'calendar-events',
-    [],
-  )
-
-  const addCategory = (category: CalendarCategory) => {
-    setCalendars([...calendars, category])
-  }
-
-  const removeCategory = (id: string) => {
-    setCalendars(calendars.filter((cal) => cal.id !== id))
-  }
-
-  const updateCategory = (id: string, category: Partial<CalendarCategory>) => {
-    setCalendars(
-      calendars.map((cal) => (cal.id === id ? { ...cal, ...category } : cal)),
-    )
-  }
-
-  const moveCategory = (id: string, direction: 'up' | 'down') => {
-    setCalendars((prevCalendars) => {
-      const currentIndex = prevCalendars.findIndex((cal) => cal.id === id)
-      if (currentIndex === -1) return prevCalendars
-
-      const targetIndex =
-        direction === 'up' ? currentIndex - 1 : currentIndex + 1
-
-      if (targetIndex < 0 || targetIndex >= prevCalendars.length) {
-        return prevCalendars
-      }
-
-      const nextCalendars = [...prevCalendars]
-      const [movedCalendar] = nextCalendars.splice(currentIndex, 1)
-      nextCalendars.splice(targetIndex, 0, movedCalendar)
-      return nextCalendars
-    })
-  }
-
-  const addEvent = (newEvent: CalendarEvent) => {
-    setEvents((prevEvents) => {
-      const eventExists = prevEvents.some((event) => event.id === newEvent.id)
-
-      if (eventExists) {
-        return prevEvents.map((event) =>
-          event.id === newEvent.id ? newEvent : event,
-        )
-      } else {
-        return [...prevEvents, newEvent]
-      }
-    })
-  }
-
-  return (
-    <CalendarContext.Provider
-      value={{
-        calendars,
-        setCalendars,
-        events,
-        setEvents,
-        addCategory,
-        removeCategory,
-        updateCategory,
-        moveCategory,
-        addEvent,
-      }}
-    >
-      {children}
-    </CalendarContext.Provider>
-  )
+  return children
 }
 
-export function useCalendar() {
-  const context = useContext(CalendarContext)
-  if (context === undefined) {
-    throw new Error('useCalendar must be used within a CalendarProvider')
-  }
-  return context
+export function useCalendar(): CalendarContextType {
+  return useCalendarStore()
 }
 
 export const useCalendarContext = useCalendar

--- a/components/providers/calendar-context.tsx
+++ b/components/providers/calendar-context.tsx
@@ -51,25 +51,10 @@ interface CalendarState {
   addEvent: (newEvent: CalendarEvent) => void
 }
 
-const defaultCalendars: CalendarCategory[] = [
-  {
-    id: 'work',
-    name: '工作',
-    color: 'bg-blue-500',
-    keywords: [],
-  },
-  {
-    id: 'personal',
-    name: '个人',
-    color: 'bg-green-500',
-    keywords: [],
-  },
-]
-
 const useCalendarStore = create<CalendarState>()(
   persist(
     (set) => ({
-      calendars: defaultCalendars,
+      calendars: [],
       events: [],
       setCalendars: (value) =>
         set((state) => ({

--- a/lib/prisma.ts
+++ b/lib/prisma.ts
@@ -1,0 +1,15 @@
+import { PrismaClient } from '@prisma/client'
+
+const globalForPrisma = globalThis as unknown as {
+  prisma: PrismaClient | undefined
+}
+
+export const prisma =
+  globalForPrisma.prisma ??
+  new PrismaClient({
+    log: process.env.NODE_ENV === 'development' ? ['error', 'warn'] : ['error'],
+  })
+
+if (process.env.NODE_ENV !== 'production') {
+  globalForPrisma.prisma = prisma
+}

--- a/lib/prisma.ts
+++ b/lib/prisma.ts
@@ -1,12 +1,19 @@
-import { PrismaClient } from '@prisma/client'
+import { PrismaClient } from '@/lib/generated/prisma/client'
+import { PrismaPg } from '@prisma/adapter-pg'
 
 const globalForPrisma = globalThis as unknown as {
   prisma: PrismaClient | undefined
 }
 
+const adapter = new PrismaPg({
+  connectionString: process.env.POSTGRES_URL ?? '',
+  ssl: { rejectUnauthorized: false },
+})
+
 export const prisma =
   globalForPrisma.prisma ??
   new PrismaClient({
+    adapter,
     log: process.env.NODE_ENV === 'development' ? ['error', 'warn'] : ['error'],
   })
 

--- a/package.json
+++ b/package.json
@@ -30,7 +30,6 @@
     "lucide-react": "latest",
     "next": "16.2.4",
     "next-themes": "latest",
-    "pg": "latest",
     "qr-code-styling": "latest",
     "radix-ui": "latest",
     "react": "^18",
@@ -40,7 +39,9 @@
     "sonner": "2.0.7",
     "tailwind-merge": "3.5.0",
     "tailwindcss-animate": "^1.0.7",
-    "react-icons": "5.6.0"
+    "react-icons": "5.6.0",
+    "@prisma/client": "latest",
+    "zustand": "latest"
   },
   "lint-staged": {
     "*.{ts,tsx,js,jsx}": [
@@ -71,6 +72,7 @@
     "typescript-eslint": "8.58.2",
     "eslint-config-next": "16.2.3",
     "lint-staged": "16.4.0",
-    "prettier": "3.8.3"
+    "prettier": "3.8.3",
+    "prisma": "latest"
   }
 }

--- a/package.json
+++ b/package.json
@@ -41,8 +41,9 @@
     "tailwind-merge": "3.5.0",
     "tailwindcss-animate": "^1.0.7",
     "react-icons": "5.6.0",
-    "@prisma/client": "6.16.2",
-    "zustand": "latest"
+    "@prisma/client": "latest",
+    "zustand": "latest",
+    "@prisma/adapter-pg": "latest"
   },
   "lint-staged": {
     "*.{ts,tsx,js,jsx}": [
@@ -74,6 +75,6 @@
     "eslint-config-next": "16.2.3",
     "lint-staged": "16.4.0",
     "prettier": "3.8.3",
-    "prisma": "6.16.2"
+    "prisma": "latest"
   }
 }

--- a/package.json
+++ b/package.json
@@ -5,14 +5,15 @@
   "packageManager": "bun@1.3.12",
   "scripts": {
     "dev": "next dev",
-    "build": "bun run generate:locales && next build",
+    "build": "bun run generate:locales && prisma generate && next build",
     "start": "next start",
     "prepare": "husky",
     "lint": "oxlint --fix && eslint . --fix",
     "lint:check": "oxlint && eslint . --max-warnings=0",
     "type-check": "tsc --noEmit",
     "generate:locales": "bun lib/gen-locales.mjs",
-    "generate:oauth-metadata": "bun lib/gen-oauth-metadata.mjs"
+    "generate:oauth-metadata": "bun lib/gen-oauth-metadata.mjs",
+    "postinstall": "prisma generate"
   },
   "dependencies": {
     "@clerk/nextjs": "^7.0.0",

--- a/package.json
+++ b/package.json
@@ -5,7 +5,7 @@
   "packageManager": "bun@1.3.12",
   "scripts": {
     "dev": "next dev",
-    "build": "bun run generate:locales && prisma generate && next build",
+    "build": "bun run generate:locales && next build",
     "start": "next start",
     "prepare": "husky",
     "lint": "oxlint --fix && eslint . --fix",

--- a/package.json
+++ b/package.json
@@ -41,7 +41,7 @@
     "tailwind-merge": "3.5.0",
     "tailwindcss-animate": "^1.0.7",
     "react-icons": "5.6.0",
-    "@prisma/client": "latest",
+    "@prisma/client": "6.16.2",
     "zustand": "latest"
   },
   "lint-staged": {
@@ -74,6 +74,6 @@
     "eslint-config-next": "16.2.3",
     "lint-staged": "16.4.0",
     "prettier": "3.8.3",
-    "prisma": "latest"
+    "prisma": "6.16.2"
   }
 }

--- a/prisma.config.ts
+++ b/prisma.config.ts
@@ -1,0 +1,8 @@
+import { defineConfig } from 'prisma/config'
+
+export default defineConfig({
+  schema: 'prisma/schema.prisma',
+  datasource: {
+    url: process.env.POSTGRES_URL ?? '',
+  },
+})

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -1,0 +1,44 @@
+generator client {
+  provider = "prisma-client-js"
+}
+
+datasource db {
+  provider = "postgresql"
+  url      = env("POSTGRES_URL")
+}
+
+model Share {
+  id            Int      @id @default(autoincrement())
+  userId        String   @map("user_id")
+  shareId       String   @unique @map("share_id")
+  encryptedData String   @map("encrypted_data")
+  iv            String
+  authTag       String   @map("auth_tag")
+  timestamp     DateTime
+  isProtected   Boolean  @default(false) @map("is_protected")
+  isBurn        Boolean  @default(false) @map("is_burn")
+  encVersion    Int?     @map("enc_version")
+
+  @@index([userId], map: "idx_shares_user_id")
+  @@map("shares")
+}
+
+model CalendarBackup {
+  userId        String   @id @map("user_id")
+  encryptedData String   @map("encrypted_data")
+  iv            String
+  timestamp     DateTime
+
+  @@map("calendar_backups")
+}
+
+model AtprotoShareBurnRead {
+  handle          String
+  ownerDid        String?  @map("owner_did")
+  shareId         String   @map("share_id")
+  burnedAt        DateTime @default(now()) @map("burned_at")
+  pdsDeleteSynced Boolean  @default(false) @map("pds_delete_synced")
+
+  @@id([shareId, handle])
+  @@map("atproto_share_burn_reads")
+}

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -1,10 +1,10 @@
 generator client {
-  provider = "prisma-client-js"
+  provider = "prisma-client"
+  output   = "../lib/generated/prisma"
 }
 
 datasource db {
   provider = "postgresql"
-  url      = env("POSTGRES_URL")
 }
 
 model Share {


### PR DESCRIPTION
### Motivation
- Replace the React context-based calendar state with a lighter, persisted store to simplify state handling and avoid prop drilling.
- Move direct `pg` client usage to Prisma to centralize database access and use a single client instance with safer raw SQL and transaction APIs.
- Keep existing HTTP API behaviour while preparing the project for Prisma schema management and code-driven DB migrations.

### Description
- Replaced `components/providers/calendar-context.tsx` implementation with a Zustand store persisted to `localStorage` using `persist`, while keeping the `useCalendar` / `CalendarProvider` API surface for consumers.
- Added a global Prisma client at `lib/prisma.ts` and a `prisma/schema.prisma` model for `shares`, `calendar_backups`, and `atproto_share_burn_reads`.
- Migrated server-side Postgres access in API routes from `pg` Pools to Prisma raw queries/executes and transaction usage in `app/api/share/route.ts`, `app/api/share/list/route.ts`, `app/api/share/public/route.ts`, `app/api/blob/route.ts`, `app/api/blob/check/route.ts`, and `app/api/account/route.ts` while preserving existing SQL and behaviour (including burn-after-read logic and backup management).
- Updated `package.json` dependencies to remove `pg` and add `zustand`, `@prisma/client`, and `prisma`.

### Testing
- No automated tests were executed as part of this change.
- The changes were committed successfully (`refactor: migrate calendar state to zustand and postgres access to prisma`).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69eb714cdc208332a05bceb22308877e)

## Summary by Sourcery

将日历客户端状态迁移到持久化的 Zustand 存储中，并在 API 路由中将 PostgreSQL 访问方式从直接使用 pg 改为使用共享的 Prisma 客户端，同时保持现有行为不变。

New Features:
- 引入基于 Zustand 的持久化日历存储，同时保留现有的 `CalendarProvider` / `useCalendar` hook API 接口。
- 添加共享的 Prisma 客户端封装，以及针对核心数据表（如 `shares`、`calendar_backups` 和 `atproto_share_burn_reads`）的初始 Prisma schema。

Enhancements:
- 重构 `share`、`blob`、`share listing/public`、`account` 和 `blob/check` 等 API 路由，改为使用 Prisma 原生查询和事务替代 pg Pools，同时保持现有 SQL 语义和「阅后即焚」逻辑。
- 简化日历 provider 的实现，将所有状态管理委托给集中式的 Zustand 存储。
- 优化数据库初始化辅助方法，通过使用内存标记避免重复的表初始化操作。

Build:
- 更新依赖，移除 `pg`，并添加与 Prisma 和 Zustand 相关的包。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Migrate calendar client state to a persisted Zustand store and move PostgreSQL access in API routes from direct pg usage to a shared Prisma client while preserving existing behavior.

New Features:
- Introduce a persisted Zustand-based calendar store with the existing CalendarProvider/useCalendar hook API surface.
- Add a shared Prisma client wrapper and initial Prisma schema for core tables such as shares, calendar_backups, and atproto_share_burn_reads.

Enhancements:
- Refactor share, blob, share listing/public, account, and blob/check API routes to use Prisma raw queries and transactions instead of pg Pools, keeping existing SQL semantics and burn-after-read logic.
- Simplify calendar provider implementation by delegating all state management to the centralized Zustand store.
- Optimize database initialization helpers to avoid repeated table setup using in-memory flags.

Build:
- Update dependencies to remove pg and add Prisma-related and Zustand packages.

</details>