### PR TITLE
Fix mobile sidebars, right-side dropdown and search results

### DIFF
--- a/components/app/calendar.tsx
+++ b/components/app/calendar.tsx
@@ -172,6 +172,7 @@ export default function Calendar({ className, ...props }: CalendarProps) {
   const [shareOnlyMode, setShareOnlyMode] = useState(false)
   const isMobile = useIsMobile()
   const [isMobileSearchActive, setIsMobileSearchActive] = useState(false)
+  const effectiveView = isMobile ? 'day' : view
 
   const updateEvent = (updatedEvent: CalendarEvent) => {
     setEvents((prevEvents) =>

--- a/components/app/calendar.tsx
+++ b/components/app/calendar.tsx
@@ -1,5 +1,7 @@
 'use client'
 
+import { MobileSidebar } from '@/components/app/sidebar/mobile/mobile-sidebar'
+import { MobileRightSidebar } from '@/components/app/sidebar/mobile/mobile-right-sidebar'
 import {
   checkPendingNotifications,
   clearAllNotificationTimers,
@@ -706,36 +708,69 @@ export default function Calendar({ className, ...props }: CalendarProps) {
     <div className={className}>
       <div className="relative flex h-dvh overflow-hidden bg-background">
         {}
-        <Sidebar
-          onCreateEvent={() => {
-            setSelectedEvent(null)
-            setQuickCreateStartTime(new Date())
-            setEventDialogOpen(true)
-          }}
-          onDateSelect={handleDateSelect}
-          onViewChange={handleViewChange}
-          language={language}
-          selectedDate={sidebarDate}
-          isCollapsed={isSidebarCollapsed}
-          onToggleCollapse={toggleSidebar}
-          onCollapseTransitionEnd={() => setIsSidebarExpanding(false)}
-          selectedCategoryFilters={selectedCategoryFilters}
-          onCategoryFilterChange={(categoryId, checked) => {
-            setSelectedCategoryFilters((prev) => {
-              if (checked) {
-                return prev.includes(categoryId) ? prev : [...prev, categoryId]
-              }
-              return prev.filter((id) => id !== categoryId)
-            })
-          }}
-        />
+        <div className="hidden md:flex">
+          <Sidebar
+            onCreateEvent={() => {
+              setSelectedEvent(null)
+              setQuickCreateStartTime(new Date())
+              setEventDialogOpen(true)
+            }}
+            onDateSelect={handleDateSelect}
+            onViewChange={handleViewChange}
+            language={language}
+            selectedDate={sidebarDate}
+            isCollapsed={isSidebarCollapsed}
+            onToggleCollapse={toggleSidebar}
+            onCollapseTransitionEnd={() => setIsSidebarExpanding(false)}
+            selectedCategoryFilters={selectedCategoryFilters}
+            onCategoryFilterChange={(categoryId, checked) => {
+              setSelectedCategoryFilters((prev) => {
+                if (checked) {
+                  return prev.includes(categoryId)
+                    ? prev
+                    : [...prev, categoryId]
+                }
+                return prev.filter((id) => id !== categoryId)
+              })
+            }}
+          />
+        </div>
 
         <div className="flex min-h-0 min-w-0 flex-1 flex-col">
           {' '}
           <header className="flex items-center px-4 h-16 border-b relative z-40 bg-background">
             <div className="pointer-events-none absolute right-0 bottom-0 h-px w-14 bg-background" />
             <div className="flex items-center space-x-4">
-              <Button variant="outline" onClick={toggleSidebar} size="sm">
+              <div className="md:hidden">
+                <MobileSidebar
+                  onCreateEvent={() => {
+                    setSelectedEvent(null)
+                    setQuickCreateStartTime(new Date())
+                    setEventDialogOpen(true)
+                  }}
+                  onDateSelect={handleDateSelect}
+                  onViewChange={handleViewChange}
+                  language={language}
+                  selectedDate={sidebarDate}
+                  selectedCategoryFilters={selectedCategoryFilters}
+                  onCategoryFilterChange={(categoryId, checked) => {
+                    setSelectedCategoryFilters((prev) => {
+                      if (checked) {
+                        return prev.includes(categoryId)
+                          ? prev
+                          : [...prev, categoryId]
+                      }
+                      return prev.filter((id) => id !== categoryId)
+                    })
+                  }}
+                />
+              </div>
+              <Button
+                variant="outline"
+                onClick={toggleSidebar}
+                size="sm"
+                className="hidden md:flex"
+              >
                 <PanelLeft />
               </Button>
               <Button variant="outline" size="sm" onClick={handleTodayClick}>
@@ -870,6 +905,12 @@ export default function Calendar({ className, ...props }: CalendarProps) {
                   {backupStatusIcon ?? <CloudUpload className="h-4 w-4" />}
                 </div>
               ) : null}
+              <div className="md:hidden">
+                <MobileRightSidebar
+                  onViewChange={handleViewChange}
+                  onEventClick={handleEventClick}
+                />
+              </div>
               <DropdownMenu>
                 <DropdownMenuTrigger asChild>
                   <Button
@@ -1061,10 +1102,12 @@ export default function Calendar({ className, ...props }: CalendarProps) {
         </div>
 
         {}
-        <RightSidebar
-          onViewChange={handleViewChange}
-          onEventClick={handleEventClick}
-        />
+        <div className="hidden md:block">
+          <RightSidebar
+            onViewChange={handleViewChange}
+            onEventClick={handleEventClick}
+          />
+        </div>
 
         {}
         <EventPreview

--- a/components/app/calendar.tsx
+++ b/components/app/calendar.tsx
@@ -173,7 +173,7 @@ export default function Calendar({ className, ...props }: CalendarProps) {
   const [shareOnlyMode, setShareOnlyMode] = useState(false)
   const isMobile = useIsMobile()
   const [isMobileSearchActive, setIsMobileSearchActive] = useState(false)
-  const effectiveView = isMobile ? 'day' : view
+  const effectiveView = isMobile && isCalendarView(view) ? 'day' : view
 
   const updateEvent = (updatedEvent: CalendarEvent) => {
     setEvents((prevEvents) =>
@@ -770,7 +770,7 @@ export default function Calendar({ className, ...props }: CalendarProps) {
                   >
                     <X className="h-5 w-5" />
                   </Button>
-                  <div className="flex-1">
+                  <div className="relative flex-1">
                     <Input
                       autoFocus
                       placeholder={t.searchEvents}
@@ -790,35 +790,75 @@ export default function Calendar({ className, ...props }: CalendarProps) {
                         }
                       }}
                     />
+                    {!!searchTerm && (
+                      <div className="absolute right-0 top-[calc(100%+6px)] z-50 w-[calc(100vw-72px)] rounded-md border bg-popover p-1 shadow-md">
+                        {searchResultEvents.length > 0 ? (
+                          <ScrollArea className="max-h-[320px]">
+                            <div className="space-y-1">
+                              {searchResultEvents.map((event) => (
+                                <button
+                                  key={event.id}
+                                  type="button"
+                                  className="w-full cursor-pointer rounded-sm px-2 py-1.5 text-left hover:bg-accent"
+                                  onMouseDown={(e) => {
+                                    e.preventDefault()
+                                    setPreviewEvent(event)
+                                    setPreviewAnchorRect(null)
+                                    setPreviewOpen(true)
+                                    setSearchTerm('')
+                                    setIsMobileSearchActive(false)
+                                  }}
+                                >
+                                  <div className="font-medium leading-none">
+                                    {event.title || t.unnamedEvent}
+                                  </div>
+                                  <div className="text-xs text-muted-foreground mt-1">
+                                    {formatDateDisplay(
+                                      new Date(event.startDate),
+                                    )}
+                                  </div>
+                                </button>
+                              ))}
+                            </div>
+                          </ScrollArea>
+                        ) : (
+                          <div className="px-2 py-1.5 text-sm text-muted-foreground">
+                            {t.noMatchingEvents}
+                          </div>
+                        )}
+                      </div>
+                    )}
                   </div>
                 </div>
               ) : (
                 <>
                   <div className="flex items-center space-x-2 md:space-x-4">
-                    <div className="md:hidden">
-                      <MobileSidebar
-                        onCreateEvent={() => {
-                          setSelectedEvent(null)
-                          setQuickCreateStartTime(new Date())
-                          setEventDialogOpen(true)
-                        }}
-                        onDateSelect={handleDateSelect}
-                        onViewChange={handleViewChange}
-                        language={language}
-                        selectedDate={sidebarDate}
-                        selectedCategoryFilters={selectedCategoryFilters}
-                        onCategoryFilterChange={(categoryId, checked) => {
-                          setSelectedCategoryFilters((prev) => {
-                            if (checked) {
-                              return prev.includes(categoryId)
-                                ? prev
-                                : [...prev, categoryId]
-                            }
-                            return prev.filter((id) => id !== categoryId)
-                          })
-                        }}
-                      />
-                    </div>
+                    {isMobile && (
+                      <div className="md:hidden">
+                        <MobileSidebar
+                          onCreateEvent={() => {
+                            setSelectedEvent(null)
+                            setQuickCreateStartTime(new Date())
+                            setEventDialogOpen(true)
+                          }}
+                          onDateSelect={handleDateSelect}
+                          onViewChange={handleViewChange}
+                          language={language}
+                          selectedDate={sidebarDate}
+                          selectedCategoryFilters={selectedCategoryFilters}
+                          onCategoryFilterChange={(categoryId, checked) => {
+                            setSelectedCategoryFilters((prev) => {
+                              if (checked) {
+                                return prev.includes(categoryId)
+                                  ? prev
+                                  : [...prev, categoryId]
+                              }
+                              return prev.filter((id) => id !== categoryId)
+                            })
+                          }}
+                        />
+                      </div>
+                    )}
                     <Button
                       variant="outline"
                       onClick={toggleSidebar}
@@ -992,6 +1032,11 @@ export default function Calendar({ className, ...props }: CalendarProps) {
                           )}
                         </div>
                       )}
+                    {isMobile && (
+                      <div className="md:hidden">
+                        <MobileRightSidebar onEventClick={handleEventClick} />
+                      </div>
+                    )}
                     {backupEnabled ? (
                       <div
                         className="inline-flex h-8 w-8 items-center justify-center rounded-full border"
@@ -1057,19 +1102,16 @@ export default function Calendar({ className, ...props }: CalendarProps) {
                       onNavigateToSettings={handleUserProfileSectionNavigate}
                       onNavigateToView={setView}
                     />
-                    <div className="md:hidden">
-                      <MobileRightSidebar
-                        onViewChange={handleViewChange}
-                        onEventClick={handleEventClick}
-                      />
-                    </div>
                   </div>
                 </>
               )}
             </div>
           </header>
-          <div className={cn('flex-1 overflow-auto', !isMobile && 'pr-14')} ref={calendarRef}>
-            {isMobile && (
+          <div
+            className={cn('flex-1 overflow-auto', !isMobile && 'pr-14')}
+            ref={calendarRef}
+          >
+            {isMobile && effectiveView === 'day' && (
               <Button
                 className="fixed bottom-6 right-6 h-14 w-14 rounded-full shadow-lg z-50 bg-[#0066FF] hover:bg-[#0052CC]"
                 onClick={() => {
@@ -1083,7 +1125,6 @@ export default function Calendar({ className, ...props }: CalendarProps) {
             )}
             {effectiveView === 'day' && (
               <DayView
-
                 date={date}
                 events={filteredEvents}
                 onEventClick={handleEventClick}

--- a/components/app/calendar.tsx
+++ b/components/app/calendar.tsx
@@ -2,6 +2,7 @@
 
 import { MobileSidebar } from '@/components/app/sidebar/mobile/mobile-sidebar'
 import { MobileRightSidebar } from '@/components/app/sidebar/mobile/mobile-right-sidebar'
+import { useIsMobile } from '@/hooks/useMobile'
 import {
   checkPendingNotifications,
   clearAllNotificationTimers,
@@ -29,6 +30,7 @@ import {
   MessageSquare,
   FileText,
   ScrollText,
+  X,
 } from 'lucide-react'
 import dynamic from 'next/dynamic'
 import {
@@ -49,6 +51,7 @@ import { ScrollArea } from '@/components/ui/scroll-area'
 import Sidebar from '@/components/app/sidebar/sidebar'
 import { translations, useLanguage } from '@/lib/i18n'
 import { Button } from '@/components/ui/button'
+import { Input } from '@/components/ui/input'
 import { APP_CONFIG } from '@/lib/config'
 import {
   isCalendarView,
@@ -166,6 +169,8 @@ export default function Calendar({ className, ...props }: CalendarProps) {
     'uploading' | 'failed' | 'done' | null
   >(null)
   const [shareOnlyMode, setShareOnlyMode] = useState(false)
+  const isMobile = useIsMobile()
+  const [isMobileSearchActive, setIsMobileSearchActive] = useState(false)
 
   const updateEvent = (updatedEvent: CalendarEvent) => {
     setEvents((prevEvents) =>
@@ -387,30 +392,38 @@ export default function Calendar({ className, ...props }: CalendarProps) {
 
   const handlePrevious = () => {
     setDate((prevDate) => {
-      if (view === 'day') return subDays(prevDate, 1)
-      if (view === 'week') return subDays(prevDate, 7)
-      if (view === 'four-day') return subDays(prevDate, 4)
-      if (view === 'year') return subYears(prevDate, 1)
+      if (effectiveView === 'day') return subDays(prevDate, 1)
+      if (effectiveView === 'week') return subDays(prevDate, 7)
+      if (effectiveView === 'four-day') return subDays(prevDate, 4)
+      if (effectiveView === 'year') return subYears(prevDate, 1)
       return subDays(prevDate, 30)
     })
   }
 
   const handleNext = () => {
     setDate((prevDate) => {
-      if (view === 'day') return addDays(prevDate, 1)
-      if (view === 'week') return addDays(prevDate, 7)
-      if (view === 'four-day') return addDays(prevDate, 4)
-      if (view === 'year') return addYears(prevDate, 1)
+      if (effectiveView === 'day') return addDays(prevDate, 1)
+      if (effectiveView === 'week') return addDays(prevDate, 7)
+      if (effectiveView === 'four-day') return addDays(prevDate, 4)
+      if (effectiveView === 'year') return addYears(prevDate, 1)
       return addDays(prevDate, 30)
     })
   }
 
   const formatDateDisplay = (date: Date) => {
-    if (view === 'year') {
+    if (isMobile) {
+      const options: Intl.DateTimeFormatOptions = {
+        month: 'short',
+        day: 'numeric',
+      }
+      return date.toLocaleDateString(language, options)
+    }
+
+    if (effectiveView === 'year') {
       return date.getFullYear().toString()
     }
 
-    if (view === 'four-day') {
+    if (effectiveView === 'four-day') {
       const startDate = new Date(date)
       const endDate = addDays(startDate, 3)
       const options: Intl.DateTimeFormatOptions = {
@@ -739,230 +752,324 @@ export default function Calendar({ className, ...props }: CalendarProps) {
         <div className="flex min-h-0 min-w-0 flex-1 flex-col">
           {' '}
           <header className="flex items-center px-4 h-16 border-b relative z-40 bg-background">
-            <div className="pointer-events-none absolute right-0 bottom-0 h-px w-14 bg-background" />
-            <div className="flex items-center space-x-4">
-              <div className="md:hidden">
-                <MobileSidebar
-                  onCreateEvent={() => {
-                    setSelectedEvent(null)
-                    setQuickCreateStartTime(new Date())
-                    setEventDialogOpen(true)
-                  }}
-                  onDateSelect={handleDateSelect}
-                  onViewChange={handleViewChange}
-                  language={language}
-                  selectedDate={sidebarDate}
-                  selectedCategoryFilters={selectedCategoryFilters}
-                  onCategoryFilterChange={(categoryId, checked) => {
-                    setSelectedCategoryFilters((prev) => {
-                      if (checked) {
-                        return prev.includes(categoryId)
-                          ? prev
-                          : [...prev, categoryId]
-                      }
-                      return prev.filter((id) => id !== categoryId)
-                    })
-                  }}
-                />
-              </div>
-              <Button
-                variant="outline"
-                onClick={toggleSidebar}
-                size="sm"
-                className="hidden md:flex"
-              >
-                <PanelLeft />
-              </Button>
-              <Button variant="outline" size="sm" onClick={handleTodayClick}>
-                {t.today || '今天'}
-              </Button>
-              {view !== 'analytics' && view !== 'settings' && (
-                <>
-                  <div className="flex items-center space-x-1">
-                    <Button
-                      variant="ghost"
-                      size="icon"
-                      onClick={handlePrevious}
-                    >
-                      <ChevronLeft className="h-4 w-4" />
-                    </Button>
-                    <Button variant="ghost" size="icon" onClick={handleNext}>
-                      <ChevronRight className="h-4 w-4" />
-                    </Button>
+            <div className="pointer-events-none absolute right-0 bottom-0 h-px w-14 bg-background hidden md:block" />
+
+            <div className="flex flex-1 items-center justify-between">
+              {isMobile && isMobileSearchActive ? (
+                <div className="flex flex-1 items-center space-x-2">
+                  <Button
+                    variant="ghost"
+                    size="icon"
+                    onClick={() => {
+                      setIsMobileSearchActive(false)
+                      setSearchTerm('')
+                    }}
+                  >
+                    <X className="h-5 w-5" />
+                  </Button>
+                  <div className="flex-1">
+                    <Input
+                      autoFocus
+                      placeholder={t.searchEvents}
+                      value={searchTerm}
+                      onChange={(e) => setSearchTerm(e.target.value)}
+                      className="w-full"
+                      onKeyDown={(e) => {
+                        if (
+                          e.key === 'Enter' &&
+                          searchResultEvents.length > 0
+                        ) {
+                          setPreviewEvent(searchResultEvents[0])
+                          setPreviewAnchorRect(null)
+                          setPreviewOpen(true)
+                          setSearchTerm('')
+                          setIsMobileSearchActive(false)
+                        }
+                      }}
+                    />
                   </div>
-                  <span className="text-lg">{formatDateDisplay(date)}</span>
+                </div>
+              ) : (
+                <>
+                  <div className="flex items-center space-x-2 md:space-x-4">
+                    <div className="md:hidden">
+                      <MobileSidebar
+                        onCreateEvent={() => {
+                          setSelectedEvent(null)
+                          setQuickCreateStartTime(new Date())
+                          setEventDialogOpen(true)
+                        }}
+                        onDateSelect={handleDateSelect}
+                        onViewChange={handleViewChange}
+                        language={language}
+                        selectedDate={sidebarDate}
+                        selectedCategoryFilters={selectedCategoryFilters}
+                        onCategoryFilterChange={(categoryId, checked) => {
+                          setSelectedCategoryFilters((prev) => {
+                            if (checked) {
+                              return prev.includes(categoryId)
+                                ? prev
+                                : [...prev, categoryId]
+                            }
+                            return prev.filter((id) => id !== categoryId)
+                          })
+                        }}
+                      />
+                    </div>
+                    <Button
+                      variant="outline"
+                      onClick={toggleSidebar}
+                      size="sm"
+                      className="hidden md:flex"
+                    >
+                      <PanelLeft />
+                    </Button>
+                    <Button
+                      variant="outline"
+                      size="sm"
+                      onClick={handleTodayClick}
+                      className={cn(isMobile && 'px-2 h-8 text-xs')}
+                    >
+                      {t.today || '今天'}
+                    </Button>
+
+                    <div className="flex items-center space-x-0.5 md:space-x-1">
+                      <Button
+                        variant="ghost"
+                        size="icon"
+                        onClick={handlePrevious}
+                        className={cn(isMobile && 'h-8 w-8')}
+                      >
+                        <ChevronLeft className="h-4 w-4" />
+                      </Button>
+                      <Button
+                        variant="ghost"
+                        size="icon"
+                        onClick={handleNext}
+                        className={cn(isMobile && 'h-8 w-8')}
+                      >
+                        <ChevronRight className="h-4 w-4" />
+                      </Button>
+                    </div>
+                    <span
+                      className={cn(
+                        'text-lg',
+                        isMobile &&
+                          'text-sm font-semibold truncate max-w-[80px]',
+                      )}
+                    >
+                      {formatDateDisplay(date)}
+                    </span>
+                  </div>
+
+                  <div className="ml-auto flex items-center space-x-1 md:space-x-2">
+                    <div className="hidden md:block">
+                      <div className="relative z-50">
+                        <Select
+                          value={
+                            effectiveView === 'day' ||
+                            effectiveView === 'week' ||
+                            effectiveView === 'four-day' ||
+                            effectiveView === 'month' ||
+                            effectiveView === 'year'
+                              ? view
+                              : defaultView === 'day' ||
+                                  defaultView === 'week' ||
+                                  defaultView === 'four-day' ||
+                                  defaultView === 'month' ||
+                                  defaultView === 'year'
+                                ? defaultView
+                                : 'week'
+                          }
+                          onValueChange={(value) => {
+                            if (isCalendarView(value)) {
+                              setView(value)
+                            }
+                          }}
+                        >
+                          <SelectTrigger className="w-[100px]">
+                            <SelectValue />
+                          </SelectTrigger>
+                          <SelectContent>
+                            <SelectGroup>
+                              <SelectItem value="day">{t.day}</SelectItem>
+                              <SelectItem value="week">{t.week}</SelectItem>
+                              <SelectItem value="month">{t.month}</SelectItem>
+                              <SelectItem value="year">{t.year}</SelectItem>
+                              <SelectItem value="four-day">
+                                {t.fourDay}
+                              </SelectItem>
+                            </SelectGroup>
+                          </SelectContent>
+                        </Select>
+                      </div>
+                    </div>
+
+                    <div className="md:hidden">
+                      <Button
+                        variant="ghost"
+                        size="icon"
+                        onClick={() => setIsMobileSearchActive(true)}
+                        className="h-8 w-8"
+                      >
+                        <Search className="h-5 w-5" />
+                      </Button>
+                    </div>
+
+                    <div className="hidden md:block relative z-50">
+                      <InputGroup className="w-48">
+                        <InputGroupAddon>
+                          <Search className="h-5 w-5 text-gray-400" />
+                        </InputGroupAddon>
+                        <InputGroupInput
+                          type="text"
+                          placeholder={t.searchEvents}
+                          value={searchTerm}
+                          onFocus={() => setIsSearchFocused(true)}
+                          onBlur={() => {
+                            window.setTimeout(
+                              () => setIsSearchFocused(false),
+                              120,
+                            )
+                          }}
+                          onChange={(e) => setSearchTerm(e.target.value)}
+                          onKeyDown={(e) => {
+                            if (
+                              e.key === 'Enter' &&
+                              searchResultEvents.length > 0
+                            ) {
+                              setPreviewEvent(searchResultEvents[0])
+                              setPreviewAnchorRect(null)
+                              setPreviewOpen(true)
+                              setSearchTerm('')
+                              setIsSearchFocused(false)
+                            }
+                          }}
+                          className="pr-4"
+                        />
+                      </InputGroup>
+                    </div>
+                    {(isSearchFocused || (isMobile && isMobileSearchActive)) &&
+                      !!searchTerm && (
+                        <div className="absolute right-4 top-[calc(100%+6px)] w-[calc(100vw-32px)] md:w-72 rounded-md border bg-popover p-1 shadow-md z-50">
+                          {searchResultEvents.length > 0 ? (
+                            <ScrollArea className="max-h-[320px]">
+                              <div className="space-y-1">
+                                {searchResultEvents.map((event) => (
+                                  <button
+                                    key={event.id}
+                                    type="button"
+                                    className="w-full cursor-pointer rounded-sm px-2 py-1.5 text-left hover:bg-accent"
+                                    onMouseDown={(e) => {
+                                      e.preventDefault()
+                                      setPreviewEvent(event)
+                                      setPreviewAnchorRect(null)
+                                      setPreviewOpen(true)
+                                      setSearchTerm('')
+                                      setIsSearchFocused(false)
+                                      setIsMobileSearchActive(false)
+                                    }}
+                                  >
+                                    <div className="font-medium leading-none">
+                                      {event.title || t.unnamedEvent}
+                                    </div>
+                                    <div className="text-xs text-muted-foreground mt-1">
+                                      {formatDateDisplay(
+                                        new Date(event.startDate),
+                                      )}
+                                    </div>
+                                  </button>
+                                ))}
+                              </div>
+                            </ScrollArea>
+                          ) : (
+                            <div className="px-2 py-1.5 text-sm text-muted-foreground">
+                              {t.noMatchingEvents}
+                            </div>
+                          )}
+                        </div>
+                      )}
+                    {backupEnabled ? (
+                      <div
+                        className="inline-flex h-8 w-8 items-center justify-center rounded-full border"
+                        title="Backup status"
+                        aria-label="Backup status"
+                      >
+                        {backupStatusIcon ?? (
+                          <CloudUpload className="h-4 w-4" />
+                        )}
+                      </div>
+                    ) : null}
+                    <div className="hidden md:block">
+                      <DropdownMenu>
+                        <DropdownMenuTrigger asChild>
+                          <Button
+                            variant="outline"
+                            size="icon"
+                            className="rounded-full h-8 w-8"
+                            aria-label="Help"
+                          >
+                            <CircleHelp className="h-4 w-4" />
+                          </Button>
+                        </DropdownMenuTrigger>
+                        <DropdownMenuContent align="end">
+                          <DropdownMenuItem
+                            onClick={() =>
+                              window.open(
+                                APP_CONFIG.contact.statusPageUrl,
+                                '_blank',
+                                'noopener,noreferrer',
+                              )
+                            }
+                          >
+                            <ShieldCheck className="mr-2 h-4 w-4" />
+                            {t.status}
+                          </DropdownMenuItem>
+                          <DropdownMenuItem
+                            onClick={() => {
+                              window.location.href = `mailto:${APP_CONFIG.contact.feedbackEmail}`
+                            }}
+                          >
+                            <MessageSquare className="mr-2 h-4 w-4" />
+                            {t.feedback}
+                          </DropdownMenuItem>
+                          <DropdownMenuItem
+                            onClick={() => router.push('/privacy')}
+                          >
+                            <FileText className="mr-2 h-4 w-4" />
+                            {t.privacy}
+                          </DropdownMenuItem>
+                          <DropdownMenuItem
+                            onClick={() => router.push('/terms')}
+                          >
+                            <ScrollText className="mr-2 h-4 w-4" />
+                            {t.tos}
+                          </DropdownMenuItem>
+                        </DropdownMenuContent>
+                      </DropdownMenu>
+                    </div>
+                    <UserProfileButton
+                      variant="outline"
+                      className="rounded-full h-8 w-8"
+                      onNavigateToSettings={handleUserProfileSectionNavigate}
+                      onNavigateToView={setView}
+                    />
+                    <div className="md:hidden">
+                      <MobileRightSidebar
+                        onViewChange={handleViewChange}
+                        onEventClick={handleEventClick}
+                      />
+                    </div>
+                  </div>
                 </>
               )}
             </div>
-
-            <div className="ml-auto flex items-center space-x-2">
-              <div className="relative z-50">
-                <Select
-                  value={
-                    view === 'day' ||
-                    view === 'week' ||
-                    view === 'four-day' ||
-                    view === 'month' ||
-                    view === 'year'
-                      ? view
-                      : defaultView === 'day' ||
-                          defaultView === 'week' ||
-                          defaultView === 'four-day' ||
-                          defaultView === 'month' ||
-                          defaultView === 'year'
-                        ? defaultView
-                        : 'week'
-                  }
-                  onValueChange={(value) => {
-                    if (isCalendarView(value)) {
-                      setView(value)
-                    }
-                  }}
-                >
-                  <SelectTrigger className="w-[100px]">
-                    <SelectValue />
-                  </SelectTrigger>
-                  <SelectContent>
-                    <SelectGroup>
-                      <SelectItem value="day">{t.day}</SelectItem>
-                      <SelectItem value="week">{t.week}</SelectItem>
-                      <SelectItem value="month">{t.month}</SelectItem>
-                      <SelectItem value="year">{t.year}</SelectItem>
-                      <SelectItem value="four-day">{t.fourDay}</SelectItem>
-                    </SelectGroup>
-                  </SelectContent>
-                </Select>
-              </div>
-              <div className="relative z-50">
-                <InputGroup className="w-48">
-                  <InputGroupAddon>
-                    <Search className="h-5 w-5 text-gray-400" />
-                  </InputGroupAddon>
-                  <InputGroupInput
-                    type="text"
-                    placeholder={t.searchEvents}
-                    value={searchTerm}
-                    onFocus={() => setIsSearchFocused(true)}
-                    onBlur={() => {
-                      window.setTimeout(() => setIsSearchFocused(false), 120)
-                    }}
-                    onChange={(e) => setSearchTerm(e.target.value)}
-                    onKeyDown={(e) => {
-                      if (e.key === 'Enter' && searchResultEvents.length > 0) {
-                        setPreviewEvent(searchResultEvents[0])
-                        setPreviewAnchorRect(null)
-                        setPreviewOpen(true)
-                        setSearchTerm('')
-                        setIsSearchFocused(false)
-                      }
-                    }}
-                    className="pr-4"
-                  />
-                </InputGroup>
-                {isSearchFocused && !!searchTerm && (
-                  <div className="absolute right-0 top-[calc(100%+6px)] w-72 rounded-md border bg-popover p-1 shadow-md z-50">
-                    {searchResultEvents.length > 0 ? (
-                      <ScrollArea className="max-h-[320px]">
-                        <div className="space-y-1">
-                          {searchResultEvents.map((event) => (
-                            <button
-                              key={event.id}
-                              type="button"
-                              className="w-full cursor-pointer rounded-sm px-2 py-1.5 text-left hover:bg-accent"
-                              onMouseDown={(e) => {
-                                e.preventDefault()
-                                setPreviewEvent(event)
-                                setPreviewAnchorRect(null)
-                                setPreviewOpen(true)
-                                setSearchTerm('')
-                                setIsSearchFocused(false)
-                              }}
-                            >
-                              <div className="font-medium leading-none">
-                                {event.title || t.unnamedEvent}
-                              </div>
-                              <div className="text-xs text-muted-foreground mt-1">
-                                {formatDateDisplay(new Date(event.startDate))}
-                              </div>
-                            </button>
-                          ))}
-                        </div>
-                      </ScrollArea>
-                    ) : (
-                      <div className="px-2 py-1.5 text-sm text-muted-foreground">
-                        {t.noMatchingEvents}
-                      </div>
-                    )}
-                  </div>
-                )}
-              </div>
-              {backupEnabled ? (
-                <div
-                  className="inline-flex h-8 w-8 items-center justify-center rounded-full border"
-                  title="Backup status"
-                  aria-label="Backup status"
-                >
-                  {backupStatusIcon ?? <CloudUpload className="h-4 w-4" />}
-                </div>
-              ) : null}
-              <div className="md:hidden">
-                <MobileRightSidebar
-                  onViewChange={handleViewChange}
-                  onEventClick={handleEventClick}
-                />
-              </div>
-              <DropdownMenu>
-                <DropdownMenuTrigger asChild>
-                  <Button
-                    variant="outline"
-                    size="icon"
-                    className="rounded-full h-8 w-8"
-                    aria-label="Help"
-                  >
-                    <CircleHelp className="h-4 w-4" />
-                  </Button>
-                </DropdownMenuTrigger>
-                <DropdownMenuContent align="end">
-                  <DropdownMenuItem
-                    onClick={() =>
-                      window.open(
-                        APP_CONFIG.contact.statusPageUrl,
-                        '_blank',
-                        'noopener,noreferrer',
-                      )
-                    }
-                  >
-                    <ShieldCheck className="mr-2 h-4 w-4" />
-                    {t.status}
-                  </DropdownMenuItem>
-                  <DropdownMenuItem
-                    onClick={() => {
-                      window.location.href = `mailto:${APP_CONFIG.contact.feedbackEmail}`
-                    }}
-                  >
-                    <MessageSquare className="mr-2 h-4 w-4" />
-                    {t.feedback}
-                  </DropdownMenuItem>
-                  <DropdownMenuItem onClick={() => router.push('/privacy')}>
-                    <FileText className="mr-2 h-4 w-4" />
-                    {t.privacy}
-                  </DropdownMenuItem>
-                  <DropdownMenuItem onClick={() => router.push('/terms')}>
-                    <ScrollText className="mr-2 h-4 w-4" />
-                    {t.tos}
-                  </DropdownMenuItem>
-                </DropdownMenuContent>
-              </DropdownMenu>
-              <UserProfileButton
-                variant="outline"
-                className="rounded-full h-8 w-8"
-                onNavigateToSettings={handleUserProfileSectionNavigate}
-                onNavigateToView={setView}
-              />
-            </div>
           </header>
-          <div className="flex-1 overflow-auto pr-14" ref={calendarRef}>
-            {view === 'day' && (
+          <div
+            className={cn('flex-1 overflow-auto', !isMobile && 'pr-14')}
+            ref={calendarRef}
+          >
+            {effectiveView === 'day' && (
               <DayView
                 date={date}
                 events={filteredEvents}
@@ -988,7 +1095,7 @@ export default function Calendar({ className, ...props }: CalendarProps) {
                 }}
               />
             )}
-            {view === 'week' && (
+            {effectiveView === 'week' && (
               <WeekView
                 date={date}
                 events={filteredEvents}
@@ -1015,7 +1122,7 @@ export default function Calendar({ className, ...props }: CalendarProps) {
                 }}
               />
             )}
-            {view === 'four-day' && (
+            {effectiveView === 'four-day' && (
               <WeekView
                 date={date}
                 events={filteredEvents}
@@ -1044,7 +1151,7 @@ export default function Calendar({ className, ...props }: CalendarProps) {
                 fixedStartDate={date}
               />
             )}
-            {view === 'month' && (
+            {effectiveView === 'month' && (
               <MonthView
                 date={date}
                 events={filteredEvents}
@@ -1054,7 +1161,7 @@ export default function Calendar({ className, ...props }: CalendarProps) {
                 timezone={timezone}
               />
             )}
-            {view === 'year' && (
+            {effectiveView === 'year' && (
               <YearView
                 date={date}
                 events={filteredEvents}
@@ -1065,7 +1172,7 @@ export default function Calendar({ className, ...props }: CalendarProps) {
                 isSidebarExpanding={isSidebarExpanding}
               />
             )}
-            {view === 'analytics' && (
+            {effectiveView === 'analytics' && (
               <AnalyticsView
                 events={events}
                 onCreateEvent={(startDate, endDate) => {
@@ -1075,7 +1182,7 @@ export default function Calendar({ className, ...props }: CalendarProps) {
                 }}
               />
             )}
-            {view === 'settings' && (
+            {effectiveView === 'settings' && (
               <Settings
                 language={language}
                 setLanguage={setLanguage}

--- a/components/app/calendar.tsx
+++ b/components/app/calendar.tsx
@@ -3,6 +3,7 @@
 import { MobileSidebar } from '@/components/app/sidebar/mobile/mobile-sidebar'
 import { MobileRightSidebar } from '@/components/app/sidebar/mobile/mobile-right-sidebar'
 import { useIsMobile } from '@/hooks/useMobile'
+import { cn } from '@/lib/utils'
 import {
   checkPendingNotifications,
   clearAllNotificationTimers,

--- a/components/app/calendar.tsx
+++ b/components/app/calendar.tsx
@@ -32,6 +32,7 @@ import {
   FileText,
   ScrollText,
   X,
+  Plus,
 } from 'lucide-react'
 import dynamic from 'next/dynamic'
 import {
@@ -1067,12 +1068,22 @@ export default function Calendar({ className, ...props }: CalendarProps) {
               )}
             </div>
           </header>
-          <div
-            className={cn('flex-1 overflow-auto', !isMobile && 'pr-14')}
-            ref={calendarRef}
-          >
+          <div className={cn('flex-1 overflow-auto', !isMobile && 'pr-14')} ref={calendarRef}>
+            {isMobile && (
+              <Button
+                className="fixed bottom-6 right-6 h-14 w-14 rounded-full shadow-lg z-50 bg-[#0066FF] hover:bg-[#0052CC]"
+                onClick={() => {
+                  setSelectedEvent(null)
+                  setQuickCreateStartTime(new Date())
+                  setEventDialogOpen(true)
+                }}
+              >
+                <Plus className="h-8 w-8 text-white" />
+              </Button>
+            )}
             {effectiveView === 'day' && (
               <DayView
+
                 date={date}
                 events={filteredEvents}
                 onEventClick={handleEventClick}

--- a/components/app/sidebar/mobile/mobile-right-sidebar.tsx
+++ b/components/app/sidebar/mobile/mobile-right-sidebar.tsx
@@ -1,0 +1,28 @@
+'use client'
+
+import { Sheet, SheetContent, SheetTrigger } from '@/components/ui/sheet'
+import { Button } from '@/components/ui/button'
+import { MoreVertical } from 'lucide-react'
+import RightSidebar from '../right-sidebar'
+import { type ComponentProps } from 'react'
+
+export function MobileRightSidebar(props: ComponentProps<typeof RightSidebar>) {
+  return (
+    <Sheet>
+      <SheetTrigger asChild>
+        <Button
+          variant="outline"
+          size="icon"
+          className="md:hidden size-8 rounded-full"
+        >
+          <MoreVertical className="h-4 w-4" />
+        </Button>
+      </SheetTrigger>
+      <SheetContent side="right" className="p-0 w-[280px]">
+        <div className="h-full pt-10">
+          <RightSidebar {...props} />
+        </div>
+      </SheetContent>
+    </Sheet>
+  )
+}

--- a/components/app/sidebar/mobile/mobile-right-sidebar.tsx
+++ b/components/app/sidebar/mobile/mobile-right-sidebar.tsx
@@ -1,28 +1,75 @@
 'use client'
 
-import { Sheet, SheetContent, SheetTrigger } from '@/components/ui/sheet'
+import { useState } from 'react'
+import { Calendar, Bookmark, MoreVertical } from 'lucide-react'
+import { ClockDashed } from '@/components/icons/clock-dashed'
 import { Button } from '@/components/ui/button'
-import { MoreVertical } from 'lucide-react'
-import RightSidebar from '../right-sidebar'
-import { type ComponentProps } from 'react'
+import {
+  DropdownMenu,
+  DropdownMenuContent,
+  DropdownMenuItem,
+  DropdownMenuTrigger,
+} from '@/components/ui/dropdown-menu'
+import MiniCalendarSheet from '../mini-calendar-sheet'
+import BookmarkPanel from '../bookmark-panel'
+import { CountdownTool } from '../countdown'
+import { translations, useLanguage } from '@/lib/i18n'
 
-export function MobileRightSidebar(props: ComponentProps<typeof RightSidebar>) {
+interface MobileRightSidebarProps {
+  onEventClick: (event: any) => void
+}
+
+export function MobileRightSidebar({ onEventClick }: MobileRightSidebarProps) {
+  const [miniCalendarOpen, setMiniCalendarOpen] = useState(false)
+  const [selectedDate, setSelectedDate] = useState(new Date())
+  const [bookmarkPanelOpen, setBookmarkPanelOpen] = useState(false)
+  const [countdownOpen, setCountdownOpen] = useState(false)
+  const [language] = useLanguage()
+  const t = translations[language]
+
   return (
-    <Sheet>
-      <SheetTrigger asChild>
-        <Button
-          variant="outline"
-          size="icon"
-          className="md:hidden size-8 rounded-full"
-        >
-          <MoreVertical className="h-4 w-4" />
-        </Button>
-      </SheetTrigger>
-      <SheetContent side="right" className="p-0 w-[280px]">
-        <div className="h-full pt-10">
-          <RightSidebar {...props} />
-        </div>
-      </SheetContent>
-    </Sheet>
+    <>
+      <DropdownMenu>
+        <DropdownMenuTrigger asChild>
+          <Button
+            variant="outline"
+            size="icon"
+            className="h-8 w-8 rounded-full"
+            aria-label="More tools"
+          >
+            <MoreVertical className="h-4 w-4" />
+          </Button>
+        </DropdownMenuTrigger>
+        <DropdownMenuContent align="end">
+          <DropdownMenuItem onClick={() => setMiniCalendarOpen(true)}>
+            <Calendar className="mr-2 h-4 w-4" />
+            {t.calendar}
+          </DropdownMenuItem>
+          <DropdownMenuItem onClick={() => setBookmarkPanelOpen(true)}>
+            <Bookmark className="mr-2 h-4 w-4" />
+            {t.bookmarks}
+          </DropdownMenuItem>
+          <DropdownMenuItem onClick={() => setCountdownOpen(true)}>
+            <ClockDashed className="mr-2 h-4 w-4" />
+            {t.countdownTitle}
+          </DropdownMenuItem>
+        </DropdownMenuContent>
+      </DropdownMenu>
+
+      <MiniCalendarSheet
+        open={miniCalendarOpen}
+        onOpenChange={setMiniCalendarOpen}
+        selectedDate={selectedDate}
+        onDateSelect={setSelectedDate}
+      />
+
+      <BookmarkPanel
+        open={bookmarkPanelOpen}
+        onOpenChange={setBookmarkPanelOpen}
+        onEventClick={onEventClick}
+      />
+
+      <CountdownTool open={countdownOpen} onOpenChange={setCountdownOpen} />
+    </>
   )
 }

--- a/components/app/sidebar/mobile/mobile-sidebar.tsx
+++ b/components/app/sidebar/mobile/mobile-sidebar.tsx
@@ -17,8 +17,8 @@ export function MobileSidebar({
           <PanelLeft />
         </Button>
       </SheetTrigger>
-      <SheetContent side="left" className="p-0 w-[280px]">
-        <Sidebar {...props} className="!w-full" />
+      <SheetContent side="left" className="p-0 w-[247px]">
+        <Sidebar {...props} className="!w-full border-r-0" hideCreateButton />
       </SheetContent>
     </Sheet>
   )

--- a/components/app/sidebar/mobile/mobile-sidebar.tsx
+++ b/components/app/sidebar/mobile/mobile-sidebar.tsx
@@ -18,7 +18,7 @@ export function MobileSidebar({
         </Button>
       </SheetTrigger>
       <SheetContent side="left" className="p-0 w-[280px]">
-        <Sidebar {...props} />
+        <Sidebar {...props} className="!w-full" />
       </SheetContent>
     </Sheet>
   )

--- a/components/app/sidebar/mobile/mobile-sidebar.tsx
+++ b/components/app/sidebar/mobile/mobile-sidebar.tsx
@@ -1,0 +1,25 @@
+'use client'
+
+import { Sheet, SheetContent, SheetTrigger } from '@/components/ui/sheet'
+import { Button } from '@/components/ui/button'
+import { PanelLeft } from 'lucide-react'
+import Sidebar from '../sidebar'
+import { type ComponentProps } from 'react'
+
+export function MobileSidebar({
+  children,
+  ...props
+}: { children: React.ReactNode } & ComponentProps<typeof Sidebar>) {
+  return (
+    <Sheet>
+      <SheetTrigger asChild>
+        <Button variant="outline" size="sm" className="md:hidden mr-2">
+          <PanelLeft />
+        </Button>
+      </SheetTrigger>
+      <SheetContent side="left" className="p-0 w-[280px]">
+        <Sidebar {...props} />
+      </SheetContent>
+    </Sheet>
+  )
+}

--- a/components/app/sidebar/mobile/mobile-sidebar.tsx
+++ b/components/app/sidebar/mobile/mobile-sidebar.tsx
@@ -6,10 +6,7 @@ import { PanelLeft } from 'lucide-react'
 import Sidebar from '../sidebar'
 import { type ComponentProps } from 'react'
 
-export function MobileSidebar({
-  children,
-  ...props
-}: { children: React.ReactNode } & ComponentProps<typeof Sidebar>) {
+export function MobileSidebar(props: ComponentProps<typeof Sidebar>) {
   return (
     <Sheet>
       <SheetTrigger asChild>
@@ -17,8 +14,15 @@ export function MobileSidebar({
           <PanelLeft />
         </Button>
       </SheetTrigger>
-      <SheetContent side="left" className="p-0 w-[247px]">
-        <Sidebar {...props} className="!w-full border-r-0" hideCreateButton />
+      <SheetContent
+        side="left"
+        className="w-[247px] max-w-[247px] p-0 sm:max-w-[247px]"
+      >
+        <Sidebar
+          {...props}
+          className="!w-[247px] max-w-[247px] border-r-0"
+          hideCreateButton
+        />
       </SheetContent>
     </Sheet>
   )

--- a/components/app/sidebar/sidebar.tsx
+++ b/components/app/sidebar/sidebar.tsx
@@ -54,6 +54,7 @@ interface SidebarProps {
   selectedCategoryFilters?: string[]
   onCategoryFilterChange?: (categoryId: string, checked: boolean) => void
   onCollapseTransitionEnd?: () => void
+  className?: string
 }
 
 export interface CalendarCategory {
@@ -88,6 +89,7 @@ export default function Sidebar({
   selectedCategoryFilters = [],
   onCategoryFilterChange,
   onCollapseTransitionEnd,
+  className,
 }: SidebarProps) {
   const {
     calendars,
@@ -235,6 +237,7 @@ export default function Sidebar({
       className={cn(
         'border-r bg-background overflow-y-auto transition-all duration-300 ease-in-out',
         isCollapsed ? 'w-0 opacity-0 overflow-hidden' : 'w-[247px] opacity-100',
+        className,
       )}
       onTransitionEnd={(event) => {
         if (

--- a/components/app/sidebar/sidebar.tsx
+++ b/components/app/sidebar/sidebar.tsx
@@ -219,8 +219,9 @@ export default function Sidebar({
       if (deleteCategoryEvents) {
         setEvents(
           events.filter((event) => event.calendarId !== categoryToDelete),
-        )
-      }
+      </div>
+  )
+}
       removeCategoryFromContext(categoryToDelete)
       toast(deleteText.toastSuccess, {
         description: deleteCategoryEvents
@@ -251,31 +252,26 @@ export default function Sidebar({
       }}
     >
       <div className="p-4">
+        <div className="mb-4 flex items-center">
+          <Image
+            src="/icon.svg"
+            alt="One Calendar"
+            width={24}
+            height={24}
+            className="mr-2 brightness-0 dark:invert"
+          />
+          <h1 className="text-lg font-semibold">One Calendar</h1>
+        </div>
 
-              <div className="mb-4 flex items-center">
-                <Image
-                  src="/icon.svg"
-                  alt="One Calendar"
-                  width={24}
-                  height={24}
-                  className="mr-2 brightness-0 dark:invert"
-                />
-                <h1 className="text-lg font-semibold">One Calendar</h1>
-              </div>
-
-              {!hideCreateButton && (
-                <Button
-                  className="mx-auto mb-4 h-10 w-full justify-center bg-[#0066FF] text-white hover:bg-[#0052CC] green:bg-[#24a854] orange:bg-[#e26912] azalea:bg-[#CD2F7B]"
-                  onClick={onCreateEvent}
-                >
-                  {t.createEvent}
-                </Button>
-              )}
-            </div>
-
-          </div>
-        )
-      )}
+        {!hideCreateButton && (
+          <Button
+            className="mx-auto mb-4 h-10 w-full justify-center bg-[#0066FF] text-white hover:bg-[#0052CC] green:bg-[#24a854] orange:bg-[#e26912] azalea:bg-[#CD2F7B]"
+            onClick={onCreateEvent}
+          >
+            {t.createEvent}
+          </Button>
+        )}
+      </div>
 
       <div className="mt-4">
         <Calendar
@@ -290,15 +286,31 @@ export default function Sidebar({
             if (date) onDateSelect(date)
           }}
           className="rounded-lg border"
-          />
-        </div>
+        />
+      </div>
+    </div>
+  )
+}
 
-        <div className="mt-8 space-y-3">
-          <div className="flex items-center justify-between">
-            <span className="text-sm font-medium">{t.myCalendars}</span>
-          </div>
-          {calendars.map((calendar) => (
-            <div
+           <div key={calendar.id} className="flex items-center space-x-2">
+             <Checkbox
+               checked={selectedCategoryFilters.includes(calendar.id)}
+               onCheckedChange={(checked) =>
+                 onCategoryFilterChange?.(calendar.id, checked === true)
+               }
+               className="h-4 w-4 rounded-md border border-muted-foreground/60"
+             />
+             <span className="text-sm text-muted-foreground">
+               {calendar.name}
+             </span>
+           </div>
+        ))}
+      </div>
+      </div>
+    </div>
+  )
+}
+
               key={calendar.id}
               className="flex items-center justify-between"
             >

--- a/components/app/sidebar/sidebar.tsx
+++ b/components/app/sidebar/sidebar.tsx
@@ -56,7 +56,7 @@ interface SidebarProps {
   onCollapseTransitionEnd?: () => void
   className?: string
   hideCreateButton?: boolean
-  }
+}
 
 export interface CalendarCategory {
   id: string
@@ -213,14 +213,14 @@ export default function Sidebar({
           : t['categoryMovedDown'] || 'Category moved down',
     })
   }
-const confirmDelete = () => {
-  if (categoryToDelete) {
-    if (deleteCategoryEvents) {
-      setEvents(
-        events.filter((event) => event.calendarId !== categoryToDelete),
-      )
-    }
-    removeCategoryFromContext(categoryToDelete)
+  const confirmDelete = () => {
+    if (categoryToDelete) {
+      if (deleteCategoryEvents) {
+        setEvents(
+          events.filter((event) => event.calendarId !== categoryToDelete),
+        )
+      }
+      removeCategoryFromContext(categoryToDelete)
 
       toast(deleteText.toastSuccess, {
         description: deleteCategoryEvents
@@ -287,27 +287,15 @@ const confirmDelete = () => {
           className="rounded-lg border"
         />
       </div>
-    </div>
-  )
-}
 
-           <div key={calendar.id} className="flex items-center space-x-2">
-             <Checkbox
-               checked={selectedCategoryFilters.includes(calendar.id)}
-               onCheckedChange={(checked) =>
-                 onCategoryFilterChange?.(calendar.id, checked === true)
-               }
-               className="h-4 w-4 rounded-md border border-muted-foreground/60"
-             />
-             <span className="text-sm text-muted-foreground">
-               {calendar.name}
-             </span>
-           ))}
-           </div>
-           </div>
-           )
-           }
-
+      <div className="px-4 pb-4">
+        <div className="space-y-1">
+          {calendars.map((calendar) => (
+            <div
+              key={calendar.id}
+              className="flex items-center justify-between"
+            >
+              <div key={calendar.id} className="flex items-center space-x-2">
                 <Checkbox
                   checked={selectedCategoryFilters.includes(calendar.id)}
                   onCheckedChange={(checked) =>

--- a/components/app/sidebar/sidebar.tsx
+++ b/components/app/sidebar/sidebar.tsx
@@ -213,16 +213,15 @@ export default function Sidebar({
           : t['categoryMovedDown'] || 'Category moved down',
     })
   }
+const confirmDelete = () => {
+  if (categoryToDelete) {
+    if (deleteCategoryEvents) {
+      setEvents(
+        events.filter((event) => event.calendarId !== categoryToDelete),
+      )
+    }
+    removeCategoryFromContext(categoryToDelete)
 
-  const confirmDelete = () => {
-    if (categoryToDelete) {
-      if (deleteCategoryEvents) {
-        setEvents(
-          events.filter((event) => event.calendarId !== categoryToDelete),
-      </div>
-  )
-}
-      removeCategoryFromContext(categoryToDelete)
       toast(deleteText.toastSuccess, {
         description: deleteCategoryEvents
           ? t.categoryDeletedWithEvents
@@ -303,18 +302,12 @@ export default function Sidebar({
              <span className="text-sm text-muted-foreground">
                {calendar.name}
              </span>
+           ))}
            </div>
-        ))}
-      </div>
-      </div>
-    </div>
-  )
-}
+           </div>
+           )
+           }
 
-              key={calendar.id}
-              className="flex items-center justify-between"
-            >
-              <div className="flex items-center space-x-2">
                 <Checkbox
                   checked={selectedCategoryFilters.includes(calendar.id)}
                   onCheckedChange={(checked) =>

--- a/components/app/sidebar/sidebar.tsx
+++ b/components/app/sidebar/sidebar.tsx
@@ -55,6 +55,7 @@ interface SidebarProps {
   onCategoryFilterChange?: (categoryId: string, checked: boolean) => void
   onCollapseTransitionEnd?: () => void
   className?: string
+  hideCreateButton?: boolean
 }
 
 export interface CalendarCategory {
@@ -90,6 +91,7 @@ export default function Sidebar({
   onCategoryFilterChange,
   onCollapseTransitionEnd,
   className,
+  hideCreateButton,
 }: SidebarProps) {
   const {
     calendars,
@@ -249,23 +251,25 @@ export default function Sidebar({
       }}
     >
       <div className="p-4">
-        <div className="mb-4 flex items-center">
-          <Image
-            src="/icon.svg"
-            alt="One Calendar"
-            width={24}
-            height={24}
-            className="mr-2 brightness-0 dark:invert"
-          />
-          <h1 className="text-lg font-semibold">One Calendar</h1>
-        </div>
 
-        <Button
-          className="mx-auto mb-4 h-10 w-full justify-center bg-[#0066FF] text-white hover:bg-[#0052CC] green:bg-[#24a854] orange:bg-[#e26912] azalea:bg-[#CD2F7B]"
-          onClick={onCreateEvent}
-        >
-          {t.createEvent}
-        </Button>
+            <Image
+              src="/icon.svg"
+              alt="One Calendar"
+              width={24}
+              height={24}
+              className="mr-2 brightness-0 dark:invert"
+            />
+            <h1 className="text-lg font-semibold">One Calendar</h1>
+          </div>
+
+          {!hideCreateButton && (
+            <Button
+              className="mx-auto mb-4 h-10 w-full justify-center bg-[#0066FF] text-white hover:bg-[#0052CC] green:bg-[#24a854] orange:bg-[#e26912] azalea:bg-[#CD2F7B]"
+              onClick={onCreateEvent}
+            >
+              {t.createEvent}
+            </Button>
+          )}
 
         <div className="mt-4">
           <Calendar

--- a/components/app/sidebar/sidebar.tsx
+++ b/components/app/sidebar/sidebar.tsx
@@ -56,7 +56,7 @@ interface SidebarProps {
   onCollapseTransitionEnd?: () => void
   className?: string
   hideCreateButton?: boolean
-}
+  }
 
 export interface CalendarCategory {
   id: string
@@ -252,38 +252,44 @@ export default function Sidebar({
     >
       <div className="p-4">
 
-            <Image
-              src="/icon.svg"
-              alt="One Calendar"
-              width={24}
-              height={24}
-              className="mr-2 brightness-0 dark:invert"
-            />
-            <h1 className="text-lg font-semibold">One Calendar</h1>
+              <div className="mb-4 flex items-center">
+                <Image
+                  src="/icon.svg"
+                  alt="One Calendar"
+                  width={24}
+                  height={24}
+                  className="mr-2 brightness-0 dark:invert"
+                />
+                <h1 className="text-lg font-semibold">One Calendar</h1>
+              </div>
+
+              {!hideCreateButton && (
+                <Button
+                  className="mx-auto mb-4 h-10 w-full justify-center bg-[#0066FF] text-white hover:bg-[#0052CC] green:bg-[#24a854] orange:bg-[#e26912] azalea:bg-[#CD2F7B]"
+                  onClick={onCreateEvent}
+                >
+                  {t.createEvent}
+                </Button>
+              )}
+            </div>
+
           </div>
+        )
+      )}
 
-          {!hideCreateButton && (
-            <Button
-              className="mx-auto mb-4 h-10 w-full justify-center bg-[#0066FF] text-white hover:bg-[#0052CC] green:bg-[#24a854] orange:bg-[#e26912] azalea:bg-[#CD2F7B]"
-              onClick={onCreateEvent}
-            >
-              {t.createEvent}
-            </Button>
-          )}
-
-        <div className="mt-4">
-          <Calendar
-            mode="single"
-            selected={localSelectedDate}
-            formatters={{
-              formatCaption: (date) => formatCalendarCaption(date),
-              formatWeekdayName: (date) => weekdayNames[date.getDay()],
-            }}
-            onSelect={(date) => {
-              setLocalSelectedDate(date)
-              if (date) onDateSelect(date)
-            }}
-            className="rounded-lg border"
+      <div className="mt-4">
+        <Calendar
+          mode="single"
+          selected={localSelectedDate}
+          formatters={{
+            formatCaption: (date) => formatCalendarCaption(date),
+            formatWeekdayName: (date) => weekdayNames[date.getDay()],
+          }}
+          onSelect={(date) => {
+            setLocalSelectedDate(date)
+            if (date) onDateSelect(date)
+          }}
+          className="rounded-lg border"
           />
         </div>
 

--- a/package.json
+++ b/package.json
@@ -17,8 +17,6 @@
     "@better-auth/drizzle-adapter": "1.6.11",
     "@better-auth/infra": "0.2.8",
     "@marsidev/react-turnstile": "1.5.2",
-    "@radix-ui/react-dialog": "latest",
-    "@radix-ui/react-slot": "^1.2.0",
     "@radix-ui/react-toast": "latest",
     "@react-email/render": "latest",
     "bcryptjs": "latest",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -17,12 +17,6 @@ importers:
       '@marsidev/react-turnstile':
         specifier: 1.5.2
         version: 1.5.2(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
-      '@radix-ui/react-dialog':
-        specifier: latest
-        version: 1.1.15(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
-      '@radix-ui/react-slot':
-        specifier: ^1.2.0
-        version: 1.2.4(@types/react@19.2.14)(react@18.3.1)
       '@radix-ui/react-toast':
         specifier: latest
         version: 1.2.15(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
@@ -1981,15 +1975,6 @@ packages:
 
   '@radix-ui/react-slot@1.2.3':
     resolution: {integrity: sha512-aeNmHnBxbi2St0au6VBVC7JXFlhLlOnvIIlePNniyUNAClzmtAUEY8/pBiK3iHjufOlwA+c20/8jngo7xcrg8A==}
-    peerDependencies:
-      '@types/react': '*'
-      react: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
-    peerDependenciesMeta:
-      '@types/react':
-        optional: true
-
-  '@radix-ui/react-slot@1.2.4':
-    resolution: {integrity: sha512-Jl+bCv8HxKnlTLVrcDE8zTMJ09R9/ukw4qBs/oZClOfoQk/cOTbDn+NceXfV7j09YPVQUryJPHurafcSg6EVKA==}
     peerDependencies:
       '@types/react': '*'
       react: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
@@ -5682,13 +5667,6 @@ snapshots:
       '@types/react-dom': 19.2.3(@types/react@19.2.14)
 
   '@radix-ui/react-slot@1.2.3(@types/react@19.2.14)(react@18.3.1)':
-    dependencies:
-      '@radix-ui/react-compose-refs': 1.1.2(@types/react@19.2.14)(react@18.3.1)
-      react: 18.3.1
-    optionalDependencies:
-      '@types/react': 19.2.14
-
-  '@radix-ui/react-slot@1.2.4(@types/react@19.2.14)(react@18.3.1)':
     dependencies:
       '@radix-ui/react-compose-refs': 1.1.2(@types/react@19.2.14)(react@18.3.1)
       react: 18.3.1

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -1,6 +1,7 @@
 packages:
   - "."
 allowBuilds:
+  '@schpet/linear-cli': false
   esbuild: false
   msw: false
   sharp: false


### PR DESCRIPTION
### Motivation
- Align mobile UI with desktop behavior so the left sidebar sheet uses the desktop sidebar width and hides the create button on the sheet. 
- Keep mobile calendar locked to the day view while still allowing `settings` and `analytics` views to open. 
- Replace the mobile right-side sheet with a compact three-dot dropdown that opens the original mini calendar / bookmarks / countdown sheets. 
- Restore mobile search results list rendering and ensure mobile-only controls do not affect desktop UI.

### Description
- Change mobile view logic to `const effectiveView = isMobile && isCalendarView(view) ? 'day' : view` so calendar views are forced to day on mobile while `settings` and `analytics` still render. (`components/app/calendar.tsx`).
- Force the mobile left `Sheet` to match the desktop sidebar width and prevent the sheet from shrinking by updating `mobile-sidebar.tsx` to use `className="w-[247px] max-w-[247px] ..."` and pass `hideCreateButton` to `Sidebar` so the create button is removed inside the sheet. (`components/app/sidebar/mobile/mobile-sidebar.tsx`).
- Replace the mobile right `Sheet` with a dropdown menu component that opens the existing `MiniCalendarSheet`, `BookmarkPanel`, and `CountdownTool` directly; localize labels via `useLanguage`. The new `MobileRightSidebar` uses `DropdownMenu` and opens the sheets instead of rendering a right sheet. (`components/app/sidebar/mobile/mobile-right-sidebar.tsx`).
- Restore mobile search results list by rendering an absolute dropdown below the mobile search input when `searchTerm` is non-empty and showing matches or an empty state. (`components/app/calendar.tsx`).
- Only mount mobile-specific sidebar/right controls when `isMobile` is true and only show the floating create button when `isMobile && effectiveView === 'day'` so settings/analytics pages are not affected on mobile or desktop. (`components/app/calendar.tsx`).
- Minor prop/type and formatting adjustments to keep behavior consistent across breakpoints.

### Testing
- Ran formatter/lint steps used in the repository: `pnpm exec prettier --write components/app/calendar.tsx components/app/sidebar/mobile/mobile-sidebar.tsx components/app/sidebar/mobile/mobile-right-sidebar.tsx` and the pre-commit hooks (prettier, `oxlint --fix`, `eslint --fix`) completed successfully. 
- Verified translation key presence with a small script that checked `locales/*.json` for the new keys used and found no missing keys. 
- Performed `git diff --check` and repository hooks checks to ensure there are no trailing errors; all checks passed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a09118cba5c8332b4ac2cc02e38c205)

## Summary by Sourcery

在移动端与桌面端之间对齐日历和侧边栏行为，改进移动端导航控件，并恢复移动端搜索结果的渲染。

Bug 修复：
- 在移动端强制日历视图仅使用“按天视图”，同时保持分析和设置仍可访问。
- 恢复移动端搜索结果下拉框的渲染，而不影响桌面端搜索行为。

功能增强：
- 引入专用的移动端侧边栏和右侧下拉组件，为移动端提供特定的导航和工具，同时保持桌面端侧边栏不变。
- 将创建按钮隐藏在移动端侧边栏弹层中，而在移动端“按天视图”中使用悬浮操作按钮来创建事件。
- 调整侧边栏布局的 props 和样式，使移动端侧边栏弹层与桌面端侧边栏宽度一致，并保持分类过滤行为的一致性。

构建：
- 从项目中移除未使用的 Radix dialog 和 slot 依赖。
- 更新 pnpm workspace 构建配置，以禁用 `@schpet/linear-cli` 包的构建。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Align calendar and sidebar behavior between mobile and desktop, improve mobile navigation controls, and restore mobile search results rendering.

Bug Fixes:
- Force calendar views to use a day-only view on mobile while keeping analytics and settings accessible.
- Restore mobile search results dropdown rendering without affecting the desktop search behavior.

Enhancements:
- Introduce dedicated mobile sidebar and right-side dropdown components to provide mobile-specific navigation and tools while keeping desktop sidebars unchanged.
- Hide the create button inside the mobile sidebar sheet and instead use a floating action button for event creation on mobile day view.
- Adjust sidebar layout props and styles so the mobile sidebar sheet matches the desktop sidebar width and maintains consistent category filtering behavior.

Build:
- Remove unused Radix dialog and slot dependencies from the project.
- Update pnpm workspace build configuration to disable builds for the @schpet/linear-cli package.

</details>