### PR TITLE
fix: /api/blob

### DIFF
--- a/app/api/blob/route.ts
+++ b/app/api/blob/route.ts
@@ -1,60 +1,12 @@
 import { NextRequest, NextResponse } from 'next/server'
-import { sql } from 'drizzle-orm'
+import { eq } from 'drizzle-orm'
 import { currentUser } from '@clerk/nextjs/server'
 import { getAtprotoSession } from '@/lib/atproto-auth'
 import { deleteRecord, getRecord, putRecord } from '@/lib/atproto'
-import { db } from '@/lib/db'
+import { db, schema } from '@/lib/db'
 
 export const runtime = 'nodejs'
 export const dynamic = 'force-dynamic'
-
-const postgresUrl = process.env.POSTGRES_URL
-let inited = false
-
-type BackupColumns = {
-  userId: 'user_id' | '"userId"'
-  encryptedData: 'encrypted_data' | '"encryptedData"'
-  timestamp: 'timestamp' | '"updatedAt"'
-}
-
-async function initDB() {
-  if (!postgresUrl) {
-    throw new Error('POSTGRES_URL is not configured')
-  }
-  if (inited) return
-  await db.execute(sql`
-    CREATE TABLE IF NOT EXISTS calendar_backups (
-      user_id TEXT PRIMARY KEY,
-      encrypted_data TEXT NOT NULL,
-      iv TEXT NOT NULL,
-      timestamp TIMESTAMP NOT NULL
-    )
-  `)
-  inited = true
-}
-
-async function getBackupColumns(): Promise<BackupColumns> {
-  await initDB()
-
-  const result = await db.execute(sql<{
-    column_name: string
-  }>`
-    SELECT column_name
-    FROM information_schema.columns
-    WHERE table_schema = 'public'
-      AND table_name = 'calendar_backups'
-  `)
-
-  const columns = new Set(result.rows.map((row) => row.column_name))
-
-  const userId = columns.has('user_id') ? 'user_id' : '"userId"'
-  const encryptedData = columns.has('encrypted_data')
-    ? 'encrypted_data'
-    : '"encryptedData"'
-  const timestamp = columns.has('timestamp') ? 'timestamp' : '"updatedAt"'
-
-  return { userId, encryptedData, timestamp }
-}
 
 const ATPROTO_BACKUP_COLLECTION = 'app.onecalendar.backup'
 const ATPROTO_BACKUP_RKEY = 'latest'
