### PR TITLE
Replace raw SQL with Prisma client, enforce DB config, and UI cleanup

### DIFF
--- a/README.md
+++ b/README.md
@@ -142,12 +142,40 @@ ATPROTO_SESSION_SECRET=...
 POSTGRES_URL=postgres://postgres:postgres@localhost:5432/onecalendar
 ```
 
+### Database Configuration
+
+This project uses Prisma schema sync.
+
+After configuring `POSTGRES_URL`, initialize schema from `schema.prisma`:
+
+```bash
+# Generate Prisma client
+bunx prisma generate
+
+# Push schema to database
+bunx prisma db push
+```
+
+### Production Recommendation
+
+For production deployments without SQL migration files, keep schema in sync with:
+
+```bash
+# Ensure Prisma Client is generated
+bunx prisma generate
+
+# Sync schema to database (no SQL migration files required)
+bunx prisma db push
+```
+
 ## Tech Stack
 
 - [Next.js](https://nextjs.org)
 - [TypeScript](https://www.typescriptlang.org/)
 - [Tailwind CSS](https://tailwindcss.com/)
 - [Shadcn/UI](https://ui.shadcn.com)
+- [Zustand](https://zustand-demo.pmnd.rs/)
+- [Prisma](https://www.prisma.io/)
 - [PostgreSQL](https://www.postgresql.org/)
 - [Clerk](https://clerk.com)
 

--- a/app/api/account/route.ts
+++ b/app/api/account/route.ts
@@ -22,14 +22,14 @@ export async function DELETE() {
         SELECT 1 as ok FROM information_schema.tables WHERE table_schema = 'public' AND table_name = 'shares' LIMIT 1
       `
       if (hasSharesTable.length > 0) {
-        await tx.$executeRaw`DELETE FROM shares WHERE user_id = ${user.id}`
+        await tx.share.deleteMany({ where: { userId: user.id } })
       }
 
       const hasBackupsTable = await tx.$queryRaw<Array<{ ok: number }>>`
         SELECT 1 as ok FROM information_schema.tables WHERE table_schema = 'public' AND table_name = 'calendar_backups' LIMIT 1
       `
       if (hasBackupsTable.length > 0) {
-        await tx.$executeRaw`DELETE FROM calendar_backups WHERE user_id = ${user.id}`
+        await tx.calendarBackup.deleteMany({ where: { userId: user.id } })
       }
     })
 

--- a/app/api/account/route.ts
+++ b/app/api/account/route.ts
@@ -18,19 +18,8 @@ export async function DELETE() {
         await tx.$executeRaw`DELETE FROM calendar_events WHERE user_id = ${user.id}`
       }
 
-      const hasSharesTable = await tx.$queryRaw<Array<{ ok: number }>>`
-        SELECT 1 as ok FROM information_schema.tables WHERE table_schema = 'public' AND table_name = 'shares' LIMIT 1
-      `
-      if (hasSharesTable.length > 0) {
-        await tx.share.deleteMany({ where: { userId: user.id } })
-      }
-
-      const hasBackupsTable = await tx.$queryRaw<Array<{ ok: number }>>`
-        SELECT 1 as ok FROM information_schema.tables WHERE table_schema = 'public' AND table_name = 'calendar_backups' LIMIT 1
-      `
-      if (hasBackupsTable.length > 0) {
-        await tx.calendarBackup.deleteMany({ where: { userId: user.id } })
-      }
+      await tx.share.deleteMany({ where: { userId: user.id } })
+      await tx.calendarBackup.deleteMany({ where: { userId: user.id } })
     })
 
     return NextResponse.json({ success: true })

--- a/app/api/share/list/route.ts
+++ b/app/api/share/list/route.ts
@@ -11,26 +11,6 @@ export const runtime = 'nodejs'
 const ALGORITHM = 'aes-256-gcm'
 const ATPROTO_SHARE_COLLECTION = 'app.onecalendar.share'
 
