### PR TITLE
Inline app SVG, normalize cloud backup payloads, adjust PBKDF2 iterations, and small UI/menu tweaks

### DIFF
--- a/components/app/auth-waiting-loading.tsx
+++ b/components/app/auth-waiting-loading.tsx
@@ -1,6 +1,7 @@
 'use client'
 
 import { translations, useLanguage } from '@/lib/i18n'
+import { GeistMono } from 'geist/font/mono'
 import { useEffect, useState } from 'react'
 
 export default function AuthWaitingLoading() {
@@ -48,8 +49,7 @@ export default function AuthWaitingLoading() {
           </g>
         </svg>
         <p
-          className="text-sm text-slate-700 dark:text-slate-300"
-          style={{ fontFamily: 'Geist Mono, monospace' }}
+          className={`${GeistMono.className} text-sm text-slate-700 dark:text-slate-300`}
         >
           {t.loadingCalendar}
           {'.'.repeat(dotCount)}

--- a/components/app/auth-waiting-loading.tsx
+++ b/components/app/auth-waiting-loading.tsx
@@ -22,25 +22,35 @@ export default function AuthWaitingLoading() {
     <div className="flex min-h-screen items-center justify-center bg-white px-6 dark:bg-black">
       <div className="flex flex-col items-center gap-5 text-center">
         <svg
+          version="1.0"
+          xmlns="http://www.w3.org/2000/svg"
           width="96"
           height="96"
-          viewBox="0 0 96 96"
-          fill="none"
-          xmlns="http://www.w3.org/2000/svg"
+          viewBox="0 0 1000 1000"
+          preserveAspectRatio="xMidYMid meet"
           aria-label="One Calendar"
           role="img"
           className="text-black dark:text-white"
         >
-          <circle cx="48" cy="14" r="9" fill="currentColor" />
-          <circle cx="30" cy="31" r="9" fill="currentColor" />
-          <circle cx="48" cy="31" r="9" fill="currentColor" />
-          <circle cx="48" cy="48" r="9" fill="currentColor" />
-          <circle cx="48" cy="65" r="9" fill="currentColor" />
-          <circle cx="30" cy="82" r="9" fill="currentColor" />
-          <circle cx="48" cy="82" r="9" fill="currentColor" />
-          <circle cx="66" cy="82" r="9" fill="currentColor" />
+          <g
+            transform="translate(0,1000) scale(0.1,-0.1)"
+            fill="currentColor"
+            stroke="none"
+          >
+            <path d="M4960 8206 c-87 -24 -164 -70 -231 -136 -101 -101 -149 -217 -149 -360 0 -144 48 -259 150 -360 102 -102 218 -150 360 -150 140 0 264 53 365 156 194 198 194 508 0 709 -67 69 -165 125 -253 144 -68 14 -184 13 -242 -3z" />
+            <path d="M3616 6859 c-109 -26 -239 -117 -307 -215 -97 -141 -111 -350 -34 -510 61 -126 166 -217 305 -264 55 -19 82 -21 175 -18 102 3 115 6 185 39 147 70 239 172 281 311 17 57 21 88 18 182 -4 109 -5 115 -46 198 -68 136 -202 245 -343 277 -54 13 -180 12 -234 0z" />
+            <path d="M4963 6855 c-228 -64 -383 -263 -383 -493 0 -149 45 -259 149 -363 105 -105 212 -149 362 -149 188 0 345 90 443 254 70 117 85 297 35 434 -48 130 -170 250 -306 302 -75 29 -225 37 -300 15z" />
+            <path d="M4940 5491 c-91 -29 -142 -61 -211 -130 -103 -103 -149 -214 -149 -361 0 -328 308 -570 629 -495 279 66 450 358 373 636 -46 164 -177 299 -340 349 -83 26 -224 26 -302 1z" />
+            <path d="M4980 4149 c-81 -16 -188 -76 -255 -145 -97 -100 -145 -215 -145 -354 0 -147 46 -258 149 -361 105 -105 212 -149 362 -149 455 0 680 547 358 869 -121 122 -296 174 -469 140z" />
+            <path d="M3601 2784 c-116 -31 -242 -125 -306 -229 -65 -105 -87 -283 -50 -410 61 -215 263 -365 490 -365 134 0 244 43 343 135 118 109 162 211 162 376 0 160 -46 267 -159 371 -103 96 -213 139 -351 137 -41 0 -99 -7 -129 -15z" />
+            <path d="M4959 2785 c-85 -23 -162 -69 -229 -135 -102 -101 -150 -216 -150 -360 0 -147 57 -278 162 -374 205 -187 515 -181 709 13 157 157 193 397 91 600 -56 112 -196 223 -326 257 -63 17 -195 17 -257 -1z" />
+            <path d="M6311 2784 c-76 -20 -146 -60 -212 -122 -113 -104 -159 -211 -159 -371 0 -189 74 -329 228 -431 103 -68 259 -97 385 -71 130 28 271 129 336 245 86 151 86 361 1 512 -38 65 -141 164 -208 198 -109 55 -256 71 -371 40z" />
+          </g>
         </svg>
-        <p className="font-geist-mono text-sm text-slate-700 dark:text-slate-300">
+        <p
+          className="text-sm text-slate-700 dark:text-slate-300"
+          style={{ fontFamily: 'Geist Mono, monospace' }}
+        >
           {t.loadingCalendar}
           {'.'.repeat(dotCount)}
         </p>

--- a/components/app/auth-waiting-loading.tsx
+++ b/components/app/auth-waiting-loading.tsx
@@ -2,7 +2,6 @@
 
 import { translations, useLanguage } from '@/lib/i18n'
 import { useEffect, useState } from 'react'
-import Image from 'next/image'
 
 export default function AuthWaitingLoading() {
   const [language] = useLanguage()
@@ -22,14 +21,26 @@ export default function AuthWaitingLoading() {
   return (
     <div className="flex min-h-screen items-center justify-center bg-white px-6 dark:bg-black">
       <div className="flex flex-col items-center gap-5 text-center">
-        <Image
-          src="/icon.svg"
-          alt="One Calendar"
-          width={96}
-          height={96}
-          priority
-        />
-        <p className="text-sm text-slate-700 dark:text-slate-300">
+        <svg
+          width="96"
+          height="96"
+          viewBox="0 0 96 96"
+          fill="none"
+          xmlns="http://www.w3.org/2000/svg"
+          aria-label="One Calendar"
+          role="img"
+          className="text-black dark:text-white"
+        >
+          <circle cx="48" cy="14" r="9" fill="currentColor" />
+          <circle cx="30" cy="31" r="9" fill="currentColor" />
+          <circle cx="48" cy="31" r="9" fill="currentColor" />
+          <circle cx="48" cy="48" r="9" fill="currentColor" />
+          <circle cx="48" cy="65" r="9" fill="currentColor" />
+          <circle cx="30" cy="82" r="9" fill="currentColor" />
+          <circle cx="48" cy="82" r="9" fill="currentColor" />
+          <circle cx="66" cy="82" r="9" fill="currentColor" />
+        </svg>
+        <p className="font-geist-mono text-sm text-slate-700 dark:text-slate-300">
           {t.loadingCalendar}
           {'.'.repeat(dotCount)}
         </p>

--- a/components/app/calendar.tsx
+++ b/components/app/calendar.tsx
@@ -27,6 +27,7 @@ import {
   MessageSquare,
   FileText,
   ScrollText,
+  House,
 } from 'lucide-react'
 import dynamic from 'next/dynamic'
 import {
@@ -78,6 +79,7 @@ import {
 } from '@/components/ui/alert-dialog'
 
 import { useRouter } from 'next/navigation'
+import { authClient } from '@/lib/auth/client'
 
 const loadDayView = () => import('@/components/app/views/day-view')
 const loadWeekView = () => import('@/components/app/views/week-view')
@@ -165,6 +167,8 @@ export default function Calendar({ className, ...props }: CalendarProps) {
     'uploading' | 'failed' | 'done' | null
   >(null)
   const [shareOnlyMode, setShareOnlyMode] = useState(false)
+  const { data: session } = authClient.useSession()
+  const isSignedIn = Boolean(session?.user)
 
   const updateEvent = (updatedEvent: CalendarEvent) => {
     setEvents((prevEvents) =>
@@ -887,6 +891,12 @@ export default function Calendar({ className, ...props }: CalendarProps) {
                   </Button>
                 </DropdownMenuTrigger>
                 <DropdownMenuContent align="end">
+                  {isSignedIn ? (
+                    <DropdownMenuItem onClick={() => router.push('/landing')}>
+                      <House className="mr-2 h-4 w-4" />
+                      {t.home || 'Home'}
+                    </DropdownMenuItem>
+                  ) : null}
                   <DropdownMenuItem
                     onClick={() =>
                       window.open(

--- a/components/app/profile/user-profile-button.tsx
+++ b/components/app/profile/user-profile-button.tsx
@@ -65,6 +65,7 @@ import {
   writeEncryptedLocalStorage,
   writeInMemoryStorage,
 } from '@/hooks/useLocalStorage'
+import { cn } from '@/lib/utils'
 
 const AUTO_KEY = 'auto-backup-enabled'
 const BACKUP_STATUS_KEY = 'auto-backup-sync-status'
@@ -878,7 +879,10 @@ export default function UserProfileButton({
               <Button
                 variant={variant}
                 size="icon"
-                className={`rounded-full overflow-hidden h-8 w-8 p-0 ${className}`}
+                className={cn(
+                  'rounded-full overflow-hidden h-8 w-8 p-0',
+                  className,
+                )}
               >
                 <img
                   src={user?.image || '/user.png'}

--- a/components/app/profile/user-profile-button.tsx
+++ b/components/app/profile/user-profile-button.tsx
@@ -173,6 +173,24 @@ async function normalizeCloudStorageValue(
   }
 }
 
+function parseCloudBackupPayload(plain: string): {
+  storage?: Record<string, unknown>
+  events?: unknown
+  calendars?: unknown
+} | null {
+  try {
+    return JSON.parse(plain)
+  } catch {
+    return null
+  }
+}
+
+function normalizeStorageRecord(storage: Record<string, unknown>) {
+  return Object.fromEntries(
+    Object.entries(storage).map(([key, value]) => [key, String(value)]),
+  )
+}
+
 async function applyCloudStorageToMemory(storage: Record<string, string>) {
   await Promise.all(
     Object.entries(storage).map(async ([key, value]) => {
@@ -583,34 +601,34 @@ export default function UserProfileButton({
       }
 
       try {
-        const data = JSON.parse(plain)
-        if (data?.storage) {
+        const data = parseCloudBackupPayload(plain)
+        const storage = data?.storage
+        const fallbackEvents = data?.events
+        const fallbackCalendars = data?.calendars
+
+        await setEncryptionPassword(password)
+
+        if (storage && typeof storage === 'object') {
+          const normalizedStorageRecord = normalizeStorageRecord(storage)
           const normalizedStorage = Object.fromEntries(
             await Promise.all(
-              Object.entries(data.storage).map(async ([key, value]) => [
-                key,
-                await normalizeCloudStorageValue(
-                  String(value),
-                  password,
-                  keyCache,
-                ),
-              ]),
+              Object.entries(normalizedStorageRecord).map(
+                async ([key, value]) => [
+                  key,
+                  await normalizeCloudStorageValue(value, password, keyCache),
+                ],
+              ),
             ),
           )
-          await setEncryptionPassword(password)
           await applyCloudStorageToMemory(normalizedStorage)
-        } else if (data?.events || data?.calendars) {
+        } else if (fallbackEvents || fallbackCalendars) {
           const fallbackStorage: Record<string, string> = {}
-          if (data?.events)
-            fallbackStorage['calendar-events'] = JSON.stringify(data.events)
-          if (data?.calendars)
-            fallbackStorage['calendar-categories'] = JSON.stringify(
-              data.calendars,
-            )
-          await setEncryptionPassword(password)
+          if (fallbackEvents)
+            fallbackStorage['calendar-events'] = JSON.stringify(fallbackEvents)
+          if (fallbackCalendars)
+            fallbackStorage['calendar-categories'] =
+              JSON.stringify(fallbackCalendars)
           await applyCloudStorageToMemory(fallbackStorage)
-        } else {
-          await setEncryptionPassword(password)
         }
 
         const [restoredEvents, restoredCalendars, restoredLanguage] =
@@ -858,9 +876,9 @@ export default function UserProfileButton({
           <DropdownMenuTrigger asChild>
             {isSignedIn ? (
               <Button
-                variant="ghost"
+                variant={variant}
                 size="icon"
-                className="rounded-full overflow-hidden h-8 w-8 p-0"
+                className={`rounded-full overflow-hidden h-8 w-8 p-0 ${className}`}
               >
                 <img
                   src={user?.image || '/user.png'}
@@ -873,16 +891,8 @@ export default function UserProfileButton({
                 />
               </Button>
             ) : (
-              <Button
-                variant="ghost"
-                size="icon"
-                className="rounded-full h-8 w-8 p-0 flex items-center justify-center bg-muted"
-              >
-                <span className="text-sm font-medium">
-                  {user?.name?.charAt(0).toUpperCase() ||
-                    user?.email?.charAt(0).toUpperCase() ||
-                    'U'}
-                </span>
+              <Button variant={variant} size="icon" className={className}>
+                <CircleUser className="h-4 w-4" />
               </Button>
             )}
           </DropdownMenuTrigger>

--- a/lib/crypto.ts
+++ b/lib/crypto.ts
@@ -3,6 +3,9 @@ export type EncryptedPayload = {
   iv: string
 }
 
+const DEFAULT_PBKDF2_ITERATIONS = 150000
+const LEGACY_PBKDF2_ITERATIONS = 250000
+
 type KeyCacheMap = Map<string, Promise<CryptoKey>>
 const MAX_CACHE_ENTRIES = 128
 
@@ -60,9 +63,10 @@ export async function deriveCryptoKey(
   password: string,
   salt: Uint8Array,
   cache = derivedKeyCache,
+  iterations = DEFAULT_PBKDF2_ITERATIONS,
 ) {
   const saltArray = new Uint8Array(salt)
-  const cacheKey = `${password}:${b64(saltArray)}`
+  const cacheKey = `${password}:${b64(saltArray)}:${iterations}`
   const cached = cache.get(cacheKey)
   if (cached) return cached
 
@@ -71,7 +75,7 @@ export async function deriveCryptoKey(
     {
       name: 'PBKDF2',
       salt: saltArray,
-      iterations: 250000,
+      iterations,
       hash: 'SHA-256',
     },
     baseKey,
@@ -84,9 +88,16 @@ export async function deriveCryptoKey(
   return derivedKey
 }
 
-function parseCiphertext(ciphertext: string): { salt: string; ct: string } {
+function parseCiphertext(ciphertext: string): {
+  salt: string
+  ct: string
+  kdfIter?: number
+} {
   const parsed = JSON.parse(ciphertext)
   if (typeof parsed?.salt !== 'string' || typeof parsed?.ct !== 'string') {
+    throw new Error('Invalid encrypted payload format')
+  }
+  if (parsed?.kdfIter !== undefined && typeof parsed.kdfIter !== 'number') {
     throw new Error('Invalid encrypted payload format')
   }
   return parsed
@@ -98,8 +109,13 @@ export async function decryptWithDerivedKey(
   iv: string,
   cache?: KeyCacheMap,
 ) {
-  const { salt, ct } = parseCiphertext(ciphertext)
-  const key = await deriveCryptoKey(password, ub64(salt), cache)
+  const { salt, ct, kdfIter } = parseCiphertext(ciphertext)
+  const key = await deriveCryptoKey(
+    password,
+    ub64(salt),
+    cache,
+    kdfIter ?? LEGACY_PBKDF2_ITERATIONS,
+  )
   const pt = await crypto.subtle.decrypt(
     { name: 'AES-GCM', iv: ub64(iv) },
     key,
@@ -125,6 +141,7 @@ export async function encryptPayload(
       v: 1,
       salt: b64(salt),
       ct: b64(new Uint8Array(ct)),
+      kdfIter: DEFAULT_PBKDF2_ITERATIONS,
     }),
     iv: b64(iv),
   }


### PR DESCRIPTION
### Motivation
- Replace external image asset with an inline SVG to simplify rendering and ensure proper dark-mode coloring and accessibility.
- Robustly handle legacy and new cloud backup formats by normalizing payloads and providing fallbacks for older backups.
- Migrate PBKDF2 iteration defaults while preserving ability to decrypt older payloads using their original iteration count.
- Surface a contextual "Home" menu entry for signed-in users and tidy up profile button styling.

### Description
- Replaced `Image` usage in `components/app/auth-waiting-loading.tsx` with an inline accessible SVG and adjusted the loading text styling to use `font-geist-mono`.
- Added `authClient.useSession()` to `components/app/calendar.tsx` and conditionally inserted a `House`-icon "Home" `DropdownMenuItem` that navigates to `/landing` when the user is signed in.
- In `components/app/profile/user-profile-button.tsx` added `parseCloudBackupPayload` and `normalizeStorageRecord`, normalized cloud backup records to strings, moved `setEncryptionPassword` earlier in the unlock flow, and supported fallback `events`/`calendars` payloads; also adjusted `Button` to use the passed `variant` and `className` and replaced the unauthenticated avatar placeholder with a `CircleUser` icon.
- In `lib/crypto.ts` introduced `DEFAULT_PBKDF2_ITERATIONS` (150000) and `LEGACY_PBKDF2_ITERATIONS` (250000), made `deriveCryptoKey` accept an `iterations` parameter and include it in the cache key, embedded `kdfIter` into newly encrypted payloads, and updated decryption to honor an embedded `kdfIter` while falling back to the legacy iteration count when absent.

### Testing
- Ran a full typecheck and build with `yarn build` which completed successfully.
- Executed the test suite with `yarn test` and all automated tests passed.
- Ran linting with `yarn lint` and no lint errors were reported.
- Verified a local development run (`yarn dev`) to confirm UI behavior for the updated menu and profile button interactions.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a1173b4f05c83328ff3e96ae3e63c9c)

## Summary by Sourcery

改进云备份处理、更新密钥派生默认配置，并优化与认证相关的界面元素。

新功能：
- 在已登录用户的日历视图中添加一个具有上下文关系的 Home 菜单项。

错误修复：
- 通过规范化并将其应用到存储中，正确处理仅包含事件/日历负载的旧版云备份。
- 在解密和恢复之前，确保云备份存储记录被规范化为字符串值。

增强改进：
- 将应用图标以内联可访问 SVG 的形式嵌入，并调整认证等待界面中的加载文本排版。
- 更新 PBKDF2 密钥派生逻辑，以在每个负载中嵌入并遵守独立的迭代次数，同时引入新的默认迭代常量和旧版迭代常量。
- 使用户资料按钮尊重传入的 variant/className 属性，并在未认证状态下使用一致的基于图标的占位符。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Improve cloud backup handling, update key-derivation defaults, and refine authentication-related UI elements.

New Features:
- Add a contextual Home menu entry in the calendar view for signed-in users.

Bug Fixes:
- Handle legacy cloud backups with events/calendars-only payloads by normalizing and applying them to storage.
- Ensure cloud backup storage records are normalized to string values before decryption and restore.

Enhancements:
- Inline the app icon as an accessible SVG and adjust loading text typography on the auth waiting screen.
- Update PBKDF2 key-derivation to embed and honor per-payload iteration counts while introducing new default and legacy iteration constants.
- Make the user profile button respect passed variant/className props and use a consistent icon-based placeholder when unauthenticated.

</details>