### PR TITLE
Support chunked cloud backups and auto-generate high-entropy encryption keys

### DIFF
--- a/components/app/profile/user-profile-button.tsx
+++ b/components/app/profile/user-profile-button.tsx
@@ -49,8 +49,9 @@ import { authClient } from '@/lib/auth/client'
 import { useRouter } from 'next/navigation'
 import QRCodeStyling from 'qr-code-styling'
 import {
-  decryptPayload,
-  encryptPayload,
+  decryptLargePayload,
+  decryptWithDerivedKey,
+  encryptLargePayload,
   isEncryptedPayload,
 } from '@/lib/crypto'
 import {
@@ -67,7 +68,7 @@ import {
 
 const AUTO_KEY = 'auto-backup-enabled'
 const BACKUP_STATUS_KEY = 'auto-backup-sync-status'
-const BACKUP_VERSION = 1
+const BACKUP_VERSION = 2
 const BACKUP_KEYS = [
   'calendar-events',
   'calendar-categories',
@@ -84,6 +85,11 @@ const BACKUP_KEYS = [
   'today-toast',
   'toast-position',
 ]
+
+function generateHighEntropyKey() {
+  const bytes = crypto.getRandomValues(new Uint8Array(32))
+  return Array.from(bytes, (b) => b.toString(16).padStart(2, '0')).join('')
+}
 
 const BACKUP_KEY_DEFAULTS: Record<string, unknown> = {
   'calendar-events': [],
@@ -358,7 +364,7 @@ export default function UserProfileButton({
           broadcastBackupStatus('done')
           return
         }
-        const payload = await encryptPayload(keyRef.current!, snapshot)
+        const payload = await encryptLargePayload(keyRef.current!, snapshot)
         await apiPost(payload)
         lastBackupSnapshotRef.current = snapshot
         broadcastBackupStatus('done')
@@ -458,16 +464,23 @@ export default function UserProfileButton({
   async function sendEmailChangeOtp() {
     if (!newEmail || !twoFactorPassword) return
     setTwoFactorPending(true)
-    const res = await authClient.emailOtp.sendVerificationOtp({
-      email: newEmail,
+    const nextEmail = newEmail.trim().toLowerCase()
+    const primary = await authClient.emailOtp.sendVerificationOtp({
+      email: nextEmail,
       type: 'email-verification',
     })
+    const res = primary.error
+      ? await authClient.emailOtp.sendVerificationOtp({
+          email: nextEmail,
+          type: 'sign-in',
+        })
+      : primary
     if (res.error) {
       toast(res.error.message || 'Failed to send verification code.')
       setTwoFactorPending(false)
       return
     }
-    setPendingEmail(newEmail)
+    setPendingEmail(nextEmail)
     setEmailStep(2)
     setTwoFactorPending(false)
     toast('Verification code sent to the new email.')
@@ -563,7 +576,7 @@ export default function UserProfileButton({
 
       let plain
       try {
-        plain = await decryptPayload(password, cloud.ciphertext, cloud.iv)
+        plain = await decryptLargePayload(password, cloud.ciphertext, cloud.iv)
       } catch {
         toast(t.incorrectPassword)
         return
@@ -637,12 +650,12 @@ export default function UserProfileButton({
   }
 
   async function enable() {
-    if (password !== confirm) {
-      setError(t.passwordsDoNotMatch)
+    if (!password) {
+      setError(t.setEncryptionPasswordDescription || 'Encryption key not ready')
       return
     }
     await setEncryptionPassword(password)
-    const payload = await encryptPayload(
+    const payload = await encryptLargePayload(
       password,
       JSON.stringify({
         v: BACKUP_VERSION,
@@ -666,21 +679,21 @@ export default function UserProfileButton({
   }
 
   async function rotate() {
-    if (password !== confirm) {
-      setError(t.passwordsDoNotMatch)
+    if (!password) {
+      setError(t.setEncryptionPasswordDescription || 'Encryption key not ready')
       return
     }
     const cloud = await apiGet()
     if (!cloud) return
 
     try {
-      await decryptPayload(oldPassword, cloud.ciphertext, cloud.iv)
+      await decryptLargePayload(oldPassword, cloud.ciphertext, cloud.iv)
     } catch {
       toast(t.incorrectOldPassword)
       return
     }
 
-    const next = await encryptPayload(
+    const next = await encryptLargePayload(
       password,
       JSON.stringify({
         v: BACKUP_VERSION,
@@ -1007,7 +1020,12 @@ export default function UserProfileButton({
                   <Button
                     id="settings-account-key"
                     variant="outline"
-                    onClick={() => setRotateOpen(true)}
+                    onClick={() => {
+                      const generated = generateHighEntropyKey()
+                      setPassword(generated)
+                      setConfirm(generated)
+                      setRotateOpen(true)
+                    }}
                   >
                     <KeyRound className="h-4 w-4 mr-2" />
                     {t.changeEncryptionKeyAction}
@@ -1441,6 +1459,9 @@ export default function UserProfileButton({
               <Button
                 onClick={() => {
                   setBackupOpen(false)
+                  const generated = generateHighEntropyKey()
+                  setPassword(generated)
+                  setConfirm(generated)
                   setSetPwdOpen(true)
                 }}
               >
@@ -1460,17 +1481,9 @@ export default function UserProfileButton({
             </DialogDescription>
           </DialogHeader>
           <Label>{t.password}</Label>
-          <Input
-            type="password"
-            value={password}
-            onChange={(e) => setPassword(e.target.value)}
-          />
+          <Input type="text" value={password} readOnly />
           <Label>{t.confirmPassword}</Label>
-          <Input
-            type="password"
-            value={confirm}
-            onChange={(e) => setConfirm(e.target.value)}
-          />
+          <Input type="text" value={confirm} readOnly />
           {error && <p className="text-sm text-red-500">{error}</p>}
           <DialogFooter>
             <Button onClick={enable}>{t.confirm}</Button>
@@ -1524,17 +1537,9 @@ export default function UserProfileButton({
             onChange={(e) => setOldPassword(e.target.value)}
           />
           <Label>{t.newPassword}</Label>
-          <Input
-            type="password"
-            value={password}
-            onChange={(e) => setPassword(e.target.value)}
-          />
+          <Input type="text" value={password} readOnly />
           <Label>{t.confirmNewPassword}</Label>
-          <Input
-            type="password"
-            value={confirm}
-            onChange={(e) => setConfirm(e.target.value)}
-          />
+          <Input type="text" value={confirm} readOnly />
           {error && <p className="text-sm text-red-500">{error}</p>}
           <DialogFooter>
             <Button onClick={rotate}>{t.confirmChange}</Button>

--- a/lib/crypto.ts
+++ b/lib/crypto.ts
@@ -142,3 +142,54 @@ export function isEncryptedPayload(value: unknown): value is EncryptedPayload {
   if (!value || typeof value !== 'object') return false
   return 'ciphertext' in value && 'iv' in value
 }
+
+const BACKUP_CHUNK_SIZE = 256 * 1024
+
+type ChunkedEncryptedPayload = {
+  v: 2
+  chunkSize: number
+  chunks: EncryptedPayload[]
+}
+
+export async function encryptLargePayload(password: string, text: string) {
+  if (text.length <= BACKUP_CHUNK_SIZE) {
+    return encryptPayload(password, text)
+  }
+
+  const chunks: EncryptedPayload[] = []
+  for (let i = 0; i < text.length; i += BACKUP_CHUNK_SIZE) {
+    const chunk = text.slice(i, i + BACKUP_CHUNK_SIZE)
+    chunks.push(await encryptPayload(password, chunk))
+  }
+
+  return {
+    ciphertext: JSON.stringify({
+      v: 2,
+      chunkSize: BACKUP_CHUNK_SIZE,
+      chunks,
+    } satisfies ChunkedEncryptedPayload),
+    iv: 'chunked-v2',
+  }
+}
+
+export async function decryptLargePayload(
+  password: string,
+  ciphertext: string,
+  iv: string,
+) {
+  if (iv !== 'chunked-v2') {
+    return decryptPayload(password, ciphertext, iv)
+  }
+
+  const parsed = JSON.parse(ciphertext) as ChunkedEncryptedPayload
+  if (!Array.isArray(parsed?.chunks)) {
+    throw new Error('Invalid chunked encrypted payload format')
+  }
+
+  const plainChunks = await Promise.all(
+    parsed.chunks.map((chunk) =>
+      decryptPayload(password, chunk.ciphertext, chunk.iv),
+    ),
+  )
+  return plainChunks.join('')
+}

--- a/lib/crypto.ts
+++ b/lib/crypto.ts
@@ -144,6 +144,7 @@ export function isEncryptedPayload(value: unknown): value is EncryptedPayload {
 }
 
 const BACKUP_CHUNK_SIZE = 256 * 1024
+const textEncoder = new TextEncoder()
 
 type ChunkedEncryptedPayload = {
   v: 2
@@ -151,18 +152,37 @@ type ChunkedEncryptedPayload = {
   chunks: EncryptedPayload[]
 }
 
-export async function encryptLargePayload(password: string, text: string) {
-  if (text.length <= BACKUP_CHUNK_SIZE) {
+export async function encryptLargePayload(
+  password: string,
+  text: string,
+): Promise<EncryptedPayload> {
+  const allBytes = textEncoder.encode(text)
+  if (allBytes.byteLength <= BACKUP_CHUNK_SIZE) {
     return encryptPayload(password, text)
   }
 
+  const textChunks: string[] = []
+  let current = ''
+  let currentBytes = 0
+  for (const char of text) {
+    const charBytes = textEncoder.encode(char).byteLength
+    if (currentBytes > 0 && currentBytes + charBytes > BACKUP_CHUNK_SIZE) {
+      textChunks.push(current)
+      current = char
+      currentBytes = charBytes
+    } else {
+      current += char
+      currentBytes += charBytes
+    }
+  }
+  if (current) textChunks.push(current)
+
   const chunks: EncryptedPayload[] = []
-  for (let i = 0; i < text.length; i += BACKUP_CHUNK_SIZE) {
-    const chunk = text.slice(i, i + BACKUP_CHUNK_SIZE)
+  for (const chunk of textChunks) {
     chunks.push(await encryptPayload(password, chunk))
   }
 
-  return {
+  const chunkedPayload: EncryptedPayload = {
     ciphertext: JSON.stringify({
       v: 2,
       chunkSize: BACKUP_CHUNK_SIZE,
@@ -170,19 +190,26 @@ export async function encryptLargePayload(password: string, text: string) {
     } satisfies ChunkedEncryptedPayload),
     iv: 'chunked-v2',
   }
+
+  return chunkedPayload
 }
 
 export async function decryptLargePayload(
   password: string,
   ciphertext: string,
   iv: string,
-) {
+): Promise<string> {
   if (iv !== 'chunked-v2') {
     return decryptPayload(password, ciphertext, iv)
   }
 
   const parsed = JSON.parse(ciphertext) as ChunkedEncryptedPayload
-  if (!Array.isArray(parsed?.chunks)) {
+  if (
+    !Array.isArray(parsed?.chunks) ||
+    typeof parsed?.chunkSize !== 'number' ||
+    !Number.isInteger(parsed.chunkSize) ||
+    parsed.chunkSize <= 0
+  ) {
     throw new Error('Invalid chunked encrypted payload format')
   }
 


### PR DESCRIPTION
### Motivation
- Allow larger backup payloads to be stored in the cloud by splitting into encrypted chunks and maintain backward compatibility with v1 payloads.
- Improve user experience by auto-generating high-entropy encryption keys for backups and preventing accidental modification of those keys in the UI.
- Harden email OTP flow to normalize the email address and attempt a fallback verification type when needed.

### Description
- Added chunked encryption/decryption support in `lib/crypto.ts` with `encryptLargePayload` and `decryptLargePayload`, using a `BACKUP_CHUNK_SIZE` of 256 KiB and producing a v2 chunked payload format while falling back to existing v1 behaviour for small or legacy payloads.
- Bumped `BACKUP_VERSION` to `2` and swapped usages of `encryptPayload`/`decryptPayload` to `encryptLargePayload`/`decryptLargePayload` where cloud backups are created, restored, or rotated.
- Added `generateHighEntropyKey()` which returns a 32-byte hex key via `crypto.getRandomValues` and wired it to pre-fill the password/confirm fields when enabling auto-backup or opening the rotate-key flow; made those password inputs read-only and visible as text so users can copy the generated key.
- Tweaked email change OTP flow to trim and lowercase the new email and attempt a fallback `sign-in` OTP type when `email-verification` returns an error.

### Testing
- Ran type checking (`tsc --noEmit`) and a local build (`pnpm build`) which completed without type or build errors.
- Ran the test suite (`pnpm test`) and lint (`pnpm lint`), both of which completed successfully on the modified code paths.
- Manually exercised the backup enable/rotate/restore flows locally to validate chunking, generation of keys, and UI changes during development.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a113b3262f48332b47a50fa4263f12b)

## Summary by Sourcery

引入分块备份加密格式（保持向后兼容的解密能力），并改进备份密钥的用户体验以及邮箱验证的可靠性。

New Features:
- 在新的 v2 备份格式中，新增对以固定大小分块的方式加密和解密大型备份负载的支持。
- 在启用或轮换云备份时自动生成高熵备份加密密钥，并以只读文本字段的形式展示，方便复制。

Bug Fixes:
- 在邮箱更改的 OTP 流程中对电子邮件地址进行规范化处理，并在邮箱验证 OTP 发送失败时回退到登录用的 OTP 类型。

Enhancements:
- 更新云备份操作以使用新的大负载加密辅助工具，并将备份版本提升到 2。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Introduce chunked backup encryption format with backward-compatible decryption and improve backup key UX and email verification robustness.

New Features:
- Add support for encrypting and decrypting large backup payloads in fixed-size chunks with a new v2 backup format.
- Auto-generate high-entropy backup encryption keys when enabling or rotating cloud backups and surface them as read-only text fields for easy copying.

Bug Fixes:
- Normalize email addresses during the email change OTP flow and fall back to a sign-in OTP type when email verification OTP sending fails.

Enhancements:
- Update cloud backup operations to use the new large-payload encryption helpers while bumping the backup version to 2.

</details>