-let burnTableReady = false
-
-async function ensureBurnTable() {
-  if (burnTableReady) return
-  await prisma.$executeRaw`
-    CREATE TABLE IF NOT EXISTS atproto_share_burn_reads (
-      handle TEXT NOT NULL,
-      owner_did TEXT,
-      share_id TEXT NOT NULL,
-      burned_at TIMESTAMPTZ NOT NULL DEFAULT NOW(),
-      pds_delete_synced BOOLEAN NOT NULL DEFAULT FALSE,
-      PRIMARY KEY (share_id, handle)
-    )
-  `
-  await prisma.$executeRaw`ALTER TABLE atproto_share_burn_reads ADD COLUMN IF NOT EXISTS owner_did TEXT`
-  await prisma.$executeRaw`ALTER TABLE atproto_share_burn_reads ADD COLUMN IF NOT EXISTS pds_delete_synced BOOLEAN NOT NULL DEFAULT FALSE`
-  await prisma.$executeRaw`CREATE UNIQUE INDEX IF NOT EXISTS idx_atproto_share_burn_reads_owner_share ON atproto_share_burn_reads(owner_did, share_id) WHERE owner_did IS NOT NULL`
-  burnTableReady = true
-}
-
 async function syncBurnedAtprotoShares(
   ownerDid: string,
   handle: string,
@@ -39,19 +19,19 @@ async function syncBurnedAtprotoShares(
   dpopPrivateKeyPem?: string,
   dpopPublicJwk?: DpopPublicJwk,
 ) {
-  await ensureBurnTable()
-
-  const pending = await prisma.$queryRaw<Array<{ share_id: string }>`
-    SELECT share_id FROM atproto_share_burn_reads
-    WHERE (owner_did = ${ownerDid} OR (owner_did IS NULL AND handle = ${handle}))
-    AND pds_delete_synced = FALSE
-  `
+  const pending = await prisma.atprotoShareBurnRead.findMany({
+    where: {
+      pdsDeleteSynced: false,
+      OR: [{ ownerDid }, { ownerDid: null, handle }],
+    },
+    select: { shareId: true },
+  })
 
   if (!pending.length) return
 
   const syncedIds: string[] = []
   for (const row of pending) {
-    const shareId = String(row.share_id)
+    const shareId = String(row.shareId)
     try {
       await deleteRecord({
         pds,
@@ -68,11 +48,12 @@ async function syncBurnedAtprotoShares(
   }
 
   if (syncedIds.length > 0) {
-    await prisma.$executeRaw`
-      DELETE FROM atproto_share_burn_reads
-      WHERE (owner_did = ${ownerDid} OR (owner_did IS NULL AND handle = ${handle}))
-      AND share_id = ANY(${syncedIds}::text[])
-    `
+    await prisma.atprotoShareBurnRead.deleteMany({
+      where: {
+        shareId: { in: syncedIds },
+        OR: [{ ownerDid }, { ownerDid: null, handle }],
+      },
+    })
   }
 }
 
@@ -158,27 +139,29 @@ export async function GET() {
   if (!user)
     return NextResponse.json({ error: 'Unauthorized' }, { status: 401 })
 
-  const result = await prisma.$queryRaw<
-    Array<{
-      share_id: string
-      encrypted_data: string
-      iv: string
-      auth_tag: string
-      timestamp: Date
-      is_protected: boolean
-    }>
-  >`SELECT share_id, encrypted_data, iv, auth_tag, timestamp, is_protected FROM shares WHERE user_id = ${user.id} ORDER BY timestamp DESC`
+  const result = await prisma.share.findMany({
+    where: { userId: user.id },
+    orderBy: { timestamp: 'desc' },
+    select: {
+      shareId: true,
+      encryptedData: true,
+      iv: true,
+      authTag: true,
+      timestamp: true,
+      isProtected: true,
+    },
+  })
 
   const shares = result.map((row) => {
     let eventId = ''
     let eventTitle = ''
-    if (!row.is_protected) {
+    if (!row.isProtected) {
       try {
         const decrypted = decryptWithKey(
-          row.encrypted_data,
+          row.encryptedData,
           row.iv,
-          row.auth_tag,
-          keyV2Unprotected(row.share_id),
+          row.authTag,
+          keyV2Unprotected(row.shareId),
         )
         const dataObj = JSON.parse(decrypted)
         eventId = dataObj.id ?? ''
@@ -189,13 +172,13 @@ export async function GET() {
       eventTitle = '受保护'
     }
     return {
-      id: row.share_id,
+      id: row.shareId,
       eventId,
       eventTitle,
       sharedBy: user.id,
       shareDate: row.timestamp.toISOString(),
-      shareLink: `/share/${row.share_id}`,
-      isProtected: row.is_protected,
+      shareLink: `/share/${row.shareId}`,
+      isProtected: row.isProtected,
     }
   })
 

--- a/app/api/share/public/route.ts
+++ b/app/api/share/public/route.ts
@@ -13,25 +13,6 @@ const ALGORITHM = 'aes-256-gcm'
 const ATPROTO_SHARE_COLLECTION = 'app.onecalendar.share'
 
 const hasPostgres = !!process.env.POSTGRES_URL
-let burnTableReady = false
-
-async function ensureBurnTable() {
-  if (!hasPostgres || burnTableReady) return
-  await prisma.$executeRaw`
-    CREATE TABLE IF NOT EXISTS atproto_share_burn_reads (
-      handle TEXT NOT NULL,
-      owner_did TEXT,
-      share_id TEXT NOT NULL,
-      burned_at TIMESTAMPTZ NOT NULL DEFAULT NOW(),
-      pds_delete_synced BOOLEAN NOT NULL DEFAULT FALSE,
-      PRIMARY KEY (share_id, handle)
-    )
-  `
-  await prisma.$executeRaw`ALTER TABLE atproto_share_burn_reads ADD COLUMN IF NOT EXISTS owner_did TEXT`
-  await prisma.$executeRaw`ALTER TABLE atproto_share_burn_reads ADD COLUMN IF NOT EXISTS pds_delete_synced BOOLEAN NOT NULL DEFAULT FALSE`
-  await prisma.$executeRaw`CREATE UNIQUE INDEX IF NOT EXISTS idx_atproto_share_burn_reads_owner_share ON atproto_share_burn_reads(owner_did, share_id) WHERE owner_did IS NOT NULL`
-  burnTableReady = true
-}
 
 async function wasPublicBurnConsumed(
   ownerDid: string,
@@ -39,14 +20,14 @@ async function wasPublicBurnConsumed(
   shareId: string,
 ) {
   if (!hasPostgres) return false
-  await ensureBurnTable()
-  const result = await prisma.$queryRaw<Array<{ found: number }>`
-    SELECT 1 as found FROM atproto_share_burn_reads
-    WHERE (owner_did = ${ownerDid} OR (owner_did IS NULL AND handle = ${handle}))
-    AND share_id = ${shareId}
-    LIMIT 1
-  `
-  return result.length > 0
+  const result = await prisma.atprotoShareBurnRead.findFirst({
+    where: {
+      shareId,
+      OR: [{ ownerDid }, { ownerDid: null, handle }],
+    },
+    select: { shareId: true },
+  })
+  return !!result
 }
 
 async function markPublicBurnConsumed(
@@ -55,13 +36,25 @@ async function markPublicBurnConsumed(
   shareId: string,
 ) {
   if (!hasPostgres) return
-  await ensureBurnTable()
-  await prisma.$executeRaw`
-      INSERT INTO atproto_share_burn_reads (handle, owner_did, share_id, pds_delete_synced)
-      VALUES (${handle}, ${ownerDid}, ${shareId}, FALSE)
-      ON CONFLICT (share_id, handle)
-      DO UPDATE SET owner_did = EXCLUDED.owner_did, pds_delete_synced = FALSE, burned_at = NOW()
-    `
+  await prisma.atprotoShareBurnRead.upsert({
+    where: {
+      shareId_handle: {
+        shareId,
+        handle,
+      },
+    },
+    update: {
+      ownerDid,
+      pdsDeleteSynced: false,
+      burnedAt: new Date(),
+    },
+    create: {
+      handle,
+      ownerDid,
+      shareId,
+      pdsDeleteSynced: false,
+    },
+  })
 }
 
 function keyV2Unprotected(shareId: string) {

--- a/app/api/share/route.ts
+++ b/app/api/share/route.ts
@@ -108,7 +108,8 @@ export async function POST(request: NextRequest) {
     if (!user) {
       return NextResponse.json({ error: 'Unauthorized' }, { status: 401 })
     }
-  
+    const now = new Date()
+
     await prisma.share.upsert({
       where: { shareId: id },
       update: {
@@ -116,7 +117,7 @@ export async function POST(request: NextRequest) {
         encryptedData,
         iv,
         authTag,
-        timestamp: new Date(),
+        timestamp: now,
         isProtected: hasPassword,
         isBurn: burn,
         encVersion: hasPassword ? 3 : 2,
@@ -127,7 +128,7 @@ export async function POST(request: NextRequest) {
         encryptedData,
         iv,
         authTag,
-        timestamp: new Date(),
+        timestamp: now,
         isProtected: hasPassword,
         isBurn: burn,
         encVersion: hasPassword ? 3 : 2,

--- a/app/api/share/route.ts
+++ b/app/api/share/route.ts
@@ -7,34 +7,6 @@ import { prisma } from '@/lib/prisma'
 
 export const runtime = 'nodejs'
 
-let initialized = false
-
-async function initializeDatabase() {
-  if (initialized) return
-  await prisma.$executeRaw`
-    CREATE TABLE IF NOT EXISTS shares (
-      id SERIAL PRIMARY KEY,
-      user_id TEXT NOT NULL,
-      share_id VARCHAR(255) NOT NULL,
-      encrypted_data TEXT NOT NULL,
-      iv TEXT NOT NULL,
-      auth_tag TEXT NOT NULL,
-      timestamp TIMESTAMP NOT NULL,
-      is_protected BOOLEAN DEFAULT FALSE,
-      is_burn BOOLEAN DEFAULT FALSE,
-      enc_version INTEGER,
-      UNIQUE(share_id)
-    )
-  `
-  await prisma.$executeRaw`ALTER TABLE shares ADD COLUMN IF NOT EXISTS user_id TEXT`
-  await prisma.$executeRaw`ALTER TABLE shares ADD COLUMN IF NOT EXISTS is_protected BOOLEAN DEFAULT FALSE`
-  await prisma.$executeRaw`ALTER TABLE shares ADD COLUMN IF NOT EXISTS is_burn BOOLEAN DEFAULT FALSE`
-  await prisma.$executeRaw`ALTER TABLE shares ADD COLUMN IF NOT EXISTS enc_version INTEGER`
-  await prisma.$executeRaw`UPDATE shares SET enc_version = 1 WHERE enc_version IS NULL`
-  await prisma.$executeRaw`CREATE INDEX IF NOT EXISTS idx_shares_user_id ON shares(user_id)`
-  initialized = true
-}
-
 const ALGORITHM = 'aes-256-gcm'
 const ATPROTO_SHARE_COLLECTION = 'app.onecalendar.share'
 
@@ -136,17 +108,31 @@ export async function POST(request: NextRequest) {
     if (!user) {
       return NextResponse.json({ error: 'Unauthorized' }, { status: 401 })
     }
-
-    await initializeDatabase()
-
-    await prisma.$executeRaw`
-      INSERT INTO shares (user_id, share_id, encrypted_data, iv, auth_tag, timestamp, is_protected, is_burn, enc_version)
-      VALUES (${user.id}, ${id}, ${encryptedData}, ${iv}, ${authTag}, ${new Date().toISOString()}, ${hasPassword}, ${burn}, ${hasPassword ? 3 : 2})
-      ON CONFLICT (share_id)
-      DO UPDATE SET encrypted_data = EXCLUDED.encrypted_data, iv = EXCLUDED.iv, auth_tag = EXCLUDED.auth_tag,
-        timestamp = EXCLUDED.timestamp, is_protected = EXCLUDED.is_protected, is_burn = EXCLUDED.is_burn,
-        enc_version = EXCLUDED.enc_version, user_id = EXCLUDED.user_id
-      `
+  
+    await prisma.share.upsert({
+      where: { shareId: id },
+      update: {
+        userId: user.id,
+        encryptedData,
+        iv,
+        authTag,
+        timestamp: new Date(),
+        isProtected: hasPassword,
+        isBurn: burn,
+        encVersion: hasPassword ? 3 : 2,
+      },
+      create: {
+        userId: user.id,
+        shareId: id,
+        encryptedData,
+        iv,
+        authTag,
+        timestamp: new Date(),
+        isProtected: hasPassword,
+        isBurn: burn,
+        encVersion: hasPassword ? 3 : 2,
+      },
+    })
 
     return NextResponse.json({
       success: true,
@@ -248,49 +234,50 @@ export async function GET(request: NextRequest) {
     const atprotoResult = await getAtprotoShare(id, password, handle)
     if (atprotoResult) return atprotoResult
 
-    await initializeDatabase()
-
     const result = await prisma.$transaction(async (tx) => {
-      const rows = await tx.$queryRaw<
-        Array<{
-          encrypted_data: string
-          iv: string
-          auth_tag: string
-          timestamp: Date
-          is_protected: boolean
-          is_burn: boolean
-        }>
-      >`SELECT encrypted_data, iv, auth_tag, timestamp, is_protected, is_burn FROM shares WHERE share_id = ${id} FOR UPDATE`
+      const share = await tx.share.findUnique({
+        where: { shareId: id },
+        select: {
+          encryptedData: true,
+          iv: true,
+          authTag: true,
+          timestamp: true,
+          isProtected: true,
+          isBurn: true,
+        },
+      })
 
-      if (!rows.length) {
+      if (!share) {
         return { status: 404 as const }
       }
 
-      const row = rows[0]
-      if (row.is_protected && !password) {
-        return { status: 401 as const, burnAfterRead: row.is_burn }
+      if (share.isProtected && !password) {
+        return { status: 401 as const, burnAfterRead: share.isBurn }
       }
 
-      const key = row.is_protected
-        ? keyV3Password(password, id)
-        : keyV2Unprotected(id)
+      const key = share.isProtected ? keyV3Password(password, id) : keyV2Unprotected(id)
       let decryptedData: string
       try {
-        decryptedData = decryptWithKey(row.encrypted_data, row.iv, row.auth_tag, key)
+        decryptedData = decryptWithKey(
+          share.encryptedData,
+          share.iv,
+          share.authTag,
+          key,
+        )
       } catch {
-        return { status: 403 as const, protected: row.is_protected }
+        return { status: 403 as const, protected: share.isProtected }
       }
 
-      if (row.is_burn) {
-        await tx.$executeRaw`DELETE FROM shares WHERE share_id = ${id}`
+      if (share.isBurn) {
+        await tx.share.delete({ where: { shareId: id } })
       }
 
       return {
         status: 200 as const,
         data: decryptedData,
-        timestamp: row.timestamp.toISOString(),
-        protected: row.is_protected,
-        burnAfterRead: row.is_burn,
+        timestamp: share.timestamp.toISOString(),
+        protected: share.isProtected,
+        burnAfterRead: share.isBurn,
       }
     })
 
@@ -362,9 +349,7 @@ export async function DELETE(request: NextRequest) {
   if (!user)
     return NextResponse.json({ error: 'Unauthorized' }, { status: 401 })
 
-  await initializeDatabase()
-
-  await prisma.$executeRaw`DELETE FROM shares WHERE share_id = ${id} AND user_id = ${user.id}`
+  await prisma.share.deleteMany({ where: { shareId: id, userId: user.id } })
 
   return NextResponse.json({ success: true })
 }

--- a/components/app/sidebar/right-sidebar.tsx
+++ b/components/app/sidebar/right-sidebar.tsx
@@ -1,53 +1,14 @@
 import {
-  User,
-  BookText,
-  Plus,
-  ArrowLeft,
-  Edit2,
-  Trash2,
   Calendar,
   Bookmark,
-  MessageSquare,
-  Sun,
 } from 'lucide-react'
-import {
-  Select,
-  SelectContent,
-  SelectItem,
-  SelectTrigger,
-  SelectValue,
-} from '@/components/ui/select'
-import {
-  Sheet,
-  SheetContent,
-  SheetHeader,
-  SheetTitle,
-} from '@/components/ui/sheet'
-import { Avatar, AvatarImage, AvatarFallback } from '@/components/ui/avatar'
 import { ClockDashed } from '@/components/icons/clock-dashed'
-import { ScrollArea } from '@/components/ui/scroll-area'
 import MiniCalendarSheet from './mini-calendar-sheet'
-import { Textarea } from '@/components/ui/textarea'
 import { Button } from '@/components/ui/button'
-import { Input } from '@/components/ui/input'
-import { Label } from '@/components/ui/label'
 import BookmarkPanel from './bookmark-panel'
-import { useRouter } from 'next/navigation'
 import { CountdownTool } from './countdown'
 import { useState } from 'react'
 import { cn } from '@/lib/utils'
-
-const colorOptions = [
-  { value: 'bg-blue-500', label: 'Blue' },
-  { value: 'bg-green-500', label: 'Green' },
-  { value: 'bg-purple-500', label: 'Purple' },
-  { value: 'bg-yellow-500', label: 'Yellow' },
-  { value: 'bg-red-500', label: 'Red' },
-  { value: 'bg-pink-500', label: 'Pink' },
-  { value: 'bg-indigo-500', label: 'Indigo' },
-  { value: 'bg-orange-500', label: 'Orange' },
-  { value: 'bg-teal-500', label: 'Teal' },
-]
 
 interface RightSidebarProps {
   onViewChange?: (view: string) => void
@@ -55,14 +16,13 @@ interface RightSidebarProps {
 }
 
 export default function RightSidebar({
-  onViewChange,
-  onEventClick,
+  onViewChange: _onViewChange,
+  onEventClick: _onEventClick,
 }: RightSidebarProps) {
   const [miniCalendarOpen, setMiniCalendarOpen] = useState(false)
   const [selectedDate, setSelectedDate] = useState(new Date())
   const [bookmarkPanelOpen, setBookmarkPanelOpen] = useState(false)
   const [countdownOpen, setCountdownOpen] = useState(false)
-  const router = useRouter()
 
   const handleDateSelect = (date: Date) => {
     setSelectedDate(date)

--- a/components/app/sidebar/sidebar.tsx
+++ b/components/app/sidebar/sidebar.tsx
@@ -28,7 +28,6 @@ import {
   Edit2,
   MoreHorizontal,
   Plus,
-  X,
   Trash2,
 } from 'lucide-react'
 import { useEffect, useState, type CSSProperties } from 'react'
@@ -79,11 +78,11 @@ const CALENDAR_COLOR_MAP = Object.fromEntries(
 export default function Sidebar({
   onCreateEvent,
   onDateSelect,
-  onViewChange,
+  onViewChange: _onViewChange,
   language = 'zh-CN',
   selectedDate,
   isCollapsed = false,
-  onToggleCollapse,
+  onToggleCollapse: _onToggleCollapse,
   selectedCategoryFilters = [],
   onCategoryFilterChange,
   onCollapseTransitionEnd,
@@ -273,7 +272,7 @@ export default function Sidebar({
             }}
             onSelect={(date) => {
               setLocalSelectedDate(date)
-              date && onDateSelect(date)
+              if (date) onDateSelect(date)
             }}
             className="rounded-lg border"
           />

--- a/components/ui/chart.tsx
+++ b/components/ui/chart.tsx
@@ -253,7 +253,7 @@ function ChartTooltipContent({
                           {itemConfig?.label ?? item.name}
                         </span>
                       </div>
-                      {item.value != null && (
+                      {item.value !== null && item.value !== undefined && (
                         <span className="font-mono font-medium text-foreground tabular-nums">
                           {typeof item.value === "number"
                             ? item.value.toLocaleString()

--- a/lib/prisma.ts
+++ b/lib/prisma.ts
@@ -5,9 +5,18 @@ const globalForPrisma = globalThis as unknown as {
   prisma: PrismaClient | undefined
 }
 
+const databaseUrl = process.env.POSTGRES_URL
+
+if (!databaseUrl) {
+  throw new Error('Missing POSTGRES_URL environment variable')
+}
+
 const adapter = new PrismaPg({
-  connectionString: process.env.POSTGRES_URL ?? '',
-  ssl: { rejectUnauthorized: false },
+  connectionString: databaseUrl,
+  ssl:
+    process.env.NODE_ENV === 'production'
+      ? { rejectUnauthorized: true }
+      : { rejectUnauthorized: false },
 })
 
 export const prisma =

--- a/lib/prisma.ts
+++ b/lib/prisma.ts
@@ -5,27 +5,42 @@ const globalForPrisma = globalThis as unknown as {
   prisma: PrismaClient | undefined
 }
 
-const databaseUrl = process.env.POSTGRES_URL
+function createPrismaClient() {
+  const databaseUrl = process.env.POSTGRES_URL
+  if (!databaseUrl) {
+    throw new Error('Missing POSTGRES_URL environment variable')
+  }
 
-if (!databaseUrl) {
-  throw new Error('Missing POSTGRES_URL environment variable')
-}
+  const adapter = new PrismaPg({
+    connectionString: databaseUrl,
+    ssl:
+      process.env.NODE_ENV === 'production'
+        ? { rejectUnauthorized: true }
+        : { rejectUnauthorized: false },
+  })
 
-const adapter = new PrismaPg({
-  connectionString: databaseUrl,
-  ssl:
-    process.env.NODE_ENV === 'production'
-      ? { rejectUnauthorized: true }
-      : { rejectUnauthorized: false },
-})
-
-export const prisma =
-  globalForPrisma.prisma ??
-  new PrismaClient({
+  return new PrismaClient({
     adapter,
     log: process.env.NODE_ENV === 'development' ? ['error', 'warn'] : ['error'],
   })
-
-if (process.env.NODE_ENV !== 'production') {
-  globalForPrisma.prisma = prisma
 }
+
+function getPrismaClient() {
+  if (globalForPrisma.prisma) {
+    return globalForPrisma.prisma
+  }
+
+  const client = createPrismaClient()
+  if (process.env.NODE_ENV !== 'production') {
+    globalForPrisma.prisma = client
+  }
+  return client
+}
+
+export const prisma = new Proxy({} as PrismaClient, {
+  get(_target, property) {
+    const client = getPrismaClient()
+    const value = Reflect.get(client as object, property)
+    return typeof value === 'function' ? value.bind(client) : value
+  },
+})


### PR DESCRIPTION
### Motivation
- Move from ad-hoc raw SQL and runtime table creation to a schema-first Prisma client usage for safer, clearer DB access.
- Ensure runtime fails fast when `POSTGRES_URL` is missing and tighten SSL behavior for production environments.
- Remove unused UI imports and fix minor React prop/variable usage warnings.

### Description
- Replaced numerous `prisma.$queryRaw`/`$executeRaw` usages with typed Prisma client calls (`findMany`, `findUnique`, `deleteMany`, `delete`, `upsert`, `deleteMany`, `upsert`) in share, public share, and account APIs, and migrated column/snake_case names to camelCase model fields.
- Removed dynamic table initialization helpers (`initializeDatabase`, `ensureBurnTable`) and adopted existing Prisma models such as `share`, `calendarBackup`, and `atprotoShareBurnRead` for persistence and burn-read tracking.
- Added explicit requirement for `POSTGRES_URL` in `lib/prisma.ts` and adjusted SSL `rejectUnauthorized` behavior to be strict in production and lenient in development.
- Updated `README.md` with Prisma setup and production sync instructions and added `Prisma` and `Zustand` to the tech stack listing.
- Cleaned up UI components by removing unused imports, prefixed unused props with underscores to avoid linter warnings, and tightened some conditional checks in `sidebar` and `chart` components.

### Testing
- Generated Prisma client with `bunx prisma generate` which completed successfully.
- Performed a TypeScript build/typecheck via `bunx tsc` which succeeded without new type errors.
- No automated unit tests failed during these changes.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69eb8ac771cc832687cd3d4b05bfb430)

## Summary by Sourcery

将基于临时 SQL 的分享和 burn-read（烧读）持久化替换为 Prisma 模型，强制要求必要的数据库配置，并清理一些次要的 UI 和配置问题。

错误修复（Bug Fixes）:
- 通过收紧对 null/undefined 的检查，防止可为空的图表 tooltip 值被渲染。
- 当缺少 `POSTGRES_URL` 时，在 Prisma 客户端初始化阶段快速失败，避免潜在的运行时问题。

功能改进（Enhancements）:
- 将分享和 burn-read API 处理逻辑从原始 SQL 迁移到类型安全的 Prisma 客户端操作，包括事务访问和 upsert 操作。
- 移除运行时的建表辅助逻辑，改为使用由 schema 管理的 Prisma 模型来处理 shares、calendar backups 和 burn-read 追踪。
- 收紧 Prisma 的 PostgreSQL SSL 配置，在生产环境强制要求证书校验，同时在开发环境保持宽松。
- 清理侧边栏和右侧边栏组件，移除未使用的 imports/props，并使日期选择逻辑更加健壮。

文档（Documentation）:
- 记录基于 Prisma 的数据库搭建和 schema 同步工作流（包括生产环境建议），并更新技术栈以列出 Prisma 和 Zustand。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Replace ad-hoc SQL-based share and burn-read persistence with Prisma models, enforce required database configuration, and clean up minor UI and configuration issues.

Bug Fixes:
- Prevent nullable chart tooltip values from rendering by tightening null/undefined checks.
- Avoid potential runtime issues when POSTGRES_URL is missing by failing fast during Prisma client initialization.

Enhancements:
- Migrate share and burn-read API handlers from raw SQL to typed Prisma client operations, including transactional access and upserts.
- Remove runtime table-creation helpers in favor of schema-managed Prisma models for shares, calendar backups, and burn-read tracking.
- Tighten Prisma PostgreSQL SSL configuration to require certificate verification in production while remaining lenient in development.
- Clean up sidebar and right-sidebar components by removing unused imports/props and making date selection logic more robust.

Documentation:
- Document Prisma-based database setup and schema sync workflow, including production recommendations, and update the tech stack to list Prisma and Zustand.

</details>