### PR TITLE
fix: persist zustand calendar state to encrypted storage

### DIFF
--- a/components/providers/calendar-context.tsx
+++ b/components/providers/calendar-context.tsx
@@ -2,7 +2,12 @@
 
 import type { Dispatch, SetStateAction } from 'react'
 import type React from 'react'
+import { useEffect, useRef } from 'react'
 import { create } from 'zustand'
+import {
+  readEncryptedLocalStorage,
+  writeEncryptedLocalStorage,
+} from '@/hooks/useLocalStorage'
 
 export interface CalendarCategory {
   id: string
@@ -107,6 +112,47 @@ const useCalendarStore = create<CalendarState>()((set) => ({
 }))
 
 export function CalendarProvider({ children }: { children: React.ReactNode }) {
+  const calendars = useCalendarStore((state) => state.calendars)
+  const events = useCalendarStore((state) => state.events)
+  const setCalendars = useCalendarStore((state) => state.setCalendars)
+  const setEvents = useCalendarStore((state) => state.setEvents)
+  const hydratedRef = useRef(false)
+
+  useEffect(() => {
+    const hydrate = async () => {
+      const storedCalendars = await readEncryptedLocalStorage<CalendarCategory[]>(
+        'calendar-categories',
+        [],
+      )
+      const storedEvents = await readEncryptedLocalStorage<CalendarEvent[]>(
+        'calendar-events',
+        [],
+      )
+
+      setCalendars(storedCalendars)
+      setEvents(
+        storedEvents.map((event) => ({
+          ...event,
+          startDate: new Date(event.startDate),
+          endDate: new Date(event.endDate),
+        })),
+      )
+      hydratedRef.current = true
+    }
+
+    void hydrate()
+  }, [setCalendars, setEvents])
+
+  useEffect(() => {
+    if (!hydratedRef.current) return
+    void writeEncryptedLocalStorage('calendar-categories', calendars)
+  }, [calendars])
+
+  useEffect(() => {
+    if (!hydratedRef.current) return
+    void writeEncryptedLocalStorage('calendar-events', events)
+  }, [events])
+
   return children
 }
 


### PR DESCRIPTION
### Motivation
- 修复将日历状态迁移到 `zustand` 后触发自动备份但敏感内存数据未被更新导致备份内容不包含最新日程的问题。
- 确保从持久化加密存储恢复时事件时间字段类型正确，以避免类型不一致导致的界面/逻辑异常。

### Description
- 在 `CalendarProvider` 中新增从加密本地存储读取 `calendar-categories` 与 `calendar-events` 的 hydration 逻辑并注入到 zustand（`components/providers/calendar-context.tsx`）。
- 将恢复的事件条目的 `startDate` 和 `endDate` 转回为 `Date` 对象以保持类型一致。 
- 在 `events` 与 `calendars` 变化时将最新状态回写到加密本地存储（`writeEncryptedLocalStorage`），以便自动备份包含最新敏感日程数据。

### Testing
- 未运行自动化测试套件（没有新增或执行自动化测试）。

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69eb87fdc09c8326933d42843ebed978)

## Summary by Sourcery

将由 zustand store 管理的日历状态持久化到加密的本地存储中，并在启动时进行 hydrate，以在会话之间保持敏感日历数据的一致性。

新功能：
- 在 provider 初始化时，将加密本地存储中的日历分类和事件 hydrate 到 zustand 的日历 store 中。

错误修复：
- 确保恢复的日历事件在开始和结束时间上具有正确类型的 Date 字段，以防止与类型相关的 UI 和逻辑问题。
- 通过在日历分类和事件发生更改时，将它们写回到加密本地存储中，保持加密日历备份为最新。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Persist calendar state managed by the zustand store to encrypted local storage and hydrate it on startup to keep sensitive calendar data consistent across sessions.

New Features:
- Hydrate calendar categories and events from encrypted local storage into the zustand calendar store on provider initialization.

Bug Fixes:
- Ensure restored calendar events have correctly typed Date fields for start and end times to prevent type-related UI and logic issues.
- Keep encrypted calendar backups up to date by writing calendar categories and events back to encrypted local storage whenever they change.

</details>