### PR TITLE
fix: add tamper-evident evlog audit logging

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -44,3 +44,5 @@ next-env.d.ts
 .turbo
 
 .env*.local
+.audit/
+.evlog/

--- a/app/api/account/route.ts
+++ b/app/api/account/route.ts
@@ -1,5 +1,5 @@
 import { NextResponse } from 'next/server'
-import { withEvlog, useLogger } from '@/lib/evlog'
+import { withEvlog, useLogger, getAuditActor } from '@/lib/evlog'
 import { getServerSession } from '@/lib/auth-server'
 import { db } from '@/lib/drizzle/client'
 import { shares, calendarBackups } from '@/lib/drizzle/schema'
@@ -15,7 +15,7 @@ export const DELETE = withEvlog(async function DELETE(_request: Request) {
     if (!user) {
       log.audit?.({
         action: 'account.delete',
-        actor: { type: 'system', id: 'anonymous' },
+        actor: getAuditActor(log),
         target: { type: 'account', id: 'unknown' },
         outcome: 'denied',
         reason: 'Authentication required',
@@ -42,7 +42,11 @@ export const DELETE = withEvlog(async function DELETE(_request: Request) {
 
     log.audit?.({
       action: 'account.delete',
-      actor: { type: 'user', id: user.id, email: user.email },
+      actor: getAuditActor(log, {
+        type: 'user',
+        id: user.id,
+        email: user.email,
+      }),
       target: { type: 'account', id: user.id },
       outcome: 'success',
       reason: 'User requested account data deletion',

--- a/app/api/account/route.ts
+++ b/app/api/account/route.ts
@@ -1,4 +1,5 @@
 import { NextResponse } from 'next/server'
+import { withEvlog, useLogger } from '@/lib/evlog'
 import { getServerSession } from '@/lib/auth-server'
 import { db } from '@/lib/drizzle/client'
 import { shares, calendarBackups } from '@/lib/drizzle/schema'
@@ -6,15 +7,23 @@ import { eq, sql } from 'drizzle-orm'
 
 export const runtime = 'nodejs'
 
-export async function DELETE() {
+export const DELETE = withEvlog(async function DELETE(_request: Request) {
   try {
+    const log = useLogger()
     const session = await getServerSession()
     const user = session?.user
-    if (!user)
+    if (!user) {
+      log.audit?.({
+        action: 'account.delete',
+        actor: { type: 'system', id: 'anonymous' },
+        target: { type: 'account', id: 'unknown' },
+        outcome: 'denied',
+        reason: 'Authentication required',
+      })
       return NextResponse.json({ error: 'Unauthorized' }, { status: 401 })
+    }
 
     await db.transaction(async (tx) => {
-      // Check if calendar_events table exists
       const hasCalendarEventsTable = await tx.execute(sql`
         SELECT 1 as ok FROM information_schema.tables WHERE table_schema = 'public' AND table_name = 'calendar_events' LIMIT 1
       `)
@@ -31,6 +40,14 @@ export async function DELETE() {
         .where(eq(calendarBackups.userId, user.id))
     })
 
+    log.audit?.({
+      action: 'account.delete',
+      actor: { type: 'user', id: user.id, email: user.email },
+      target: { type: 'account', id: user.id },
+      outcome: 'success',
+      reason: 'User requested account data deletion',
+    })
+
     return NextResponse.json({ success: true })
   } catch (e: any) {
     return NextResponse.json(
@@ -38,4 +55,4 @@ export async function DELETE() {
       { status: 500 },
     )
   }
-}
+})

--- a/app/api/auth/[...all]/route.ts
+++ b/app/api/auth/[...all]/route.ts
@@ -1,4 +1,52 @@
 import { auth } from '@/lib/auth'
+import { withEvlog, useLogger } from '@/lib/evlog'
 import { toNextJsHandler } from 'better-auth/next-js'
 
-export const { GET, POST } = toNextJsHandler(auth)
+const authHandlers = toNextJsHandler(auth)
+
+async function readAuthBody(request: Request) {
+  if (request.method !== 'POST') return null
+  try {
+    return (await request.clone().json()) as Record<string, unknown>
+  } catch {
+    return null
+  }
+}
+
+function authAction(pathname: string) {
+  if (pathname.endsWith('/sign-in/email')) return 'auth.login'
+  if (pathname.endsWith('/sign-out')) return 'auth.logout'
+  if (pathname.endsWith('/sign-up/email')) return 'auth.register'
+  if (pathname.includes('/reset-password')) return 'auth.password_reset'
+  return null
+}
+
+async function handleAuth(request: Request) {
+  const log = useLogger()
+  const pathname = new URL(request.url).pathname
+  const action = authAction(pathname)
+  const body = await readAuthBody(request)
+  const email = typeof body?.email === 'string' ? body.email : undefined
+  const response =
+    await authHandlers[request.method as keyof typeof authHandlers](request)
+
+  if (action) {
+    const success = response.status < 400
+    log.audit?.({
+      action,
+      actor: email
+        ? { type: 'user', id: email, email }
+        : { type: 'system', id: 'anonymous' },
+      target: { type: 'auth_session', id: email ?? 'unknown' },
+      outcome: success ? 'success' : 'failure',
+      reason: success
+        ? 'Better Auth request completed'
+        : `Better Auth request failed with status ${response.status}`,
+    })
+  }
+
+  return response
+}
+
+export const GET = withEvlog(handleAuth)
+export const POST = withEvlog(handleAuth)

--- a/app/api/auth/[...all]/route.ts
+++ b/app/api/auth/[...all]/route.ts
@@ -1,8 +1,18 @@
 import { auth } from '@/lib/auth'
-import { withEvlog, useLogger } from '@/lib/evlog'
+import { db } from '@/lib/drizzle/client'
+import { user as users } from '@/lib/drizzle/schema'
+import { anonymousAuditActor, withEvlog, useLogger } from '@/lib/evlog'
 import { toNextJsHandler } from 'better-auth/next-js'
+import { eq } from 'drizzle-orm'
 
 const authHandlers = toNextJsHandler(auth)
+
+type AuthAuditSubject = {
+  actor:
+    | typeof anonymousAuditActor
+    | { type: 'user'; id: string; email?: string }
+  target: { type: 'auth_identity'; id: string; email?: string }
+}
 
 async function readAuthBody(request: Request) {
   if (request.method !== 'POST') return null
@@ -21,23 +31,83 @@ function authAction(pathname: string) {
   return null
 }
 
+async function findUserByEmail(email: string) {
+  const [result] = await db
+    .select({ id: users.id, email: users.email })
+    .from(users)
+    .where(eq(users.email, email))
+    .limit(1)
+  return result ?? null
+}
+
+async function getExistingSessionSubject(
+  request: Request,
+): Promise<AuthAuditSubject | null> {
+  const session = await auth.api.getSession({ headers: request.headers })
+  const user = session?.user
+  if (!user?.id) return null
+
+  return {
+    actor: {
+      type: 'user',
+      id: user.id,
+      ...(user.email ? { email: user.email } : {}),
+    },
+    target: {
+      type: 'auth_identity',
+      id: user.id,
+      ...(user.email ? { email: user.email } : {}),
+    },
+  }
+}
+
+async function resolveAuthSubject(
+  request: Request,
+  email?: string,
+): Promise<AuthAuditSubject> {
+  const sessionSubject = await getExistingSessionSubject(request)
+  if (sessionSubject) return sessionSubject
+
+  if (email) {
+    const user = await findUserByEmail(email)
+    if (user) {
+      return {
+        actor: anonymousAuditActor,
+        target: { type: 'auth_identity', id: user.id, email: user.email },
+      }
+    }
+  }
+
+  return {
+    actor: anonymousAuditActor,
+    target: {
+      type: 'auth_identity',
+      id: 'unknown',
+      ...(email ? { email } : {}),
+    },
+  }
+}
+
 async function handleAuth(request: Request) {
   const log = useLogger()
   const pathname = new URL(request.url).pathname
   const action = authAction(pathname)
   const body = await readAuthBody(request)
   const email = typeof body?.email === 'string' ? body.email : undefined
+  let subject = await resolveAuthSubject(request, email)
   const response =
     await authHandlers[request.method as keyof typeof authHandlers](request)
 
   if (action) {
     const success = response.status < 400
+    if (success && subject.target.id === 'unknown') {
+      subject = await resolveAuthSubject(request, email)
+    }
+
     log.audit?.({
       action,
-      actor: email
-        ? { type: 'user', id: email, email }
-        : { type: 'system', id: 'anonymous' },
-      target: { type: 'auth_session', id: email ?? 'unknown' },
+      actor: subject.actor,
+      target: subject.target,
       outcome: success ? 'success' : 'failure',
       reason: success
         ? 'Better Auth request completed'

--- a/app/api/blob/route.ts
+++ b/app/api/blob/route.ts
@@ -1,4 +1,5 @@
 import { NextRequest, NextResponse } from 'next/server'
+import { withEvlog, useLogger } from '@/lib/evlog'
 import { getServerSession } from '@/lib/auth-server'
 import { db } from '@/lib/drizzle/client'
 import { calendarBackups } from '@/lib/drizzle/schema'
@@ -20,13 +21,23 @@ function jsonNoStore(body: unknown, init?: ResponseInit) {
   })
 }
 
-export async function POST(req: NextRequest) {
+export const POST = withEvlog(async function POST(req: NextRequest) {
   try {
+    const log = useLogger()
     const [session, body] = await Promise.all([getServerSession(), req.json()])
-    const userId = session?.user?.id
+    const user = session?.user
+    const userId = user?.id
 
-    if (!userId)
+    if (!userId) {
+      log.audit?.({
+        action: 'calendar_backup.upsert',
+        actor: { type: 'system', id: 'anonymous' },
+        target: { type: 'calendar_backup', id: 'unknown' },
+        outcome: 'denied',
+        reason: 'Authentication required',
+      })
       return NextResponse.json({ error: 'Unauthorized' }, { status: 401 })
+    }
 
     const encrypted_data = body?.ciphertext
     const iv = body?.iv
@@ -47,19 +58,37 @@ export async function POST(req: NextRequest) {
         set: { encryptedData: encrypted_data, iv, timestamp: new Date() },
       })
 
+    log.audit?.({
+      action: 'calendar_backup.upsert',
+      actor: { type: 'user', id: userId, email: user?.email },
+      target: { type: 'calendar_backup', id: userId },
+      outcome: 'success',
+      reason: 'User saved encrypted calendar backup',
+    })
     return NextResponse.json({ success: true, backend: 'postgres' })
   } catch (e: unknown) {
     const message = e instanceof Error ? e.message : 'Internal error'
     return NextResponse.json({ error: message }, { status: 500 })
   }
-}
+})
 
-export async function GET() {
+export const GET = withEvlog(async function GET(_req: NextRequest) {
   try {
+    const log = useLogger()
     const session = await getServerSession()
-    const userId = session?.user?.id
+    const user = session?.user
+    const userId = user?.id
 
-    if (!userId) return jsonNoStore({ error: 'Unauthorized' }, { status: 401 })
+    if (!userId) {
+      log.audit?.({
+        action: 'calendar_backup.export',
+        actor: { type: 'system', id: 'anonymous' },
+        target: { type: 'calendar_backup', id: 'unknown' },
+        outcome: 'denied',
+        reason: 'Authentication required',
+      })
+      return jsonNoStore({ error: 'Unauthorized' }, { status: 401 })
+    }
 
     const [result] = await db
       .select({
@@ -70,7 +99,24 @@ export async function GET() {
       .from(calendarBackups)
       .where(eq(calendarBackups.userId, userId))
 
-    if (!result) return jsonNoStore({ error: 'Not found' }, { status: 404 })
+    if (!result) {
+      log.audit?.({
+        action: 'calendar_backup.export',
+        actor: { type: 'user', id: userId, email: user?.email },
+        target: { type: 'calendar_backup', id: userId },
+        outcome: 'failure',
+        reason: 'No encrypted calendar backup found',
+      })
+      return jsonNoStore({ error: 'Not found' }, { status: 404 })
+    }
+
+    log.audit?.({
+      action: 'calendar_backup.export',
+      actor: { type: 'user', id: userId, email: user?.email },
+      target: { type: 'calendar_backup', id: userId },
+      outcome: 'success',
+      reason: 'User exported encrypted calendar backup',
+    })
 
     return jsonNoStore({
       ciphertext: result.encryptedData,
@@ -82,21 +128,39 @@ export async function GET() {
     const message = e instanceof Error ? e.message : 'Internal error'
     return jsonNoStore({ error: message }, { status: 500 })
   }
-}
+})
 
-export async function DELETE() {
+export const DELETE = withEvlog(async function DELETE(_req: NextRequest) {
   try {
+    const log = useLogger()
     const session = await getServerSession()
-    const userId = session?.user?.id
+    const user = session?.user
+    const userId = user?.id
 
-    if (!userId)
+    if (!userId) {
+      log.audit?.({
+        action: 'calendar_backup.delete',
+        actor: { type: 'system', id: 'anonymous' },
+        target: { type: 'calendar_backup', id: 'unknown' },
+        outcome: 'denied',
+        reason: 'Authentication required',
+      })
       return NextResponse.json({ error: 'Unauthorized' }, { status: 401 })
+    }
 
     await db.delete(calendarBackups).where(eq(calendarBackups.userId, userId))
+
+    log.audit?.({
+      action: 'calendar_backup.delete',
+      actor: { type: 'user', id: userId, email: user?.email },
+      target: { type: 'calendar_backup', id: userId },
+      outcome: 'success',
+      reason: 'User deleted encrypted calendar backup',
+    })
 
     return NextResponse.json({ success: true, backend: 'postgres' })
   } catch (e: unknown) {
     const message = e instanceof Error ? e.message : 'Internal error'
     return NextResponse.json({ error: message }, { status: 500 })
   }
-}
+})

--- a/app/api/blob/route.ts
+++ b/app/api/blob/route.ts
@@ -1,5 +1,5 @@
 import { NextRequest, NextResponse } from 'next/server'
-import { withEvlog, useLogger } from '@/lib/evlog'
+import { withEvlog, useLogger, getAuditActor } from '@/lib/evlog'
 import { getServerSession } from '@/lib/auth-server'
 import { db } from '@/lib/drizzle/client'
 import { calendarBackups } from '@/lib/drizzle/schema'
@@ -31,7 +31,7 @@ export const POST = withEvlog(async function POST(req: NextRequest) {
     if (!userId) {
       log.audit?.({
         action: 'calendar_backup.upsert',
-        actor: { type: 'system', id: 'anonymous' },
+        actor: getAuditActor(log),
         target: { type: 'calendar_backup', id: 'unknown' },
         outcome: 'denied',
         reason: 'Authentication required',
@@ -60,7 +60,11 @@ export const POST = withEvlog(async function POST(req: NextRequest) {
 
     log.audit?.({
       action: 'calendar_backup.upsert',
-      actor: { type: 'user', id: userId, email: user?.email },
+      actor: getAuditActor(log, {
+        type: 'user',
+        id: userId,
+        ...(user?.email ? { email: user.email } : {}),
+      }),
       target: { type: 'calendar_backup', id: userId },
       outcome: 'success',
       reason: 'User saved encrypted calendar backup',
@@ -82,7 +86,7 @@ export const GET = withEvlog(async function GET(_req: NextRequest) {
     if (!userId) {
       log.audit?.({
         action: 'calendar_backup.export',
-        actor: { type: 'system', id: 'anonymous' },
+        actor: getAuditActor(log),
         target: { type: 'calendar_backup', id: 'unknown' },
         outcome: 'denied',
         reason: 'Authentication required',
@@ -102,7 +106,11 @@ export const GET = withEvlog(async function GET(_req: NextRequest) {
     if (!result) {
       log.audit?.({
         action: 'calendar_backup.export',
-        actor: { type: 'user', id: userId, email: user?.email },
+        actor: getAuditActor(log, {
+          type: 'user',
+          id: userId,
+          ...(user?.email ? { email: user.email } : {}),
+        }),
         target: { type: 'calendar_backup', id: userId },
         outcome: 'failure',
         reason: 'No encrypted calendar backup found',
@@ -112,7 +120,11 @@ export const GET = withEvlog(async function GET(_req: NextRequest) {
 
     log.audit?.({
       action: 'calendar_backup.export',
-      actor: { type: 'user', id: userId, email: user?.email },
+      actor: getAuditActor(log, {
+        type: 'user',
+        id: userId,
+        ...(user?.email ? { email: user.email } : {}),
+      }),
       target: { type: 'calendar_backup', id: userId },
       outcome: 'success',
       reason: 'User exported encrypted calendar backup',
@@ -140,7 +152,7 @@ export const DELETE = withEvlog(async function DELETE(_req: NextRequest) {
     if (!userId) {
       log.audit?.({
         action: 'calendar_backup.delete',
-        actor: { type: 'system', id: 'anonymous' },
+        actor: getAuditActor(log),
         target: { type: 'calendar_backup', id: 'unknown' },
         outcome: 'denied',
         reason: 'Authentication required',
@@ -152,7 +164,11 @@ export const DELETE = withEvlog(async function DELETE(_req: NextRequest) {
 
     log.audit?.({
       action: 'calendar_backup.delete',
-      actor: { type: 'user', id: userId, email: user?.email },
+      actor: getAuditActor(log, {
+        type: 'user',
+        id: userId,
+        ...(user?.email ? { email: user.email } : {}),
+      }),
       target: { type: 'calendar_backup', id: userId },
       outcome: 'success',
       reason: 'User deleted encrypted calendar backup',

--- a/app/api/share/list/route.ts
+++ b/app/api/share/list/route.ts
@@ -1,4 +1,5 @@
-import { NextResponse } from 'next/server'
+import { type NextRequest, NextResponse } from 'next/server'
+import { withEvlog, useLogger } from '@/lib/evlog'
 import { getServerSession } from '@/lib/auth-server'
 import crypto from 'crypto'
 import { db } from '@/lib/drizzle/client'
@@ -30,11 +31,20 @@ function decryptWithKey(
   return decrypted
 }
 
-export async function GET() {
+export const GET = withEvlog(async function GET(_req: NextRequest) {
+  const log = useLogger()
   const session = await getServerSession()
   const user = session?.user
-  if (!user)
+  if (!user) {
+    log.audit?.({
+      action: 'share.list',
+      actor: { type: 'system', id: 'anonymous' },
+      target: { type: 'share_collection', id: 'unknown' },
+      outcome: 'denied',
+      reason: 'Authentication required',
+    })
     return NextResponse.json({ error: 'Unauthorized' }, { status: 401 })
+  }
 
   const result = await db
     .select()
@@ -72,5 +82,13 @@ export async function GET() {
     }
   })
 
+  log.audit?.({
+    action: 'share.list',
+    actor: { type: 'user', id: user.id, email: user.email },
+    target: { type: 'share_collection', id: user.id },
+    outcome: 'success',
+    reason: 'User listed shares',
+  })
+
   return NextResponse.json({ shares: shareList })
-}
+})

--- a/app/api/share/list/route.ts
+++ b/app/api/share/list/route.ts
@@ -1,5 +1,5 @@
 import { type NextRequest, NextResponse } from 'next/server'
-import { withEvlog, useLogger } from '@/lib/evlog'
+import { withEvlog, useLogger, getAuditActor } from '@/lib/evlog'
 import { getServerSession } from '@/lib/auth-server'
 import crypto from 'crypto'
 import { db } from '@/lib/drizzle/client'
@@ -38,7 +38,7 @@ export const GET = withEvlog(async function GET(_req: NextRequest) {
   if (!user) {
     log.audit?.({
       action: 'share.list',
-      actor: { type: 'system', id: 'anonymous' },
+      actor: getAuditActor(log),
       target: { type: 'share_collection', id: 'unknown' },
       outcome: 'denied',
       reason: 'Authentication required',
@@ -84,7 +84,11 @@ export const GET = withEvlog(async function GET(_req: NextRequest) {
 
   log.audit?.({
     action: 'share.list',
-    actor: { type: 'user', id: user.id, email: user.email },
+    actor: getAuditActor(log, {
+      type: 'user',
+      id: user.id,
+      email: user.email,
+    }),
     target: { type: 'share_collection', id: user.id },
     outcome: 'success',
     reason: 'User listed shares',

--- a/app/api/share/route.ts
+++ b/app/api/share/route.ts
@@ -1,5 +1,5 @@
 import { type NextRequest, NextResponse } from 'next/server'
-import { withEvlog, useLogger } from '@/lib/evlog'
+import { withEvlog, useLogger, getAuditActor } from '@/lib/evlog'
 import { getServerSession } from '@/lib/auth-server'
 import crypto from 'crypto'
 import { db } from '@/lib/drizzle/client'
@@ -70,7 +70,7 @@ export const POST = withEvlog(async function POST(request: NextRequest) {
     if (!user) {
       log.audit?.({
         action: 'share.create',
-        actor: { type: 'system', id: 'anonymous' },
+        actor: getAuditActor(log),
         target: { type: 'share', id },
         outcome: 'denied',
         reason: 'Authentication required',
@@ -116,7 +116,11 @@ export const POST = withEvlog(async function POST(request: NextRequest) {
 
     log.audit?.({
       action: 'share.create',
-      actor: { type: 'user', id: user.id, email: user.email },
+      actor: getAuditActor(log, {
+        type: 'user',
+        id: user.id,
+        email: user.email,
+      }),
       target: { type: 'share', id },
       outcome: 'success',
       reason: burn
@@ -188,7 +192,7 @@ export const GET = withEvlog(async function GET(request: NextRequest) {
     if (result.status === 404) {
       log.audit?.({
         action: 'share.export',
-        actor: { type: 'system', id: 'anonymous' },
+        actor: getAuditActor(log),
         target: { type: 'share', id },
         outcome: 'failure',
         reason: 'Share not found',
@@ -198,7 +202,7 @@ export const GET = withEvlog(async function GET(request: NextRequest) {
     if (result.status === 401) {
       log.audit?.({
         action: 'share.export',
-        actor: { type: 'system', id: 'anonymous' },
+        actor: getAuditActor(log),
         target: { type: 'share', id },
         outcome: 'denied',
         reason: 'Password required',
@@ -215,7 +219,7 @@ export const GET = withEvlog(async function GET(request: NextRequest) {
     if (result.status === 403) {
       log.audit?.({
         action: 'share.export',
-        actor: { type: 'system', id: 'anonymous' },
+        actor: getAuditActor(log),
         target: { type: 'share', id },
         outcome: 'denied',
         reason: result.protected
@@ -234,7 +238,7 @@ export const GET = withEvlog(async function GET(request: NextRequest) {
 
     log.audit?.({
       action: result.burnAfterRead ? 'share.burn_after_read' : 'share.export',
-      actor: { type: 'system', id: 'anonymous' },
+      actor: getAuditActor(log),
       target: { type: 'share', id },
       outcome: 'success',
       reason: result.burnAfterRead
@@ -272,7 +276,7 @@ export const DELETE = withEvlog(async function DELETE(request: NextRequest) {
   if (!user) {
     log.audit?.({
       action: 'share.delete',
-      actor: { type: 'system', id: 'anonymous' },
+      actor: getAuditActor(log),
       target: { type: 'share', id },
       outcome: 'denied',
       reason: 'Authentication required',
@@ -286,7 +290,11 @@ export const DELETE = withEvlog(async function DELETE(request: NextRequest) {
 
   log.audit?.({
     action: 'share.delete',
-    actor: { type: 'user', id: user.id, email: user.email },
+    actor: getAuditActor(log, {
+      type: 'user',
+      id: user.id,
+      email: user.email,
+    }),
     target: { type: 'share', id },
     outcome: 'success',
     reason: 'User deleted share',

--- a/app/api/share/route.ts
+++ b/app/api/share/route.ts
@@ -1,4 +1,5 @@
 import { type NextRequest, NextResponse } from 'next/server'
+import { withEvlog, useLogger } from '@/lib/evlog'
 import { getServerSession } from '@/lib/auth-server'
 import crypto from 'crypto'
 import { db } from '@/lib/drizzle/client'
@@ -48,8 +49,9 @@ function decryptWithKey(
   return decrypted
 }
 
-export async function POST(request: NextRequest) {
+export const POST = withEvlog(async function POST(request: NextRequest) {
   try {
+    const log = useLogger()
     const body = await request.json()
     const { id, data, password, burnAfterRead } = body as {
       id?: string
@@ -65,8 +67,16 @@ export async function POST(request: NextRequest) {
 
     const session = await getServerSession()
     const user = session?.user
-    if (!user)
+    if (!user) {
+      log.audit?.({
+        action: 'share.create',
+        actor: { type: 'system', id: 'anonymous' },
+        target: { type: 'share', id },
+        outcome: 'denied',
+        reason: 'Authentication required',
+      })
       return NextResponse.json({ error: 'Unauthorized' }, { status: 401 })
+    }
 
     const hasPassword = typeof password === 'string' && password.length > 0
     const burn = !!burnAfterRead
@@ -104,6 +114,16 @@ export async function POST(request: NextRequest) {
         },
       })
 
+    log.audit?.({
+      action: 'share.create',
+      actor: { type: 'user', id: user.id, email: user.email },
+      target: { type: 'share', id },
+      outcome: 'success',
+      reason: burn
+        ? 'User created burn-after-read share'
+        : 'User created share',
+    })
+
     return NextResponse.json({
       success: true,
       id,
@@ -120,9 +140,10 @@ export async function POST(request: NextRequest) {
       { status: 500 },
     )
   }
-}
+})
 
-export async function GET(request: NextRequest) {
+export const GET = withEvlog(async function GET(request: NextRequest) {
+  const log = useLogger()
   const id = request.nextUrl.searchParams.get('id')
   const password = request.nextUrl.searchParams.get('password') ?? ''
   if (!id)
@@ -164,9 +185,24 @@ export async function GET(request: NextRequest) {
       }
     })
 
-    if (result.status === 404)
+    if (result.status === 404) {
+      log.audit?.({
+        action: 'share.export',
+        actor: { type: 'system', id: 'anonymous' },
+        target: { type: 'share', id },
+        outcome: 'failure',
+        reason: 'Share not found',
+      })
       return NextResponse.json({ error: 'Share not found' }, { status: 404 })
-    if (result.status === 401)
+    }
+    if (result.status === 401) {
+      log.audit?.({
+        action: 'share.export',
+        actor: { type: 'system', id: 'anonymous' },
+        target: { type: 'share', id },
+        outcome: 'denied',
+        reason: 'Password required',
+      })
       return NextResponse.json(
         {
           error: 'Password required',
@@ -175,7 +211,17 @@ export async function GET(request: NextRequest) {
         },
         { status: 401 },
       )
-    if (result.status === 403)
+    }
+    if (result.status === 403) {
+      log.audit?.({
+        action: 'share.export',
+        actor: { type: 'system', id: 'anonymous' },
+        target: { type: 'share', id },
+        outcome: 'denied',
+        reason: result.protected
+          ? 'Invalid password'
+          : 'Failed to decrypt share data',
+      })
       return NextResponse.json(
         {
           error: result.protected
@@ -184,6 +230,17 @@ export async function GET(request: NextRequest) {
         },
         { status: 403 },
       )
+    }
+
+    log.audit?.({
+      action: result.burnAfterRead ? 'share.burn_after_read' : 'share.export',
+      actor: { type: 'system', id: 'anonymous' },
+      target: { type: 'share', id },
+      outcome: 'success',
+      reason: result.burnAfterRead
+        ? 'Burn-after-read share exported and deleted'
+        : 'Share exported',
+    })
 
     return NextResponse.json({
       success: true,
@@ -201,9 +258,10 @@ export async function GET(request: NextRequest) {
       { status: 500 },
     )
   }
-}
+})
 
-export async function DELETE(request: NextRequest) {
+export const DELETE = withEvlog(async function DELETE(request: NextRequest) {
+  const log = useLogger()
   const body = await request.json()
   const { id } = body as { id?: string }
   if (!id)
@@ -211,11 +269,28 @@ export async function DELETE(request: NextRequest) {
 
   const session = await getServerSession()
   const user = session?.user
-  if (!user)
+  if (!user) {
+    log.audit?.({
+      action: 'share.delete',
+      actor: { type: 'system', id: 'anonymous' },
+      target: { type: 'share', id },
+      outcome: 'denied',
+      reason: 'Authentication required',
+    })
     return NextResponse.json({ error: 'Unauthorized' }, { status: 401 })
+  }
 
   await db
     .delete(shares)
     .where(and(eq(shares.shareId, id), eq(shares.userId, user.id)))
+
+  log.audit?.({
+    action: 'share.delete',
+    actor: { type: 'user', id: user.id, email: user.email },
+    target: { type: 'share', id },
+    outcome: 'success',
+    reason: 'User deleted share',
+  })
+
   return NextResponse.json({ success: true })
-}
+})

--- a/app/api/verify/route.ts
+++ b/app/api/verify/route.ts
@@ -1,22 +1,17 @@
 import { NextRequest } from 'next/server'
 import { withEvlog, useLogger, createError } from '@/lib/evlog'
-import { auth } from '@/lib/auth'
 
 export const POST = withEvlog(async (request: NextRequest) => {
   const log = useLogger()
-  const session = await auth.api.getSession({ headers: request.headers })
-
-  if (session?.user) {
-    log.set('actor', { id: session.user.id, email: session.user.email })
-  }
-
   try {
     const { token, action } = await request.json()
     const secretKey = process.env.TURNSTILE_SECRET_KEY
 
-    log.set('body', {
-      token: token ? token.slice(0, 10) + '...' : null,
-      action,
+    log.set({
+      body: {
+        token: token ? token.slice(0, 10) + '...' : null,
+        action,
+      },
     })
 
     if (!token) {
@@ -27,7 +22,7 @@ export const POST = withEvlog(async (request: NextRequest) => {
         fix: 'Provide token',
       })
     }
-    
+
     if (!secretKey) {
       throw createError({
         message: 'Missing secret',
@@ -59,14 +54,15 @@ export const POST = withEvlog(async (request: NextRequest) => {
     }
 
     const data = await response.json()
-    log.set('cloudflareResponse', data)
+    log.set({ cloudflareResponse: data })
 
     if (data.success) {
-      log.audit({
-        action: 'verify_captcha',
-        actor: session?.user ? { id: session.user.id, email: session.user.email } : { id: 'anonymous' },
-        target: 'turnstile',
+      log.audit?.({
+        action: 'captcha.verify',
+        actor: { type: 'system', id: 'anonymous' },
+        target: { type: 'turnstile', id: action ?? 'unknown' },
         outcome: 'success',
+        reason: 'CAPTCHA verification succeeded',
       })
       return new Response(JSON.stringify({ success: true }), {
         status: 200,

--- a/app/api/verify/route.ts
+++ b/app/api/verify/route.ts
@@ -1,5 +1,5 @@
 import { NextRequest } from 'next/server'
-import { withEvlog, useLogger, createError } from '@/lib/evlog'
+import { withEvlog, useLogger, createError, getAuditActor } from '@/lib/evlog'
 
 export const POST = withEvlog(async (request: NextRequest) => {
   const log = useLogger()
@@ -59,7 +59,7 @@ export const POST = withEvlog(async (request: NextRequest) => {
     if (data.success) {
       log.audit?.({
         action: 'captcha.verify',
-        actor: { type: 'system', id: 'anonymous' },
+        actor: getAuditActor(log),
         target: { type: 'turnstile', id: action ?? 'unknown' },
         outcome: 'success',
         reason: 'CAPTCHA verification succeeded',

--- a/lib/evlog.ts
+++ b/lib/evlog.ts
@@ -1,21 +1,68 @@
-import { createEvlog } from 'evlog';
-import { createFsDrain } from 'evlog/adapters/fs';
-import { signed } from 'evlog/adapters/signed';
+import { auditEnricher, auditOnly, signed, type AuditActor } from 'evlog'
+import { createAuthMiddleware } from 'evlog/better-auth'
+import { createFsDrain } from 'evlog/fs'
+import { createEvlog } from 'evlog/next'
+import { auth } from '@/lib/auth'
 
-export const evlog = createEvlog({
-  service: 'one-calendar',
-  enrich: (event) => {
-    return {
-      ...event,
-      timestamp: new Date().toISOString(),
-    };
+const identify = createAuthMiddleware(auth)
+const mainDrain = createFsDrain({ dir: '.evlog/logs', pretty: false })
+const auditDrain = auditOnly(
+  signed(createFsDrain({ dir: '.audit', pretty: false }), {
+    strategy: 'hash-chain',
+  }),
+  { await: true },
+)
+
+function actorFromEvent(event: Record<string, unknown>): AuditActor | null {
+  const user = event.user
+  if (user && typeof user === 'object') {
+    const candidate = user as Record<string, unknown>
+    if (typeof candidate.id === 'string') {
+      return {
+        type: 'user',
+        id: candidate.id,
+        ...(typeof candidate.email === 'string'
+          ? { email: candidate.email }
+          : {}),
+        ...(typeof candidate.name === 'string'
+          ? { displayName: candidate.name }
+          : {}),
+      }
+    }
+  }
+
+  if (typeof event.userId === 'string')
+    return { type: 'user', id: event.userId }
+
+  return null
+}
+
+const auditEnrich = auditEnricher({
+  bridge: {
+    getSession: ({ event }) => actorFromEvent(event as Record<string, unknown>),
   },
-  drain: [
-    signed(createFsDrain({ dir: '.audit' }), {
-      strategy: 'hash-chain',
-      await: true,
-    }),
-  ],
-});
+})
 
-export const { withEvlog, useLogger, createError } = evlog;
+const evlog = createEvlog({
+  service: 'one-calendar',
+  drain: async (ctx) => {
+    const results = await Promise.allSettled([mainDrain(ctx), auditDrain(ctx)])
+    const rejected = results.find((result) => result.status === 'rejected')
+    if (rejected?.status === 'rejected') throw rejected.reason
+  },
+  enrich: auditEnrich,
+})
+
+const withEvlogBase = evlog.withEvlog
+
+export const withEvlog: typeof evlog.withEvlog = (handler) =>
+  withEvlogBase(async (...args: Parameters<typeof handler>) => {
+    const request = args[0]
+    if (request instanceof Request) {
+      const log = evlog.useLogger()
+      await identify(log, request.headers, new URL(request.url).pathname)
+    }
+    return handler(...args)
+  })
+
+export const { useLogger, log, createError, createEvlogError } = evlog

--- a/lib/evlog.ts
+++ b/lib/evlog.ts
@@ -1,4 +1,10 @@
-import { auditEnricher, auditOnly, signed, type AuditActor } from 'evlog'
+import {
+  auditEnricher,
+  auditOnly,
+  signed,
+  type AuditActor,
+  type RequestLogger,
+} from 'evlog'
 import { createAuthMiddleware } from 'evlog/better-auth'
 import { createFsDrain } from 'evlog/fs'
 import { createEvlog } from 'evlog/next'
@@ -12,6 +18,11 @@ const auditDrain = auditOnly(
   }),
   { await: true },
 )
+
+export const anonymousAuditActor = {
+  type: 'system',
+  id: 'anonymous',
+} satisfies AuditActor
 
 function actorFromEvent(event: Record<string, unknown>): AuditActor | null {
   const user = event.user
@@ -35,6 +46,13 @@ function actorFromEvent(event: Record<string, unknown>): AuditActor | null {
     return { type: 'user', id: event.userId }
 
   return null
+}
+
+export function getAuditActor(
+  logger: Pick<RequestLogger, 'getContext'>,
+  fallback: AuditActor = anonymousAuditActor,
+) {
+  return actorFromEvent(logger.getContext()) ?? fallback
 }
 
 const auditEnrich = auditEnricher({

--- a/package.json
+++ b/package.json
@@ -29,6 +29,7 @@
     "csv-parse": "latest",
     "date-fns": "4.1.0",
     "drizzle-orm": "^0.45.2",
+    "evlog": "^2.17.0",
     "framer-motion": "^12.7.4",
     "geist": "latest",
     "ics": "latest",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -53,6 +53,9 @@ importers:
       drizzle-orm:
         specifier: ^0.45.2
         version: 0.45.2(@electric-sql/pglite@0.4.1)(@prisma/client@7.8.0(prisma@7.8.0(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(typescript@6.0.3))(typescript@6.0.3))(@types/pg@8.20.0)(kysely@0.28.17)(mysql2@3.15.3)(pg@8.20.0)(postgres@3.4.9)(prisma@7.8.0(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(typescript@6.0.3))
+      evlog:
+        specifier: ^2.17.0
+        version: 2.17.0(hono@4.12.18)(next@16.2.6(@babel/core@7.29.0)(react-dom@18.3.1(react@18.3.1))(react@18.3.1))(react@18.3.1)
       framer-motion:
         specifier: ^12.7.4
         version: 12.38.0(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
@@ -3624,6 +3627,59 @@ packages:
   eventemitter3@5.0.4:
     resolution: {integrity: sha512-mlsTRyGaPBjPedk6Bvw+aqbsXDtoAyAzm5MO7JgU+yVRyMQ5O8bD4Kcci7BS85f93veegeCPkL8R4GLClnjLFw==}
 
+  evlog@2.17.0:
+    resolution: {integrity: sha512-v6PWFV0SAEB04l70vENByG6o4r2v8KXIUNroeqYQ6uXb2xEzRRgRCxiAsAntb+Tqd4xPKenX+X67v/KyM6ar5g==}
+    peerDependencies:
+      '@nestjs/common': '>=11.1.19'
+      '@nuxt/kit': ^4.4.2
+      '@tanstack/start-client-core': ^1.167.20
+      ai: '>=6.0.168'
+      elysia: '>=1.4.28'
+      express: '>=5.2.1'
+      fastify: '>=5.8.5'
+      h3: ^1.15.11
+      hono: ''
+      next: '>=16.2.4'
+      nitro: ^3.0.260311-beta
+      nitropack: ^2.13.3
+      ofetch: ^1.5.1
+      react: '>=19.2.5'
+      react-router: '>=7.14.2'
+      vite: ^7.0.0 || ^8.0.0
+    peerDependenciesMeta:
+      '@nestjs/common':
+        optional: true
+      '@nuxt/kit':
+        optional: true
+      '@tanstack/start-client-core':
+        optional: true
+      ai:
+        optional: true
+      elysia:
+        optional: true
+      express:
+        optional: true
+      fastify:
+        optional: true
+      h3:
+        optional: true
+      hono:
+        optional: true
+      next:
+        optional: true
+      nitro:
+        optional: true
+      nitropack:
+        optional: true
+      ofetch:
+        optional: true
+      react:
+        optional: true
+      react-router:
+        optional: true
+      vite:
+        optional: true
+
   exsolve@1.0.8:
     resolution: {integrity: sha512-LmDxfWXwcTArk8fUEnOfSZpHOJ6zOMUJKOtFLFqJLoKJetuQG874Uc7/Kki7zFLzYybmZhp1M7+98pfMqeX8yA==}
 
@@ -5233,6 +5289,7 @@ packages:
 
   uuid@8.3.2:
     resolution: {integrity: sha512-+NYs2QeMWy+GWFOEm9xnn6HCDp0l7QBD7ml8zLUmJ+93Q5NF0NocErnwkTkXVFNiX3/fpC6afS8Dhb/gz7R7eg==}
+    deprecated: uuid@10 and below is no longer supported.  For ESM codebases, update to uuid@latest.  For CommonJS codebases, use uuid@11 (but be aware this version will likely be deprecated in 2028).
     hasBin: true
 
   valibot@1.2.0:
@@ -8621,6 +8678,12 @@ snapshots:
   esutils@2.0.3: {}
 
   eventemitter3@5.0.4: {}
+
+  evlog@2.17.0(hono@4.12.18)(next@16.2.6(@babel/core@7.29.0)(react-dom@18.3.1(react@18.3.1))(react@18.3.1))(react@18.3.1):
+    optionalDependencies:
+      hono: 4.12.18
+      next: 16.2.6(@babel/core@7.29.0)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+      react: 18.3.1
 
   exsolve@1.0.8:
     optional: true


### PR DESCRIPTION
### Motivation

- Add a tamper-evident audit log on top of the existing evlog usage so security-sensitive actions are always retained and verifiable.
- Auto-identify Better Auth sessions on every request and surface actor fields in audit entries for reliable attribution.
- Ensure audit events are force-kept past sampling and written to a signed, hash-chain-backed store before responses return.

### Description

- Installed and configured `evlog` and wired a Next.js integration in `lib/evlog.ts` with a primary filesystem drain and a separate `auditOnly(signed(createFsDrain({ dir: '.audit' }), { strategy: 'hash-chain' }), { await: true })` audit drain running alongside it.
- Added `createAuthMiddleware` (Better Auth bridge) and a `withEvlog` wrapper that calls `identify(log, headers, path)` so `actor.id` / `actor.email` are auto-populated on request loggers.
- Registered `auditEnricher` (via `auditEnricher({ bridge })`) to populate request/runtime context and fill `event.audit.actor` from Better Auth when missing.
- Emitted `log.audit(...)` events for security-sensitive flows across API routes (auth endpoints, account deletion, calendar backup create/export/delete, share create/list/export/delete, CAPTCHA verification) and added deny/success/failure outcomes where appropriate.
- Updated package files to add `evlog`, added `.audit/` and `.evlog/` to `.gitignore`, and adjusted `pnpm-lock.yaml` accordingly.

### Testing

- Ran `pnpm exec eslint` on the modified files (routes and `lib/evlog.ts`) and the lint tasks completed successfully.
- Verified that changed files do not introduce new TypeScript errors using the focused check (`pnpm exec tsc --noEmit ... | tee /tmp/one-calendar-tsc.log` filtered for unrelated paths) which reported no new errors for the modified files.
- Ran full type-check with `pnpm run type-check` which failed due to preexisting, unrelated project-wide TypeScript errors outside the modified evlog/audit files (UI/analytics types and other unrelated modules), so the audit changes themselves are type-safe but the repo still has existing type issues.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69ffd8ba045c8326aa00c9692aa72f9c)

## Summary by Sourcery

使用 evlog 为安全敏感的 API 流程引入可篡改检测、带行为主体归属的审计日志。

New Features:
- 添加基于 evlog 的日志基础设施，提供文件系统和签名哈希链支持的审计 drain，并与 Next.js 和 Better Auth 集成，实现自动行为主体识别。
- 为认证、账户删除、日历备份、分享管理以及 CAPTCHA 验证等端点发出结构化审计事件，包括 action、actor、target、outcome 和 reason 等元数据。

Enhancements:
- 使用 evlog 中间件包装现有的 API 路由处理程序，确保请求上下文被捕获并一致地应用审计日志。
- 扩展 evlog helper 的导出，以支持更丰富的错误处理和在整个代码库中复用的日志工具。

Build:
- 添加 evlog 依赖，并在版本控制中忽略生成的日志和审计目录。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Introduce tamper-evident, actor-attributed audit logging for security-sensitive API flows using evlog.

New Features:
- Add evlog-based logging infrastructure with filesystem and signed hash-chain-backed audit drains, integrated with Next.js and Better Auth for automatic actor identification.
- Emit structured audit events for auth, account deletion, calendar backup, share management, and CAPTCHA verification endpoints, including action, actor, target, outcome, and reason metadata.

Enhancements:
- Wrap existing API route handlers with an evlog middleware to ensure request context is captured and audit logging is consistently applied.
- Extend the evlog helper exports to support richer error handling and shared logger utilities across the codebase.

Build:
- Add evlog dependency and ignore generated log and audit directories in version control.

</details>