### PR TITLE
fix: improve auth/profile flows, sharing identity, reset UX, and locales

### DIFF
--- a/components/app/event/event-preview.tsx
+++ b/components/app/event/event-preview.tsx
@@ -344,9 +344,9 @@ export default function EventPreview({
       setIsSharing(true)
       const shareId =
         Date.now().toString() + Math.random().toString(36).substring(2, 9)
-      const clerkUsername =
-        user?.username || user?.firstName || 'Anonymous'
-      const sharedEvent = { ...event, sharedBy: clerkUsername }
+      const sharedByName =
+        user?.name || user?.username || user?.firstName || user?.email || 'User'
+      const sharedEvent = { ...event, sharedBy: sharedByName }
 
       const payload: any = { id: shareId, data: sharedEvent }
       if (passwordEnabled) payload.password = sharePassword
@@ -416,7 +416,7 @@ export default function EventPreview({
           id: shareId,
           eventId: event.id,
           eventTitle: event.title,
-          sharedBy: clerkUsername,
+          sharedBy: sharedByName,
           shareDate: new Date().toISOString(),
           shareLink: link,
           protected: !!passwordEnabled,

--- a/components/app/profile/user-profile-button.tsx
+++ b/components/app/profile/user-profile-button.tsx
@@ -247,7 +247,7 @@ export default function UserProfileButton({
   const [pendingEmail, setPendingEmail] = useState('')
   const [changePasswordValue, setChangePasswordValue] = useState('')
   const [emailStep, setEmailStep] = useState<1 | 2>(1)
-  const [twoFaStep, setTwoFaStep] = useState<1 | 2>(1)
+  const [twoFaStep, setTwoFaStep] = useState<1 | 2 | 3>(1)
   const [profileSaving, setProfileSaving] = useState(false)
   const [avatarUploading, setAvatarUploading] = useState(false)
   const [twoFactorPassword, setTwoFactorPassword] = useState('')
@@ -435,21 +435,25 @@ export default function UserProfileButton({
 
   async function sendEmailChangeOtp() {
     if (!newEmail || !twoFactorPassword) return
+    setTwoFactorPending(true)
     const res = await authClient.emailOtp.sendVerificationOtp({
       email: newEmail,
       type: 'email-verification',
     })
     if (res.error) {
       toast(res.error.message || 'Failed to send verification code.')
+      setTwoFactorPending(false)
       return
     }
     setPendingEmail(newEmail)
     setEmailStep(2)
+    setTwoFactorPending(false)
     toast('Verification code sent to the new email.')
   }
 
   async function confirmEmailChange() {
     if (!pendingEmail || !emailOtp || !twoFactorPassword) return
+    setTwoFactorPending(true)
     const verifyRes = await authClient.emailOtp.verifyEmail({
       email: pendingEmail,
       otp: emailOtp,
@@ -457,6 +461,7 @@ export default function UserProfileButton({
     } as any)
     if (verifyRes.error) {
       toast(verifyRes.error.message || 'Invalid verification code.')
+      setTwoFactorPending(false)
       return
     }
     const updateRes = await authClient.changeEmail({
@@ -466,6 +471,7 @@ export default function UserProfileButton({
     } as any)
     if (updateRes.error) {
       toast(updateRes.error.message || 'Failed to update email.')
+      setTwoFactorPending(false)
       return
     }
     setNewEmail('')
@@ -473,6 +479,9 @@ export default function UserProfileButton({
     setEmailOtp('')
     toast('Email updated successfully.')
     await authClient.getSession()
+    setEmailStep(1)
+    setTwoFactorPassword('')
+    setTwoFactorPending(false)
   }
 
   async function confirmChangePassword() {
@@ -737,6 +746,7 @@ export default function UserProfileButton({
     }
     toast('2FA setup verified.')
     setTwoFactorCode('')
+    setTwoFaStep(3)
     setTwoFactorPending(false)
   }
   async function deleteAccount() {
@@ -823,7 +833,7 @@ export default function UserProfileButton({
             <>
               <div className="flex items-center gap-3">
                 <img
-                  src={user?.image || '/placeholder.svg'}
+                  src={user?.image || '/user.png'}
                   alt="avatar"
                   width={40}
                   height={40}
@@ -1028,7 +1038,7 @@ export default function UserProfileButton({
                   <div className="flex items-center gap-3">
                     <img
                       src={
-                        user?.image || '/placeholder.svg'
+                        user?.image || '/user.png'
                       }
                       alt="avatar"
                       width={52}
@@ -1128,25 +1138,28 @@ export default function UserProfileButton({
                       <Input type="password" value={twoFactorPassword} onChange={(e) => setTwoFactorPassword(e.target.value)} />
                     </div>
                     <div className="flex gap-2">
-                      <Button variant="outline" onClick={enableTwoFactor} disabled={twoFactorPending || twoFactorEnabled}>{t.next}</Button>
-                      <Button variant="outline" onClick={disableTwoFactor} disabled={twoFactorPending || !twoFactorEnabled}>{t.disable2fa}</Button>
+                      <Button variant="outline" onClick={enableTwoFactor} disabled={twoFactorPending || twoFactorEnabled || !twoFactorPassword}>{t.next}</Button>
+                      <Button variant="outline" onClick={disableTwoFactor} disabled={twoFactorPending || !twoFactorEnabled || !twoFactorPassword}>{t.disable2fa}</Button>
                     </div>
                   </>
                 ) : null}
                 {twoFaStep === 2 && twoFactorUri ? (
-                  <div className="space-y-2">
-                    <Label>{t.scanQrFor2fa}</Label>
-                    <img src={`https://api.qrserver.com/v1/create-qr-code/?size=220x220&data=${encodeURIComponent(twoFactorUri)}`} alt="2fa qr" className="h-44 w-44 rounded-md border" />
+                  <div className="space-y-3">
+                    <div className="space-y-2">
+                      <Label>{t.scanQrFor2fa}</Label>
+                      <img src={`https://api.qrserver.com/v1/create-qr-code/?size=220x220&data=${encodeURIComponent(twoFactorUri)}`} alt="2fa qr" className="h-44 w-44 rounded-md border" />
+                    </div>
+                    <div className="space-y-2">
+                      <Label>{t.otpCode}</Label>
+                      <Input value={twoFactorCode} onChange={(e) => setTwoFactorCode(e.target.value.replace(/\D/g, '').slice(0, 6))} />
+                    </div>
+                    <div className="flex gap-2">
+                      <Button variant="outline" onClick={verifyTwoFactorSetup} disabled={twoFactorPending || twoFactorCode.length < 6}>{t.verify2faCode}</Button>
+                      <Button variant="outline" onClick={() => setTwoFaStep(1)}>{t.back}</Button>
+                    </div>
                   </div>
                 ) : null}
-                <div className="space-y-2">
-                  <Label>{t.otpCode}</Label>
-                  <Input value={twoFactorCode} onChange={(e) => setTwoFactorCode(e.target.value.replace(/\D/g, '').slice(0, 6))} />
-                  <div className="flex gap-2">
-                    <Button variant="outline" onClick={verifyTwoFactorSetup} disabled={twoFactorPending || twoFactorCode.length < 6}>{t.verify2faCode}</Button>
-                    <Button variant="outline" onClick={() => setTwoFaStep(1)}>{t.back}</Button>
-                  </div>
-                </div>
+                {twoFaStep === 3 ? <p className="text-sm text-muted-foreground">{t.twoFactorEnabledMessage}</p> : null}
               </section>
 
               <section

--- a/components/app/profile/user-profile-button.tsx
+++ b/components/app/profile/user-profile-button.tsx
@@ -47,6 +47,7 @@ import { useCalendar } from '@/components/providers/calendar-context'
 import { translations, useLanguage } from '@/lib/i18n'
 import { authClient } from '@/lib/auth-client'
 import { useRouter } from 'next/navigation'
+import QRCodeStyling from 'qr-code-styling'
 import {
   decryptPayload,
   encryptPayload,
@@ -255,6 +256,8 @@ export default function UserProfileButton({
   const [twoFactorPending, setTwoFactorPending] = useState(false)
   const [twoFactorEnabled, setTwoFactorEnabled] = useState(false)
   const [twoFactorUri, setTwoFactorUri] = useState('')
+  const [twoFactorQrCode, setTwoFactorQrCode] = useState('')
+  const twoFactorQrCodeRef = useRef<string | null>(null)
 
   const keyRef = useRef<string | null>(null)
   const lastBackupSnapshotRef = useRef<string | null>(null)
@@ -299,6 +302,14 @@ export default function UserProfileButton({
     setFirstName(parts[0] || '')
     setLastName(parts.slice(1).join(' '))
   }, [user])
+
+  useEffect(() => {
+    return () => {
+      if (twoFactorQrCodeRef.current) {
+        URL.revokeObjectURL(twoFactorQrCodeRef.current)
+      }
+    }
+  }, [])
 
   useEffect(() => {
     if (mode === 'settings') return
@@ -713,7 +724,26 @@ export default function UserProfileButton({
       setTwoFactorPending(false)
       return
     }
-    setTwoFactorUri((setupRes as any).data?.totpURI || (setupRes as any).data?.totpUri || '')
+    const totpUri = (setupRes as any).data?.totpURI || (setupRes as any).data?.totpUri || ''
+    setTwoFactorUri(totpUri)
+    if (totpUri) {
+      const qrCode = new QRCodeStyling({
+        width: 220,
+        height: 220,
+        type: 'canvas',
+        data: totpUri,
+        margin: 2,
+      })
+      const qrBlob = await qrCode.getRawData('png')
+      if (qrBlob) {
+        if (twoFactorQrCodeRef.current) {
+          URL.revokeObjectURL(twoFactorQrCodeRef.current)
+        }
+        const qrUrl = URL.createObjectURL(qrBlob)
+        twoFactorQrCodeRef.current = qrUrl
+        setTwoFactorQrCode(qrUrl)
+      }
+    }
     setTwoFactorEnabled(true)
     setTwoFaStep(2)
     setTwoFactorPending(false)
@@ -731,6 +761,12 @@ export default function UserProfileButton({
     }
     setTwoFactorEnabled(false)
     setTwoFaStep(1)
+    if (twoFactorQrCodeRef.current) {
+      URL.revokeObjectURL(twoFactorQrCodeRef.current)
+      twoFactorQrCodeRef.current = null
+    }
+    setTwoFactorQrCode('')
+    setTwoFactorUri('')
     setTwoFactorPending(false)
     toast(t.twoFactorAuthentication)
   }
@@ -886,7 +922,7 @@ export default function UserProfileButton({
 
                     <div className="space-y-3 rounded-md border p-3">
                       <p className="text-sm font-semibold">{t.twoFactorAuthentication}</p>
-                      <p className="text-xs text-muted-foreground">Enable or disable TOTP-based 2FA.</p>
+                      <p className="text-xs text-muted-foreground">{t.twoFactorAuthenticationDescription}</p>
                       <Button variant="outline" onClick={() => openProfileSection('twofa')}>
                         <KeyRound className="h-4 w-4 mr-2" />
                         {t.openTwoFactorSettings}
@@ -895,7 +931,7 @@ export default function UserProfileButton({
 
                     <div className="space-y-3 rounded-md border p-3">
                       <p className="text-sm font-semibold">{t.changePassword}</p>
-                      <p className="text-xs text-muted-foreground">Use one-time email code to securely change your password.</p>
+                      <p className="text-xs text-muted-foreground">{t.changePasswordDescription}</p>
                       <Button variant="outline" onClick={() => openProfileSection('password')}>
                         <KeyRound className="h-4 w-4 mr-2" />
                         {t.openPasswordSettings}
@@ -1147,7 +1183,7 @@ export default function UserProfileButton({
                   <div className="space-y-3">
                     <div className="space-y-2">
                       <Label>{t.scanQrFor2fa}</Label>
-                      <img src={`https://api.qrserver.com/v1/create-qr-code/?size=220x220&data=${encodeURIComponent(twoFactorUri)}`} alt="2fa qr" className="h-44 w-44 rounded-md border" />
+                      <img src={twoFactorQrCode} alt={t.twoFactorQrCodeAlt} className="h-44 w-44 rounded-md border" />
                     </div>
                     <div className="space-y-2">
                       <Label>{t.otpCode}</Label>

--- a/components/auth/login-form.tsx
+++ b/components/auth/login-form.tsx
@@ -126,6 +126,12 @@ export function LoginForm({ className, ...props }: React.ComponentPropsWithoutRe
               </div>
             </form>
           )}
+
+        <div className="text-balance text-center text-xs text-muted-foreground [&_a]:underline [&_a]:underline-offset-4 [&_a]:hover:text-primary">
+          By clicking continue, you agree to our{' '}
+          <a href="/terms">Terms of Service</a> and{' '}
+          <a href="/privacy">Privacy Policy</a>.
+        </div>
         </CardContent>
       </Card>
     </div>

--- a/components/auth/reset-form.tsx
+++ b/components/auth/reset-form.tsx
@@ -21,6 +21,7 @@ export function ResetPasswordForm({ className, ...props }: React.ComponentPropsW
   const [isLoading, setIsLoading] = useState(false)
   const [error, setError] = useState('')
   const [done, setDone] = useState(false)
+  const [notice, setNotice] = useState('')
   const [isCaptchaCompleted, setIsCaptchaCompleted] = useState(process.env.NEXT_PUBLIC_TURNSTILE_SITE_KEY ? false : true)
 
   const handleSubmit = async (e: React.FormEvent) => {
@@ -28,9 +29,11 @@ export function ResetPasswordForm({ className, ...props }: React.ComponentPropsW
     if (process.env.NEXT_PUBLIC_TURNSTILE_SITE_KEY && !isCaptchaCompleted) return setError('Please complete the CAPTCHA verification.')
     setIsLoading(true)
     setError('')
+    setNotice('')
     const res = await authClient.forgetPassword({ email, redirectTo: '/reset-password' } as never)
     if (!res.error) {
       setDone(true)
+      setNotice('Reset email sent. Please check your inbox.')
       setIsLoading(false)
       return
     }
@@ -50,7 +53,7 @@ export function ResetPasswordForm({ className, ...props }: React.ComponentPropsW
         }
       } catch {}
     }
-    if (fallbackSucceeded) setDone(true)
+    if (fallbackSucceeded) { setDone(true); setNotice('Reset email sent. Please check your inbox.') }
     else setError(res.error.message || 'An error occurred. Please try again.')
     setIsLoading(false)
   }
@@ -122,12 +125,19 @@ export function ResetPasswordForm({ className, ...props }: React.ComponentPropsW
                   }}
                 />
               )}
+              {!isTokenFlow && notice ? <div className="text-sm text-emerald-600">{notice}</div> : null}
               {error && <div className="text-sm text-red-500">{error}</div>}
               <Button type="submit" className="w-full bg-[#0066ff] text-white hover:bg-[#0047cc]" disabled={isLoading || !isCaptchaCompleted}>
                 {isLoading ? (isTokenFlow ? 'Updating...' : 'Sending...') : isTokenFlow ? 'Update password' : 'Send reset email'}
               </Button>
             </div>
           </form>
+
+        <div className="text-balance text-center text-xs text-muted-foreground [&_a]:underline [&_a]:underline-offset-4 [&_a]:hover:text-primary">
+          By clicking continue, you agree to our{' '}
+          <a href="/terms">Terms of Service</a> and{' '}
+          <a href="/privacy">Privacy Policy</a>.
+        </div>
         </CardContent>
       </Card>
     </div>

--- a/components/auth/sign-up-form.tsx
+++ b/components/auth/sign-up-form.tsx
@@ -195,6 +195,12 @@ export function SignUpForm({ className, ...props }: React.ComponentPropsWithoutR
               </div>
             </form>
           )}
+
+        <div className="text-balance text-center text-xs text-muted-foreground [&_a]:underline [&_a]:underline-offset-4 [&_a]:hover:text-primary">
+          By clicking continue, you agree to our{' '}
+          <a href="/terms">Terms of Service</a> and{' '}
+          <a href="/privacy">Privacy Policy</a>.
+        </div>
         </CardContent>
       </Card>
     </div>

--- a/locales/en.json
+++ b/locales/en.json
@@ -558,4 +558,10 @@
   "updatePassword": "Update password"
 ,
   "twoFactorEnabledMessage": "Two-factor authentication is now active on your account."
+,
+  "twoFactorAuthenticationDescription": "Enable or disable TOTP-based 2FA."
+,
+  "changePasswordDescription": "Use one-time email code to securely change your password."
+,
+  "twoFactorQrCodeAlt": "Two-factor QR code"
 }

--- a/locales/en.json
+++ b/locales/en.json
@@ -554,4 +554,8 @@
   "next": "Next",
   "back": "Back",
   "scanQrFor2fa": "Scan this QR code in your authenticator app"
+,
+  "updatePassword": "Update password"
+,
+  "twoFactorEnabledMessage": "Two-factor authentication is now active on your account."
 }

--- a/locales/zh-CN.json
+++ b/locales/zh-CN.json
@@ -546,4 +546,8 @@
   "next": "下一步",
   "back": "上一步",
   "scanQrFor2fa": "在身份验证器应用中扫描此二维码"
+,
+  "updatePassword": "更新密码"
+,
+  "twoFactorEnabledMessage": "双重身份验证已在你的账户上启用。"
 }

--- a/locales/zh-CN.json
+++ b/locales/zh-CN.json
@@ -550,4 +550,10 @@
   "updatePassword": "更新密码"
 ,
   "twoFactorEnabledMessage": "双重身份验证已在你的账户上启用。"
+,
+  "twoFactorAuthenticationDescription": "启用或禁用基于 TOTP 的双重身份验证。"
+,
+  "changePasswordDescription": "使用一次性邮箱验证码安全地修改密码。"
+,
+  "twoFactorQrCodeAlt": "双重身份验证二维码"
 }


### PR DESCRIPTION
### Motivation
- Ensure shares show the real sharing identity by preferring the current Better Auth user's display name instead of falling back to anonymous. 
- Make email-change and 2FA flows in the profile UI robust and user-friendly by adding stepwise interactions and proper pending/error handling. 
- Improve reset-password UX so success feedback is visible under the input and add the standard legal footer to auth pages. 

### Description
- Updated share payload to use `user?.name || user?.username || user?.firstName || user?.email || 'User'` as the shared-by identity in `components/app/event/event-preview.tsx`. 
- Hardened the email-change flow in `components/app/profile/user-profile-button.tsx` by setting and clearing a pending state around `authClient.emailOtp` calls, resetting `emailStep` and clearing `twoFactorPassword` on success, and avoiding stuck states. 
- Reworked 2FA UI in `components/app/profile/user-profile-button.tsx` to a multi-step flow by adding a third step state, splitting password entry, QR display + code entry, and a completion message, and disabling actions until required fields are present. 
- Standardized avatar fallback to `'/user.png'` (public default) when `user.image` is absent in `components/app/profile/user-profile-button.tsx`. 
- Surface reset-email success as an inline notice under the input in `components/auth/reset-form.tsx`. 
- Added the legal footer block (Terms of Service / Privacy Policy) to the auth forms in `components/auth/login-form.tsx`, `components/auth/sign-up-form.tsx`, and `components/auth/reset-form.tsx`. 
- Added missing locale entries (`twoFactorEnabledMessage` and `updatePassword`) to `locales/en.json` and `locales/zh-CN.json` to support the updated UI text. 
- Files changed: `components/app/event/event-preview.tsx`, `components/app/profile/user-profile-button.tsx`, `components/auth/reset-form.tsx`, `components/auth/login-form.tsx`, `components/auth/sign-up-form.tsx`, `locales/en.json`, `locales/zh-CN.json`.

### Testing
- No automated tests were executed for this change (per request no eslint/tests/screenshots were run). 
- Changes were validated by static inspection and local edits to ensure UI text keys and component state transitions are present and integrated; no test failures to report.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f8251e23248326aa8484ea7d3f316a)