@@ -101,23 +53,24 @@ export async function POST(req: NextRequest) {
     if (!user)
       return NextResponse.json({ error: 'Unauthorized' }, { status: 401 })
 
-    const columns = await getBackupColumns()
     const now = new Date()
 
-    await db.execute(sql`
-      INSERT INTO calendar_backups (
-        ${sql.raw(columns.userId)},
-        ${sql.raw(columns.encryptedData)},
+    await db
+      .insert(schema.calendarBackups)
+      .values({
+        userId: user.id,
+        encryptedData: encrypted_data,
         iv,
-        ${sql.raw(columns.timestamp)}
-      )
-      VALUES (${user.id}, ${encrypted_data}, ${iv}, ${now})
-      ON CONFLICT (${sql.raw(columns.userId)})
-      DO UPDATE SET
-        ${sql.raw(columns.encryptedData)} = ${encrypted_data},
-        iv = ${iv},
-        ${sql.raw(columns.timestamp)} = ${now}
-    `)
+        timestamp: now,
+      })
+      .onConflictDoUpdate({
+        target: schema.calendarBackups.userId,
+        set: {
+          encryptedData: encrypted_data,
+          iv,
+          timestamp: now,
+        },
+      })
 
     return NextResponse.json({ success: true, backend: 'postgres' })
   } catch (e: unknown) {
@@ -155,29 +108,23 @@ export async function GET() {
     const user = await currentUser()
     if (!user) return jsonNoStore({ error: 'Unauthorized' }, { status: 401 })
 
-    const columns = await getBackupColumns()
+    const result = await db
+      .select({
+        encryptedData: schema.calendarBackups.encryptedData,
+        iv: schema.calendarBackups.iv,
+        timestamp: schema.calendarBackups.timestamp,
+      })
+      .from(schema.calendarBackups)
+      .where(eq(schema.calendarBackups.userId, user.id))
+      .limit(1)
 
-    const result = await db.execute(sql<{
-      encrypted_data: string
-      iv: string
-      timestamp: Date
-    }>`
-      SELECT
-        ${sql.raw(columns.encryptedData)} AS encrypted_data,
-        iv,
-        ${sql.raw(columns.timestamp)} AS timestamp
-      FROM calendar_backups
-      WHERE ${sql.raw(columns.userId)} = ${user.id}
-      LIMIT 1
-    `)
-
-    if (result.rows.length === 0)
-      return jsonNoStore({ error: 'Not found' }, { status: 404 })
+    const backup = result[0]
+    if (!backup) return jsonNoStore({ error: 'Not found' }, { status: 404 })
 
     return jsonNoStore({
-      ciphertext: result.rows[0].encrypted_data,
-      iv: result.rows[0].iv,
-      timestamp: result.rows[0].timestamp,
+      ciphertext: backup.encryptedData,
+      iv: backup.iv,
+      timestamp: backup.timestamp,
       backend: 'postgres',
     })
   } catch (e: unknown) {
@@ -206,12 +153,9 @@ export async function DELETE() {
     if (!user)
       return NextResponse.json({ error: 'Unauthorized' }, { status: 401 })
 
-    const columns = await getBackupColumns()
-
-    await db.execute(sql`
-      DELETE FROM calendar_backups
-      WHERE ${sql.raw(columns.userId)} = ${user.id}
-    `)
+    await db
+      .delete(schema.calendarBackups)
+      .where(eq(schema.calendarBackups.userId, user.id))
 
     return NextResponse.json({ success: true, backend: 'postgres' })
   } catch (e: unknown) {


### PR DESCRIPTION
### Motivation
- 修复在从 Prisma 迁移到 Drizzle 后，`/api/blob` 因动态 SQL / 列名探测与原生 `sql.raw` 拼接导致的偶发 500 错误。

### Description
- 移除运行时建表、列名探测与原生 `sql` 分支，改为直接使用 Drizzle schema：引入 `schema` 并用类型安全的操作替代原生 SQL。
- `POST /api/blob` 改为 `db.insert(schema.calendarBackups).values(...).onConflictDoUpdate(...)`，替换原先的 `INSERT ... ON CONFLICT` 原生拼接实现。
- `GET /api/blob` 改为 `db.select(...).from(schema.calendarBackups).where(eq(...)).limit(1)` 并使用返回的首条数据；`DELETE /api/blob` 改为 `db.delete(schema.calendarBackups).where(eq(...))`。
- 更新了导入：移除对 `sql` 的依赖，新增 `eq` 和 `schema` 的导入，删除兼容函数 `initDB` / `getBackupColumns`。

### Testing
- 未运行任何自动化测试或 lint（按仓库/任务要求未执行自动测试）。

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69ec1f3fdba08326b68d3d096eca3000)

## 由 Sourcery 提供的总结

将基于动态 SQL 的日历备份 API 替换为基于模式（schema）的 Drizzle 操作，以在 ORM 迁移后提高可靠性。

Bug 修复：
- 修复在迁移到 Drizzle 之后，由于使用原始 SQL 在运行时检测表和列，导致 `/api/blob` 上偶发性 500 错误的问题。

功能增强：
- 使用带类型的 Drizzle schema 来插入、更新、查询和删除 `calendar_backups` 记录，而不是使用原始 SQL 和运行时元数据探测。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Replace dynamic SQL-based calendar backup API with schema-based Drizzle operations to improve reliability after the ORM migration.

Bug Fixes:
- Fix intermittent 500 errors on /api/blob caused by runtime table and column detection with raw SQL after migrating to Drizzle.

Enhancements:
- Use typed Drizzle schema for inserting, updating, selecting, and deleting calendar_backups records instead of raw SQL and runtime metadata probing.

</details>