### PR TITLE
fix: /api/blob 500

### DIFF
--- a/app/api/blob/route.ts
+++ b/app/api/blob/route.ts
@@ -1,15 +1,21 @@
 import { NextRequest, NextResponse } from 'next/server'
+import { sql } from 'drizzle-orm'
 import { currentUser } from '@clerk/nextjs/server'
-import { eq, sql } from 'drizzle-orm'
 import { getAtprotoSession } from '@/lib/atproto-auth'
 import { deleteRecord, getRecord, putRecord } from '@/lib/atproto'
-import { db, schema } from '@/lib/db'
+import { db } from '@/lib/db'
 
 export const runtime = 'nodejs'
 export const dynamic = 'force-dynamic'
 
 const postgresUrl = process.env.POSTGRES_URL
 let inited = false
+
+type BackupColumns = {
+  userId: 'user_id' | '"userId"'
+  encryptedData: 'encrypted_data' | '"encryptedData"'
+  timestamp: 'timestamp' | '"updatedAt"'
+}
 
 async function initDB() {
   if (!postgresUrl) {
@@ -25,6 +31,29 @@ async function initDB() {
     )
   `)
   inited = true
+}
+
+async function getBackupColumns(): Promise<BackupColumns> {
+  await initDB()
+
+  const result = await db.execute(sql<{
+    column_name: string
+  }>`
+    SELECT column_name
+    FROM information_schema.columns
+    WHERE table_schema = 'public'
+      AND table_name = 'calendar_backups'
+  `)
+
+  const columns = new Set(result.rows.map((row) => row.column_name))
+
+  const userId = columns.has('user_id') ? 'user_id' : '"userId"'
+  const encryptedData = columns.has('encrypted_data')
+    ? 'encrypted_data'
+    : '"encryptedData"'
+  const timestamp = columns.has('timestamp') ? 'timestamp' : '"updatedAt"'
+
+  return { userId, encryptedData, timestamp }
 }
 
 const ATPROTO_BACKUP_COLLECTION = 'app.onecalendar.backup'
@@ -72,24 +101,24 @@ export async function POST(req: NextRequest) {
     if (!user)
       return NextResponse.json({ error: 'Unauthorized' }, { status: 401 })
 
-    await initDB()
+    const columns = await getBackupColumns()
+    const now = new Date()
 
-    await db
-      .insert(schema.calendarBackups)
-      .values({
-        userId: user.id,
-        encryptedData: encrypted_data,
+    await db.execute(sql`
+      INSERT INTO calendar_backups (
+        ${sql.raw(columns.userId)},
+        ${sql.raw(columns.encryptedData)},
         iv,
-        timestamp: new Date(),
-      })
-      .onConflictDoUpdate({
-        target: schema.calendarBackups.userId,
-        set: {
-          encryptedData: encrypted_data,
-          iv,
-          timestamp: new Date(),
-        },
-      })
+        ${sql.raw(columns.timestamp)}
+      )
+      VALUES (${user.id}, ${encrypted_data}, ${iv}, ${now})
+      ON CONFLICT (${sql.raw(columns.userId)})
+      DO UPDATE SET
+        ${sql.raw(columns.encryptedData)} = ${encrypted_data},
+        iv = ${iv},
+        ${sql.raw(columns.timestamp)} = ${now}
+    `)
+
     return NextResponse.json({ success: true, backend: 'postgres' })
   } catch (e: unknown) {
     const message = e instanceof Error ? e.message : 'Internal error'
@@ -126,24 +155,29 @@ export async function GET() {
     const user = await currentUser()
     if (!user) return jsonNoStore({ error: 'Unauthorized' }, { status: 401 })
 
-    await initDB()
+    const columns = await getBackupColumns()
 
-    const result = await db
-      .select({
-        encrypted_data: schema.calendarBackups.encryptedData,
-        iv: schema.calendarBackups.iv,
-        timestamp: schema.calendarBackups.timestamp,
-      })
-      .from(schema.calendarBackups)
-      .where(eq(schema.calendarBackups.userId, user.id))
+    const result = await db.execute(sql<{
+      encrypted_data: string
+      iv: string
+      timestamp: Date
+    }>`
+      SELECT
+        ${sql.raw(columns.encryptedData)} AS encrypted_data,
+        iv,
+        ${sql.raw(columns.timestamp)} AS timestamp
+      FROM calendar_backups
+      WHERE ${sql.raw(columns.userId)} = ${user.id}
+      LIMIT 1
+    `)
 
-    if (result.length === 0)
+    if (result.rows.length === 0)
       return jsonNoStore({ error: 'Not found' }, { status: 404 })
 
     return jsonNoStore({
-      ciphertext: result[0].encrypted_data,
-      iv: result[0].iv,
-      timestamp: result[0].timestamp,
+      ciphertext: result.rows[0].encrypted_data,
+      iv: result.rows[0].iv,
+      timestamp: result.rows[0].timestamp,
       backend: 'postgres',
     })
   } catch (e: unknown) {
@@ -172,11 +206,12 @@ export async function DELETE() {
     if (!user)
       return NextResponse.json({ error: 'Unauthorized' }, { status: 401 })
 
-    await initDB()
+    const columns = await getBackupColumns()
 
-    await db
-      .delete(schema.calendarBackups)
-      .where(eq(schema.calendarBackups.userId, user.id))
+    await db.execute(sql`
+      DELETE FROM calendar_backups
+      WHERE ${sql.raw(columns.userId)} = ${user.id}
+    `)
 
     return NextResponse.json({ success: true, backend: 'postgres' })
   } catch (e: unknown) {


### PR DESCRIPTION
### Motivation
- 修复在从 Prisma 迁移到 Drizzle 后，`/api/blob` 因 `calendar_backups` 列名不一致导致的 500 错误，恢复对历史表结构的兼容性。 

### Description
- 新增 `getBackupColumns()`，在运行时从 `information_schema.columns` 探测 `calendar_backups` 的实际列名并返回对应映射。 
- 将 `POST`/`GET`/`DELETE` 的 Postgres 分支从依赖固定 Drizzle `schema` 的 API 调用改为使用基于探测结果的原生 SQL（通过 `sql.raw(...)`）进行插入/查询/删除。 
- 在文件 `app/api/blob/route.ts` 中添加 `BackupColumns` 类型、删除对 `schema` 的固定引用并保留 `CREATE TABLE IF NOT EXISTS` 的初始化逻辑以保证表存在。 

### Testing
- 运行了版本控制相关命令 `git add` / `git commit` 和查看变更 `git show --stat --oneline HEAD`, 命令均成功执行。 
- 未执行任何自动化测试或 linter（按请求未运行 `eslint`/测试）。

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69ec184dfb6c8326975407173589d9b9)

## Summary by Sourcery

使 `/api/blob` 的 Postgres 实现同时兼容旧版和新版的 `calendar_backups` 列名，以防止在 ORM 迁移后出现运行时错误。

Bug Fixes:
- 通过在运行时为 `/api/blob` 操作动态解析列名，恢复与历史 `calendar_backups` 表结构的兼容性。

Enhancements:
- 为 `calendar_backups` 引入运行时列发现辅助方法，并根据检测到的模式，在 `/api/blob` 中将 Postgres 的 CRUD 操作切换为使用基于原始 SQL 的实现，而不是依赖硬编码的 ORM 模式引用。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Make the /api/blob Postgres implementation compatible with both legacy and new calendar_backups column names to prevent runtime errors after the ORM migration.

Bug Fixes:
- Restore compatibility with historical calendar_backups schemas by dynamically resolving column names at runtime for /api/blob operations.

Enhancements:
- Introduce a runtime column discovery helper for calendar_backups and switch Postgres CRUD operations in /api/blob to use raw SQL based on the detected schema instead of hard-coded ORM schema references.

</details>