### PR TITLE
feat(settings): align settings header/cards and restore shortcuts dialog

### DIFF
--- a/components/app/profile/settings.tsx
+++ b/components/app/profile/settings.tsx
@@ -336,44 +336,64 @@ export default function Settings({
                   </DialogHeader>
                   <div className="space-y-2 text-sm">
                     <div className="flex justify-between gap-3">
-                      <span>N</span>
+                      <kbd className="min-w-8 rounded-md border bg-muted px-2 py-0.5 text-center font-mono text-xs">
+                        N
+                      </kbd>
                       <span>{t.newEvent}</span>
                     </div>
                     <div className="flex justify-between gap-3">
-                      <span>/</span>
+                      <kbd className="min-w-8 rounded-md border bg-muted px-2 py-0.5 text-center font-mono text-xs">
+                        /
+                      </kbd>
                       <span>{t.searchEvents}</span>
                     </div>
                     <div className="flex justify-between gap-3">
-                      <span>T</span>
+                      <kbd className="min-w-8 rounded-md border bg-muted px-2 py-0.5 text-center font-mono text-xs">
+                        T
+                      </kbd>
                       <span>{t.today}</span>
                     </div>
                     <div className="flex justify-between gap-3">
-                      <span>1</span>
+                      <kbd className="min-w-8 rounded-md border bg-muted px-2 py-0.5 text-center font-mono text-xs">
+                        1
+                      </kbd>
                       <span>{t.day}</span>
                     </div>
                     <div className="flex justify-between gap-3">
-                      <span>2</span>
+                      <kbd className="min-w-8 rounded-md border bg-muted px-2 py-0.5 text-center font-mono text-xs">
+                        2
+                      </kbd>
                       <span>{t.week}</span>
                     </div>
                     <div className="flex justify-between gap-3">
-                      <span>3</span>
+                      <kbd className="min-w-8 rounded-md border bg-muted px-2 py-0.5 text-center font-mono text-xs">
+                        3
+                      </kbd>
                       <span>{t.month}</span>
                     </div>
                     <div className="flex justify-between gap-3">
-                      <span>4</span>
+                      <kbd className="min-w-8 rounded-md border bg-muted px-2 py-0.5 text-center font-mono text-xs">
+                        4
+                      </kbd>
                       <span>{t.year}</span>
                     </div>
                     <div className="flex justify-between gap-3">
-                      <span>5</span>
+                      <kbd className="min-w-8 rounded-md border bg-muted px-2 py-0.5 text-center font-mono text-xs">
+                        5
+                      </kbd>
                       <span>{t.fourDay}</span>
                     </div>
                     <div className="flex justify-between gap-3">
-                      <span>←</span>
-                      <span>{t.previous}</span>
+                      <kbd className="min-w-8 rounded-md border bg-muted px-2 py-0.5 text-center font-mono text-xs">
+                        ←
+                      </kbd>
+                      <span>{t.previousPeriod}</span>
                     </div>
                     <div className="flex justify-between gap-3">
-                      <span>→</span>
-                      <span>{t.next}</span>
+                      <kbd className="min-w-8 rounded-md border bg-muted px-2 py-0.5 text-center font-mono text-xs">
+                        →
+                      </kbd>
+                      <span>{t.nextPeriod}</span>
                     </div>
                   </div>
                 </DialogContent>

--- a/components/app/profile/settings.tsx
+++ b/components/app/profile/settings.tsx
@@ -29,6 +29,13 @@ import {
 } from '@/components/app/calendar-types'
 import { Switch } from '@/components/ui/switch'
 import { Label } from '@/components/ui/label'
+import {
+  Dialog,
+  DialogContent,
+  DialogHeader,
+  DialogTitle,
+  DialogTrigger,
+} from '@/components/ui/dialog'
 import { useTheme } from 'next-themes'
 import {
   Bell,
@@ -164,161 +171,215 @@ export default function Settings({
 
   return (
     <div className="space-y-8 p-4 md:p-6">
-      <div className="rounded-2xl border bg-card/60 p-6 backdrop-blur">
-        <div className="flex items-center justify-between gap-3">
-          <h1 className="text-2xl font-bold">{t.settings}</h1>
-          <Button
-            variant="outline"
-            size="sm"
-            onClick={() => onBackToCalendar?.()}
-          >
-            <ArrowLeft className="mr-2 h-4 w-4" />
-            {t.back || 'Back'}
-          </Button>
-        </div>
-        <p className="mt-1 text-sm text-muted-foreground">
-          {t.calendarSettings || t.settings}
-        </p>
+      <div className="flex items-center justify-between gap-3">
+        <h1 className="text-2xl font-bold">{t.settings}</h1>
+        <Button
+          variant="outline"
+          size="sm"
+          onClick={() => onBackToCalendar?.()}
+        >
+          <ArrowLeft className="mr-2 h-4 w-4" />
+          {t.back || 'Back'}
+        </Button>
       </div>
 
-      <div className="grid gap-4 md:grid-cols-2 xl:grid-cols-3">
-        <div className="rounded-2xl border bg-card p-4 space-y-3">
-          <div className="flex items-center gap-2 text-sm font-semibold">
-            <Palette className="h-4 w-4" />
-            {t.theme}
+      <div className="rounded-lg border p-4 space-y-4">
+        <div className="grid gap-4 md:grid-cols-2 xl:grid-cols-3">
+          <div className="rounded-2xl border bg-card p-4 space-y-3">
+            <div className="flex items-center gap-2 text-sm font-semibold">
+              <Palette className="h-4 w-4" />
+              {t.theme}
+            </div>
+            <Select value={theme || 'system'} onValueChange={handleThemeChange}>
+              <SelectTrigger id="theme">
+                <SelectValue />
+              </SelectTrigger>
+              <SelectContent>
+                <SelectItem value="light">{t.themeLight}</SelectItem>
+                <SelectItem value="dark">{t.themeDark}</SelectItem>
+                <SelectItem value="green">{t.themeGreen}</SelectItem>
+                <SelectItem value="orange">{t.themeOrange}</SelectItem>
+                <SelectItem value="azalea">{t.themeAzalea}</SelectItem>
+                <SelectItem value="system">{t.themeSystem}</SelectItem>
+              </SelectContent>
+            </Select>
           </div>
-          <Select value={theme || 'system'} onValueChange={handleThemeChange}>
-            <SelectTrigger id="theme">
-              <SelectValue />
-            </SelectTrigger>
-            <SelectContent>
-              <SelectItem value="light">{t.themeLight}</SelectItem>
-              <SelectItem value="dark">{t.themeDark}</SelectItem>
-              <SelectItem value="green">{t.themeGreen}</SelectItem>
-              <SelectItem value="orange">{t.themeOrange}</SelectItem>
-              <SelectItem value="azalea">{t.themeAzalea}</SelectItem>
-              <SelectItem value="system">{t.themeSystem}</SelectItem>
-            </SelectContent>
-          </Select>
-        </div>
-        <div className="rounded-2xl border bg-card p-4 space-y-3">
-          <div className="flex items-center gap-2 text-sm font-semibold">
-            <Globe2 className="h-4 w-4" />
-            {t.language}
+          <div className="rounded-2xl border bg-card p-4 space-y-3">
+            <div className="flex items-center gap-2 text-sm font-semibold">
+              <Globe2 className="h-4 w-4" />
+              {t.language}
+            </div>
+            <Select
+              value={language}
+              onValueChange={(value: Language) => handleLanguageChange(value)}
+            >
+              <SelectTrigger id="language">
+                <SelectValue />
+              </SelectTrigger>
+              <SelectContent>
+                {supportedLanguages.map((lang) => (
+                  <SelectItem key={lang} value={lang}>
+                    {getLanguageAutonym(lang)}
+                  </SelectItem>
+                ))}
+              </SelectContent>
+            </Select>
           </div>
-          <Select
-            value={language}
-            onValueChange={(value: Language) => handleLanguageChange(value)}
-          >
-            <SelectTrigger id="language">
-              <SelectValue />
-            </SelectTrigger>
-            <SelectContent>
-              {supportedLanguages.map((lang) => (
-                <SelectItem key={lang} value={lang}>
-                  {getLanguageAutonym(lang)}
+          <div className="rounded-2xl border bg-card p-4 space-y-3">
+            <div className="flex items-center gap-2 text-sm font-semibold">
+              <CalendarDays className="h-4 w-4" />
+              {t.firstDayOfWeek}
+            </div>
+            <Select
+              value={firstDayOfWeek.toString()}
+              onValueChange={(value) => {
+                const day = Number(value)
+                setFirstDayOfWeek(day === 0 || day === 1 || day === 6 ? day : 0)
+              }}
+            >
+              <SelectTrigger id="first-day">
+                <SelectValue />
+              </SelectTrigger>
+              <SelectContent>
+                <SelectItem value="0">{t.sunday}</SelectItem>
+                <SelectItem value="1">{t.monday}</SelectItem>
+                <SelectItem value="6">{t.saturday}</SelectItem>
+              </SelectContent>
+            </Select>
+          </div>
+          <div className="rounded-2xl border bg-card p-4 space-y-3">
+            <div className="flex items-center gap-2 text-sm font-semibold">
+              <Monitor className="h-4 w-4" />
+              {t.defaultView}
+            </div>
+            <Select
+              value={defaultView}
+              onValueChange={(value) => {
+                if (isCalendarView(value)) {
+                  setDefaultView(value)
+                }
+              }}
+            >
+              <SelectTrigger id="default-view">
+                <SelectValue />
+              </SelectTrigger>
+              <SelectContent>
+                <SelectItem value="day">{t.day}</SelectItem>
+                <SelectItem value="week">{t.week}</SelectItem>
+                <SelectItem value="month">{t.month}</SelectItem>
+                <SelectItem value="year">{t.year}</SelectItem>
+                <SelectItem value="four-day">{t.fourDay}</SelectItem>
+              </SelectContent>
+            </Select>
+          </div>
+          <div className="rounded-2xl border bg-card p-4 space-y-3">
+            <div className="flex items-center gap-2 text-sm font-semibold">
+              <Globe2 className="h-4 w-4" />
+              {t.timezone}
+            </div>
+            <Select value={timezone} onValueChange={setTimezone}>
+              <SelectTrigger id="timezone">
+                <SelectValue />
+              </SelectTrigger>
+              <SelectContent className="max-h-[240px]">
+                {gmtTimezones.map((tz) => (
+                  <SelectItem key={tz.value} value={tz.value}>
+                    {tz.label}
+                  </SelectItem>
+                ))}
+              </SelectContent>
+            </Select>
+          </div>
+          <div className="rounded-2xl border bg-card p-4 space-y-3">
+            <div className="flex items-center gap-2 text-sm font-semibold">
+              <Bell className="h-4 w-4" />
+              {t.timeFormat}
+            </div>
+            <Select
+              value={timeFormat}
+              onValueChange={(value: '24h' | '12h') => setTimeFormat(value)}
+            >
+              <SelectTrigger id="time-format">
+                <SelectValue />
+              </SelectTrigger>
+              <SelectContent>
+                <SelectItem value="24h">{t.timeFormat24h}</SelectItem>
+                <SelectItem value="12h">
+                  {t.timeFormat12hWithMeridiem}
                 </SelectItem>
-              ))}
-            </SelectContent>
-          </Select>
-        </div>
-        <div className="rounded-2xl border bg-card p-4 space-y-3">
-          <div className="flex items-center gap-2 text-sm font-semibold">
-            <CalendarDays className="h-4 w-4" />
-            {t.firstDayOfWeek}
+              </SelectContent>
+            </Select>
           </div>
-          <Select
-            value={firstDayOfWeek.toString()}
-            onValueChange={(value) => {
-              const day = Number(value)
-              setFirstDayOfWeek(day === 0 || day === 1 || day === 6 ? day : 0)
-            }}
-          >
-            <SelectTrigger id="first-day">
-              <SelectValue />
-            </SelectTrigger>
-            <SelectContent>
-              <SelectItem value="0">{t.sunday}</SelectItem>
-              <SelectItem value="1">{t.monday}</SelectItem>
-              <SelectItem value="6">{t.saturday}</SelectItem>
-            </SelectContent>
-          </Select>
-        </div>
-        <div className="rounded-2xl border bg-card p-4 space-y-3">
-          <div className="flex items-center gap-2 text-sm font-semibold">
-            <Monitor className="h-4 w-4" />
-            {t.defaultView}
+          <div className="rounded-2xl border bg-card p-4 space-y-4">
+            <div className="flex items-center gap-2 text-sm font-semibold">
+              <Keyboard className="h-4 w-4" />
+              {t.enableShortcuts}
+            </div>
+            <div className="flex items-center justify-between gap-3">
+              <div className="flex items-center gap-3">
+                <Switch
+                  id="enable-shortcuts"
+                  checked={enableShortcuts}
+                  onCheckedChange={setEnableShortcuts}
+                />
+                <Label htmlFor="enable-shortcuts">{t.enableShortcuts}</Label>
+              </div>
+              <Dialog>
+                <DialogTrigger asChild>
+                  <Button variant="outline" size="sm">
+                    {t.availableShortcuts}
+                  </Button>
+                </DialogTrigger>
+                <DialogContent>
+                  <DialogHeader>
+                    <DialogTitle>{t.availableShortcuts}</DialogTitle>
+                  </DialogHeader>
+                  <div className="space-y-2 text-sm">
+                    <div className="flex justify-between gap-3">
+                      <span>N</span>
+                      <span>{t.newEvent}</span>
+                    </div>
+                    <div className="flex justify-between gap-3">
+                      <span>/</span>
+                      <span>{t.searchEvents}</span>
+                    </div>
+                    <div className="flex justify-between gap-3">
+                      <span>T</span>
+                      <span>{t.today}</span>
+                    </div>
+                    <div className="flex justify-between gap-3">
+                      <span>1</span>
+                      <span>{t.day}</span>
+                    </div>
+                    <div className="flex justify-between gap-3">
+                      <span>2</span>
+                      <span>{t.week}</span>
+                    </div>
+                    <div className="flex justify-between gap-3">
+                      <span>3</span>
+                      <span>{t.month}</span>
+                    </div>
+                    <div className="flex justify-between gap-3">
+                      <span>4</span>
+                      <span>{t.year}</span>
+                    </div>
+                    <div className="flex justify-between gap-3">
+                      <span>5</span>
+                      <span>{t.fourDay}</span>
+                    </div>
+                    <div className="flex justify-between gap-3">
+                      <span>←</span>
+                      <span>{t.previous}</span>
+                    </div>
+                    <div className="flex justify-between gap-3">
+                      <span>→</span>
+                      <span>{t.next}</span>
+                    </div>
+                  </div>
+                </DialogContent>
+              </Dialog>
+            </div>
           </div>
-          <Select
-            value={defaultView}
-            onValueChange={(value) => {
-              if (isCalendarView(value)) {
-                setDefaultView(value)
-              }
-            }}
-          >
-            <SelectTrigger id="default-view">
-              <SelectValue />
-            </SelectTrigger>
-            <SelectContent>
-              <SelectItem value="day">{t.day}</SelectItem>
-              <SelectItem value="week">{t.week}</SelectItem>
-              <SelectItem value="month">{t.month}</SelectItem>
-              <SelectItem value="year">{t.year}</SelectItem>
-              <SelectItem value="four-day">{t.fourDay}</SelectItem>
-            </SelectContent>
-          </Select>
-        </div>
-        <div className="rounded-2xl border bg-card p-4 space-y-3 md:col-span-2 xl:col-span-1">
-          <div className="flex items-center gap-2 text-sm font-semibold">
-            <Globe2 className="h-4 w-4" />
-            {t.timezone}
-          </div>
-          <Select value={timezone} onValueChange={setTimezone}>
-            <SelectTrigger id="timezone">
-              <SelectValue />
-            </SelectTrigger>
-            <SelectContent className="max-h-[240px]">
-              {gmtTimezones.map((tz) => (
-                <SelectItem key={tz.value} value={tz.value}>
-                  {tz.label}
-                </SelectItem>
-              ))}
-            </SelectContent>
-          </Select>
-        </div>
-        <div className="rounded-2xl border bg-card p-4 space-y-3">
-          <div className="flex items-center gap-2 text-sm font-semibold">
-            <Bell className="h-4 w-4" />
-            {t.timeFormat}
-          </div>
-          <Select
-            value={timeFormat}
-            onValueChange={(value: '24h' | '12h') => setTimeFormat(value)}
-          >
-            <SelectTrigger id="time-format">
-              <SelectValue />
-            </SelectTrigger>
-            <SelectContent>
-              <SelectItem value="24h">{t.timeFormat24h}</SelectItem>
-              <SelectItem value="12h">{t.timeFormat12hWithMeridiem}</SelectItem>
-            </SelectContent>
-          </Select>
-        </div>
-      </div>
-
-      <div className="rounded-2xl border bg-card p-4 space-y-4">
-        <div className="flex items-center gap-2 text-sm font-semibold">
-          <Keyboard className="h-4 w-4" />
-          {t.enableShortcuts}
-        </div>
-        <div className="flex items-center gap-3">
-          <Switch
-            id="enable-shortcuts"
-            checked={enableShortcuts}
-            onCheckedChange={setEnableShortcuts}
-          />
-          <Label htmlFor="enable-shortcuts">{t.enableShortcuts}</Label>
         </div>
       </div>
 


### PR DESCRIPTION
### Motivation
- Make the settings page header consistent with the analytics view by removing the extra top card and using a plain title + back button row. 
- Group the top-level appearance and calendar options into a single outer card that visually matches the account management card. 
- Ensure the timezone and time format controls flow together so the time format appears directly after the timezone. 
- Restore a discoverable keyboard shortcuts UI so users can view the available shortcuts in a dialog while keeping the enable/disable switch.

### Description
- Updated `components/app/profile/settings.tsx` to simplify the header and remove the previous top card wrapper. 
- Wrapped theme, language, first-day, default-view, timezone, time-format and shortcuts into a single outer bordered card (`rounded-lg border p-4 space-y-4`) to match account-area styling. 
- Moved the `timeFormat` select to follow the `timezone` select within the same grid flow. 
- Added `Dialog` imports and a shortcuts dialog UI showing mappings (N, `/`, T, 1–5 and arrow keys) and a trigger button (`Available Shortcuts`), while keeping the `Enable Keyboard Shortcuts` `Switch` wired to `setEnableShortcuts`.

### Testing
- Ran pre-commit automated checks where `prettier` formatting, `oxlint --fix`, and `eslint --fix` were executed and passed on the final commit. 
- Commit message linting initially flagged the message format but was corrected outside of the code changes and did not affect the runtime behavior. 
- No unit/integration test suite or screenshots were run as per repository/user constraints.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a11aef94940833286e3eb902c8c51ed)

## Sourcery 总结

使设置页面的布局与其他视图保持一致，并提升在个人资料设置中发现键盘快捷键的便捷性。

新功能：
- 在设置中新增键盘快捷键对话框，列出可用的快捷键及其对应操作。

增强改进：
- 将设置页头部简化为仅包含标题和返回按钮的行，不再使用额外的卡片包装。
- 将外观、日历、时区、时间格式和键盘快捷键等设置分组到单个带边框的卡片中，以形成更统一的布局。
- 将时间格式选择器放在时区选择器旁边，以便将相关的时间设置集中在一起。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Align the settings page layout with other views and improve keyboard shortcuts discoverability in the profile settings.

New Features:
- Add a keyboard shortcuts dialog in settings that lists available shortcut keys and their actions.

Enhancements:
- Simplify the settings header to a plain title and back button row without an extra card wrapper.
- Group appearance, calendar, timezone, time format, and keyboard shortcut settings into a single bordered card for a more cohesive layout.
- Place the time format selector alongside the timezone selector to keep related time settings together.

</details>