### PR TITLE
fix(calendar): dark-mode drag preview in Day/Week views and bump version to 2.5.0

### DIFF
--- a/components/app/views/day-view.tsx
+++ b/components/app/views/day-view.tsx
@@ -8,6 +8,10 @@ import { cn } from '@/lib/utils'
 import type { CalendarEvent } from '../calendar'
 import { translations, type Language } from '@/lib/i18n'
 import { formatSelectionRange } from '@/components/app/views/selection-range'
+import {
+  getEventAccentColor,
+  getEventBackgroundColor,
+} from '@/components/app/views/event-colors'
 
 const ContextMenu = ({ children }: { children: React.ReactNode }) => (
   <>{children}</>
@@ -138,38 +142,6 @@ export default function DayView({
       timeZone: timezone,
     }
     return new Intl.DateTimeFormat(language, options).format(date)
-  }
-
-  function getDarkerColorClass(color: string) {
-    const colorMapping: Record<string, string> = {
-      'bg-[#E6F6FD]': '#3B82F6',
-      'bg-[#E7F8F2]': '#10B981',
-      'bg-[#FEF5E6]': '#F59E0B',
-      'bg-[#FFE4E6]': '#EF4444',
-      'bg-[#F3EEFE]': '#8B5CF6',
-      'bg-[#FCE7F3]': '#EC4899',
-      'bg-[#EEF2FF]': '#6366F1',
-      'bg-[#FFF0E5]': '#FB923C',
-      'bg-[#E6FAF7]': '#14B8A6',
-    }
-
-    return colorMapping[color] || '#3A3A3A'
-  }
-
-  function getEventBackgroundColor(color: string) {
-    if (!isDark) return undefined
-
-    const darkModeColorMapping: Record<string, string> = {
-      'bg-[#E6F6FD]': '#2F4655',
-      'bg-[#E7F8F2]': '#2D4935',
-      'bg-[#FEF5E6]': '#4F3F1B',
-      'bg-[#FFE4E6]': '#6C2920',
-      'bg-[#F3EEFE]': '#483A63',
-      'bg-[#FCE7F3]': '#5A334A',
-      'bg-[#E6FAF7]': '#1F4A47',
-    }
-
-    return darkModeColorMapping[color]
   }
 
   const isAllDayEvent = (event: CalendarEvent) => {
@@ -523,7 +495,7 @@ export default function DayView({
               left: '0',
               right: '0',
               opacity: isDark ? 1 : 0.9,
-              backgroundColor: getEventBackgroundColor(event.color),
+              backgroundColor: getEventBackgroundColor(event.color, isDark),
               zIndex: 10 + index,
             }}
             onMouseDown={(e) => handleEventDragStart(event, e)}
@@ -544,11 +516,11 @@ export default function DayView({
           >
             <div
               className={cn('absolute left-0 top-0 w-1 h-full rounded-l-md')}
-              style={{ backgroundColor: getDarkerColorClass(event.color) }}
+              style={{ backgroundColor: getEventAccentColor(event.color) }}
             />
             <div
               className="pl-1.5 truncate"
-              style={{ color: getDarkerColorClass(event.color) }}
+              style={{ color: getEventAccentColor(event.color) }}
             >
               {event.title}
             </div>
@@ -626,18 +598,21 @@ export default function DayView({
           left: '2px',
           zIndex: 100,
           border: '2px dashed white',
-          backgroundColor: getEventBackgroundColor(draggingEvent.color),
+          backgroundColor: getEventBackgroundColor(
+            draggingEvent?.color,
+            isDark,
+          ),
           pointerEvents: 'none',
         }}
       >
         <div
           className={cn('absolute left-0 top-0 w-1 h-full rounded-l-md')}
-          style={{ backgroundColor: getDarkerColorClass(draggingEvent.color) }}
+          style={{ backgroundColor: getEventAccentColor(draggingEvent.color) }}
         />
         <div className="pl-1">
           <div
             className="font-medium truncate"
-            style={{ color: getDarkerColorClass(draggingEvent.color) }}
+            style={{ color: getEventAccentColor(draggingEvent.color) }}
           >
             {draggingEvent.title}
           </div>
@@ -770,7 +745,10 @@ export default function DayView({
                       top: `${startMinutes}px`,
                       height: `${height}px`,
                       opacity: isDark ? 1 : 0.9,
-                      backgroundColor: getEventBackgroundColor(event.color),
+                      backgroundColor: getEventBackgroundColor(
+                        event.color,
+                        isDark,
+                      ),
                       width,
                       left,
                       zIndex: column + 1,
@@ -791,14 +769,14 @@ export default function DayView({
                         'absolute left-0 top-0 w-1 h-full rounded-l-md',
                       )}
                       style={{
-                        backgroundColor: getDarkerColorClass(event.color),
+                        backgroundColor: getEventAccentColor(event.color),
                       }}
                     />
                     <div className="pl-1">
                       <div
                         className="font-medium leading-tight break-words"
                         style={{
-                          color: getDarkerColorClass(event.color),
+                          color: getEventAccentColor(event.color),
                           display: '-webkit-box',
                           WebkitBoxOrient: 'vertical',
                           WebkitLineClamp: Math.max(
@@ -814,7 +792,7 @@ export default function DayView({
                       {height >= 40 && (
                         <div
                           className="text-xs truncate"
-                          style={{ color: getDarkerColorClass(event.color) }}
+                          style={{ color: getEventAccentColor(event.color) }}
                         >
                           {formatDateWithTimezone(start)} -{' '}
                           {formatDateWithTimezone(end)}

--- a/components/app/views/day-view.tsx
+++ b/components/app/views/day-view.tsx
@@ -626,6 +626,7 @@ export default function DayView({
           left: '2px',
           zIndex: 100,
           border: '2px dashed white',
+          backgroundColor: getEventBackgroundColor(draggingEvent.color),
           pointerEvents: 'none',
         }}
       >

--- a/components/app/views/event-colors.ts
+++ b/components/app/views/event-colors.ts
@@ -1,0 +1,35 @@
+export function getEventAccentColor(color?: string) {
+  const colorMapping: Record<string, string> = {
+    'bg-[#E6F6FD]': '#3B82F6',
+    'bg-[#E7F8F2]': '#10B981',
+    'bg-[#FEF5E6]': '#F59E0B',
+    'bg-[#FFE4E6]': '#EF4444',
+    'bg-[#F3EEFE]': '#8B5CF6',
+    'bg-[#FCE7F3]': '#EC4899',
+    'bg-[#EEF2FF]': '#6366F1',
+    'bg-[#FFF0E5]': '#FB923C',
+    'bg-[#E6FAF7]': '#14B8A6',
+  }
+
+  if (!color) return '#3A3A3A'
+  return colorMapping[color] || '#3A3A3A'
+}
+
+export function getEventBackgroundColor(
+  color: string | undefined,
+  isDark: boolean,
+) {
+  if (!isDark || !color) return undefined
+
+  const darkModeColorMapping: Record<string, string> = {
+    'bg-[#E6F6FD]': '#2F4655',
+    'bg-[#E7F8F2]': '#2D4935',
+    'bg-[#FEF5E6]': '#4F3F1B',
+    'bg-[#FFE4E6]': '#6C2920',
+    'bg-[#F3EEFE]': '#483A63',
+    'bg-[#FCE7F3]': '#5A334A',
+    'bg-[#E6FAF7]': '#1F4A47',
+  }
+
+  return darkModeColorMapping[color]
+}

--- a/components/app/views/week-view.tsx
+++ b/components/app/views/week-view.tsx
@@ -19,6 +19,10 @@ import { translations, type Language } from '@/lib/i18n'
 import type { CalendarEvent } from '../calendar'
 import type { FirstDayOfWeek } from '@/components/app/calendar-types'
 import { formatSelectionRange } from '@/components/app/views/selection-range'
+import {
+  getEventAccentColor,
+  getEventBackgroundColor,
+} from '@/components/app/views/event-colors'
 
 const ContextMenu = ({ children }: { children: React.ReactNode }) => (
   <>{children}</>
@@ -140,38 +144,6 @@ export default function WeekView({
     share: t.share,
     bookmark: t.bookmark,
     delete: t.delete,
-  }
-
-  function getDarkerColorClass(color: string) {
-    const colorMapping: Record<string, string> = {
-      'bg-[#E6F6FD]': '#3B82F6',
-      'bg-[#E7F8F2]': '#10B981',
-      'bg-[#FEF5E6]': '#F59E0B',
-      'bg-[#FFE4E6]': '#EF4444',
-      'bg-[#F3EEFE]': '#8B5CF6',
-      'bg-[#FCE7F3]': '#EC4899',
-      'bg-[#EEF2FF]': '#6366F1',
-      'bg-[#FFF0E5]': '#FB923C',
-      'bg-[#E6FAF7]': '#14B8A6',
-    }
-
-    return colorMapping[color] || '#3A3A3A'
-  }
-
-  function getEventBackgroundColor(color: string) {
-    if (!isDark) return undefined
-
-    const darkModeColorMapping: Record<string, string> = {
-      'bg-[#E6F6FD]': '#2F4655',
-      'bg-[#E7F8F2]': '#2D4935',
-      'bg-[#FEF5E6]': '#4F3F1B',
-      'bg-[#FFE4E6]': '#6C2920',
-      'bg-[#F3EEFE]': '#483A63',
-      'bg-[#FCE7F3]': '#5A334A',
-      'bg-[#E6FAF7]': '#1F4A47',
-    }
-
-    return darkModeColorMapping[color]
   }
 
   useEffect(() => {
@@ -631,7 +603,7 @@ export default function WeekView({
               left: '0',
               right: '0',
               opacity: isDark ? 1 : 0.9,
-              backgroundColor: getEventBackgroundColor(event.color),
+              backgroundColor: getEventBackgroundColor(event.color, isDark),
               zIndex: 10 + index,
             }}
             onMouseDown={(e) => handleEventDragStart(event, e)}
@@ -652,11 +624,11 @@ export default function WeekView({
           >
             <div
               className={cn('absolute left-0 top-0 w-1 h-full rounded-l-md')}
-              style={{ backgroundColor: getDarkerColorClass(event.color) }}
+              style={{ backgroundColor: getEventAccentColor(event.color) }}
             />
             <div
               className="pl-1.5 truncate"
-              style={{ color: getDarkerColorClass(event.color) }}
+              style={{ color: getEventAccentColor(event.color) }}
             >
               {event.title}
             </div>
@@ -739,18 +711,21 @@ export default function WeekView({
           left: '2px',
           zIndex: 100,
           border: '2px dashed white',
-          backgroundColor: getEventBackgroundColor(draggingEvent.color),
+          backgroundColor: getEventBackgroundColor(
+            draggingEvent?.color,
+            isDark,
+          ),
           pointerEvents: 'none',
         }}
       >
         <div
           className={cn('absolute left-0 top-0 w-1 h-full rounded-l-md')}
-          style={{ backgroundColor: getDarkerColorClass(draggingEvent.color) }}
+          style={{ backgroundColor: getEventAccentColor(draggingEvent.color) }}
         />
         <div className="pl-1">
           <div
             className="font-medium truncate"
-            style={{ color: getDarkerColorClass(draggingEvent.color) }}
+            style={{ color: getEventAccentColor(draggingEvent.color) }}
           >
             {draggingEvent.title}
           </div>
@@ -908,14 +883,14 @@ export default function WeekView({
                               'absolute left-0 top-0 w-1 h-full rounded-l-md',
                             )}
                             style={{
-                              backgroundColor: getDarkerColorClass(event.color),
+                              backgroundColor: getEventAccentColor(event.color),
                             }}
                           />
                           <div className="pl-1">
                             <div
                               className="font-medium leading-tight break-words"
                               style={{
-                                color: getDarkerColorClass(event.color),
+                                color: getEventAccentColor(event.color),
                                 display: '-webkit-box',
                                 WebkitBoxOrient: 'vertical',
                                 WebkitLineClamp: Math.max(
@@ -932,7 +907,7 @@ export default function WeekView({
                               <div
                                 className="text-xs truncate"
                                 style={{
-                                  color: getDarkerColorClass(event.color),
+                                  color: getEventAccentColor(event.color),
                                 }}
                               >
                                 {formatDateWithTimezone(start)} -{' '}

--- a/components/app/views/week-view.tsx
+++ b/components/app/views/week-view.tsx
@@ -739,6 +739,7 @@ export default function WeekView({
           left: '2px',
           zIndex: 100,
           border: '2px dashed white',
+          backgroundColor: getEventBackgroundColor(draggingEvent.color),
           pointerEvents: 'none',
         }}
       >

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "one-calendar",
-  "version": "2.4.1",
+  "version": "2.5.0",
   "private": true,
   "packageManager": "pnpm@11.1.2",
   "scripts": {


### PR DESCRIPTION
### Motivation
- Dragging an event in Day and Week views showed a light background in dark mode, causing contrast and visibility issues during drag operations.
- Ensure the drag preview respects the app's dark-mode color mappings so the preview matches the rendered event appearance.
- Bump the app version to reflect the user-visible fix by updating `package.json` to `2.5.0`.

### Description
- Apply `backgroundColor: getEventBackgroundColor(draggingEvent.color)` to the drag-preview style in `components/app/views/day-view.tsx` so the preview uses the dark-mode background mapping when `isDark`.
- Apply the same `backgroundColor` change to the drag-preview style in `components/app/views/week-view.tsx` to keep Week/Four-day drag previews consistent with dark mode.
- Update `package.json` `version` from `2.4.1` to `2.5.0`.

### Testing
- Pre-commit formatting and lint hooks (`prettier`, `oxlint`, `eslint`) ran automatically and completed successfully on the modified files.
- No unit or integration tests were executed per the change request (no additional automated test runs were performed).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a11b794d79c8332bdabfad0af77370e)

## Summary by Sourcery

确保日历事件拖拽预览遵循深色模式样式，并提升应用版本。

Bug 修复：
- 修复「日」视图中的拖拽预览背景，使事件预览在深色模式下使用正确的主题颜色。
- 修复「周」视图中的拖拽预览背景，使事件预览在深色模式下使用正确的主题颜色。

构建：
- 将 `package.json` 版本从 2.4.1 更新到 2.5.0。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Ensure calendar event drag previews respect dark-mode styling and bump the application version.

Bug Fixes:
- Fix Day view drag-preview background so event previews use the correct themed color in dark mode.
- Fix Week view drag-preview background so event previews use the correct themed color in dark mode.

Build:
- Update package.json version from 2.4.1 to 2.5.0.

</details>