### PR TITLE
Make share retrieval transactional with row lock and centralize DB pool handling

### DIFF
--- a/app/api/share/route.ts
+++ b/app/api/share/route.ts
@@ -1,7 +1,7 @@
 import { type NextRequest, NextResponse } from 'next/server'
 import { currentUser } from '@clerk/nextjs/server'
 import crypto from 'crypto'
-import { and, eq } from 'drizzle-orm'
+import { and, eq, sql } from 'drizzle-orm'
 import { deleteRecord, getRecord, putRecord } from '@/lib/atproto'
 import { getAtprotoSession } from '@/lib/atproto-auth'
 import { db, schema } from '@/lib/db'
@@ -48,6 +48,10 @@ function decryptWithKey(
   let decrypted = decipher.update(encryptedData, 'hex', 'utf8')
   decrypted += decipher.final('utf8')
   return decrypted
+}
+
+function formatTimestamp(value: Date | string) {
+  return (value instanceof Date ? value : new Date(value)).toISOString()
 }
 
 export async function POST(request: NextRequest) {
@@ -238,65 +242,65 @@ export async function GET(request: NextRequest) {
     const atprotoResult = await getAtprotoShare(id, password, handle)
     if (atprotoResult) return atprotoResult
 
-    const share = await db.query.shares.findFirst({
-      where: eq(schema.shares.shareId, id),
-      columns: {
-        encryptedData: true,
-        iv: true,
-        authTag: true,
-        timestamp: true,
-        isProtected: true,
-        isBurn: true,
-      },
-    })
+    return await db.transaction(async (tx) => {
+      const result = await tx.execute(sql<{
+        encryptedData: string
+        iv: string
+        authTag: string
+        timestamp: Date | string
+        isProtected: boolean
+        isBurn: boolean
+      }>`select encrypted_data as "encryptedData", iv, auth_tag as "authTag", timestamp, is_protected as "isProtected", is_burn as "isBurn" from shares where share_id = ${id} for update`)
+      const share = result.rows[0]
 
-    if (!share) {
-      return NextResponse.json({ error: 'Share not found' }, { status: 404 })
-    }
+      if (!share) {
+        return NextResponse.json({ error: 'Share not found' }, { status: 404 })
+      }
 
-    if (share.isProtected && !password) {
-      return NextResponse.json(
-        {
-          error: 'Password required',
-          requiresPassword: true,
-          burnAfterRead: share.isBurn,
-        },
-        { status: 401 },
-      )
-    }
+      if (share.isProtected && !password) {
+        return NextResponse.json(
+          {
+            error: 'Password required',
+            requiresPassword: true,
+            burnAfterRead: share.isBurn,
+          },
+          { status: 401 },
+        )
+      }
 
-    const key = share.isProtected
-      ? keyV3Password(password, id)
-      : keyV2Unprotected(id)
-    let decryptedData: string
-    try {
-      decryptedData = decryptWithKey(
-        share.encryptedData,
-        share.iv,
-        share.authTag,
-        key,
-      )
-    } catch {
-      return NextResponse.json(
-        {
-          error: share.isProtected
-            ? 'Invalid password'
-            : 'Failed to decrypt share data.',
-        },
-        { status: 403 },
-      )
-    }
+      const key = share.isProtected
+        ? keyV3Password(password, id)
+        : keyV2Unprotected(id)
+      let decryptedData: string
+      try {
+        decryptedData = decryptWithKey(
+          share.encryptedData,
+          share.iv,
+          share.authTag,
+          key,
+        )
+      } catch {
+        return NextResponse.json(
+          {
+            error: share.isProtected
+              ? 'Invalid password'
+              : 'Failed to decrypt share data.',
+          },
+          { status: 403 },
+        )
+      }
 
-    if (share.isBurn) {
-      await db.delete(schema.shares).where(eq(schema.shares.shareId, id))
-    }
+      if (share.isBurn) {
+        await tx.delete(schema.shares).where(eq(schema.shares.shareId, id))
+      }
 
-    return NextResponse.json({
-      success: true,
-      data: decryptedData,
-      timestamp: share.timestamp.toISOString(),
-      protected: share.isProtected,
-      burnAfterRead: share.isBurn,
+      return NextResponse.json({
+        success: true,
+        data: decryptedData,
+        timestamp: formatTimestamp(share.timestamp),
+        protected: share.isProtected,
+        burnAfterRead: share.isBurn,
+      })
     })
   } catch (error) {
     return NextResponse.json(

--- a/lib/db/index.ts
+++ b/lib/db/index.ts
@@ -27,13 +27,21 @@ function getPool() {
   }
 
   const pool = createPool()
-  if (process.env.NODE_ENV !== 'production') {
-    globalForDb.dbPool = pool
-  }
+  globalForDb.dbPool = pool
 
   return pool
 }
 
-export const db = drizzle(getPool(), { schema })
+const lazyPool: Pick<Pool, 'query' | 'connect' | 'end' | 'on'> = {
+  query: (...args) => getPool().query(...args),
+  connect: (...args) => getPool().connect(...args),
+  end: (...args) => getPool().end(...args),
+  on(...args) {
+    getPool().on(...args)
+    return this
+  },
+}
+
+export const db = drizzle(lazyPool as Pool, { schema })
 
 export { schema }


### PR DESCRIPTION
### Motivation
- Ensure concurrent reads + burn-after-read deletes are safe by acquiring a row-level lock during share retrieval. 
- Standardize database pool usage to avoid creating multiple pools in server environments. 
- Normalize timestamp formatting returned by the share API.

### Description
- Updated `app/api/share/route.ts` to run share retrieval inside a `db.transaction` and use a `SELECT ... FOR UPDATE` via `sql` to lock the row while decrypting and optionally deleting burn-after-read shares. 
- Moved decryption and conditional deletion into the transaction and returned a formatted timestamp using a new helper `formatTimestamp`. 
- Added `sql` import from `drizzle-orm` and introduced `formatTimestamp` helper in `route.ts`. 
- Reworked `lib/db/index.ts` to always cache the pool in `globalThis` and provide a `lazyPool` proxy that defers obtaining the real pool until first use, then passed that to `drizzle` for safe reuse across environments.

### Testing
- Ran the automated test suite with `pnpm test`, including unit tests for the share logic, and all tests passed. 
- Executed integration tests against the `/api/share` endpoints covering protected, unprotected, and burn-after-read flows, and they passed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69ec15887ff8832690137373406bf8c8)

## Summary by Sourcery

使分享检索具备事务性，并采用行级锁定，同时集中管理数据库连接池，以提升并发访问的安全性，并在不同环境间复用连接池。

新特性：
- 添加时间戳格式化辅助工具，用于规范化分享 API 的时间戳输出。

增强内容：
- 将分享检索、解密以及“阅后即焚”删除操作封装到单一的数据库事务中，并使用行级锁定。
- 引入惰性加载的全局缓存数据库连接池代理，确保在各个环境中复用同一个连接池实例。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Make share retrieval transactional with row-level locking and centralize database pool management for safer concurrent access and reuse across environments.

New Features:
- Add a timestamp formatting helper to normalize share API timestamp output.

Enhancements:
- Wrap share retrieval, decryption, and burn-after-read deletion in a single database transaction using row-level locking.
- Introduce a lazy, globally cached database pool proxy to ensure a single reusable pool instance across environments.

</details>