### PR TITLE
Server-side encryption and per-event calendar backup refactor

### DIFF
--- a/app/api/blob/route.ts
+++ b/app/api/blob/route.ts
@@ -2,8 +2,15 @@ import { NextRequest, NextResponse } from 'next/server'
 import { withEvlog, useLogger, getAuditActor } from '@/lib/evlog'
 import { getServerSession } from '@/lib/auth/server'
 import { db } from '@/lib/drizzle/client'
-import { calendarBackups } from '@/lib/drizzle/schema'
-import { eq } from 'drizzle-orm'
+import {
+  calendarBackups,
+  calendarBookmarks,
+  calendarCategories,
+  calendarCountdowns,
+  userSettings,
+} from '@/lib/drizzle/schema'
+import { and, asc, eq, gte, lte } from 'drizzle-orm'
+import { decryptServerJson, encryptServerJson } from '@/lib/server-crypto'
 
 export const runtime = 'nodejs'
 export const dynamic = 'force-dynamic'
@@ -21,53 +28,270 @@ function jsonNoStore(body: unknown, init?: ResponseInit) {
   })
 }
 
+async function requireUser(log: ReturnType<typeof useLogger>) {
+  const session = await getServerSession()
+  const user = session?.user
+  if (!user?.id) {
+    log.audit?.({
+      action: 'calendar_data.access',
+      actor: getAuditActor(log),
+      target: { type: 'calendar_data', id: 'unknown' },
+      outcome: 'denied',
+      reason: 'Authentication required',
+    })
+    return null
+  }
+  return user
+}
+
+function asDate(value: unknown, fallback: Date) {
+  if (typeof value !== 'string') return fallback
+  const date = new Date(value)
+  return Number.isNaN(date.getTime()) ? fallback : date
+}
+
+function normalizeEvent(raw: any) {
+  const startDate = asDate(raw?.startDate, new Date())
+  const endDate = asDate(
+    raw?.endDate,
+    new Date(startDate.getTime() + 60 * 60 * 1000),
+  )
+  return {
+    id: String(raw?.id || crypto.randomUUID()),
+    title: String(raw?.title || ''),
+    startDate: startDate.toISOString(),
+    endDate: endDate.toISOString(),
+    isAllDay: Boolean(raw?.isAllDay),
+    recurrence: ['none', 'daily', 'weekly', 'monthly', 'yearly'].includes(
+      raw?.recurrence,
+    )
+      ? raw.recurrence
+      : 'none',
+    location: typeof raw?.location === 'string' ? raw.location : undefined,
+    participants: Array.isArray(raw?.participants) ? raw.participants : [],
+    notification: Number.isFinite(Number(raw?.notification))
+      ? Number(raw.notification)
+      : 0,
+    description:
+      typeof raw?.description === 'string' ? raw.description : undefined,
+    color: String(raw?.color || 'bg-blue-500'),
+    calendarId: String(raw?.calendarId || ''),
+  }
+}
+
+function decryptRows<T>(
+  rows: Array<{ encryptedData: string; iv: string; authTag: string }>,
+  scope: string,
+) {
+  return rows.flatMap((row) => {
+    try {
+      return [
+        decryptServerJson<T>(row.encryptedData, row.iv, row.authTag, scope),
+      ]
+    } catch {
+      return []
+    }
+  })
+}
+
+export const GET = withEvlog(async function GET(req: NextRequest) {
+  try {
+    const log = useLogger()
+    const user = await requireUser(log)
+    if (!user) return jsonNoStore({ error: 'Unauthorized' }, { status: 401 })
+
+    const now = new Date()
+    const start = asDate(
+      req.nextUrl.searchParams.get('start'),
+      new Date(now.getFullYear(), now.getMonth() - 1, 1),
+    )
+    const end = asDate(
+      req.nextUrl.searchParams.get('end'),
+      new Date(now.getFullYear(), now.getMonth() + 2, 0, 23, 59, 59, 999),
+    )
+
+    const [eventRows, categoryRows, settingsRow, bookmarkRows, countdownRows] =
+      await Promise.all([
+        db
+          .select()
+          .from(calendarBackups)
+          .where(
+            and(
+              eq(calendarBackups.userId, user.id),
+              lte(calendarBackups.startDate, end),
+              gte(calendarBackups.endDate, start),
+            ),
+          )
+          .orderBy(asc(calendarBackups.startDate)),
+        db
+          .select()
+          .from(calendarCategories)
+          .where(eq(calendarCategories.userId, user.id))
+          .orderBy(asc(calendarCategories.position)),
+        db.select().from(userSettings).where(eq(userSettings.userId, user.id)),
+        db
+          .select()
+          .from(calendarBookmarks)
+          .where(eq(calendarBookmarks.userId, user.id)),
+        db
+          .select()
+          .from(calendarCountdowns)
+          .where(eq(calendarCountdowns.userId, user.id)),
+      ])
+
+    return jsonNoStore({
+      backend: 'postgres',
+      range: { start: start.toISOString(), end: end.toISOString() },
+      events: decryptRows(eventRows, 'calendar-event'),
+      calendars: decryptRows(categoryRows, 'calendar-category'),
+      settings: settingsRow[0]?.settings ?? {},
+      bookmarks: decryptRows(bookmarkRows, 'calendar-bookmark'),
+      countdowns: decryptRows(countdownRows, 'calendar-countdown'),
+    })
+  } catch (e: unknown) {
+    const message = e instanceof Error ? e.message : 'Internal error'
+    return jsonNoStore({ error: message }, { status: 500 })
+  }
+})
+
 export const POST = withEvlog(async function POST(req: NextRequest) {
   try {
     const log = useLogger()
-    const [session, body] = await Promise.all([getServerSession(), req.json()])
-    const user = session?.user
-    const userId = user?.id
-
-    if (!userId) {
-      log.audit?.({
-        action: 'calendar_backup.upsert',
-        actor: getAuditActor(log),
-        target: { type: 'calendar_backup', id: 'unknown' },
-        outcome: 'denied',
-        reason: 'Authentication required',
-      })
+    const [user, body] = await Promise.all([requireUser(log), req.json()])
+    if (!user)
       return NextResponse.json({ error: 'Unauthorized' }, { status: 401 })
+
+    const now = new Date()
+
+    if (body?.event) {
+      const event = normalizeEvent(body.event)
+      const encrypted = encryptServerJson(event, 'calendar-event')
+      await db
+        .insert(calendarBackups)
+        .values({
+          id: event.id,
+          userId: user.id,
+          ...encrypted,
+          startDate: new Date(event.startDate),
+          endDate: new Date(event.endDate),
+          calendarId: event.calendarId || null,
+          timestamp: now,
+        })
+        .onConflictDoUpdate({
+          target: calendarBackups.id,
+          set: {
+            ...encrypted,
+            startDate: new Date(event.startDate),
+            endDate: new Date(event.endDate),
+            calendarId: event.calendarId || null,
+            timestamp: now,
+          },
+        })
     }
 
-    const encrypted_data = body?.ciphertext
-    const iv = body?.iv
+    if (Array.isArray(body?.events)) {
+      for (const raw of body.events) {
+        const event = normalizeEvent(raw)
+        const encrypted = encryptServerJson(event, 'calendar-event')
+        await db
+          .insert(calendarBackups)
+          .values({
+            id: event.id,
+            userId: user.id,
+            ...encrypted,
+            startDate: new Date(event.startDate),
+            endDate: new Date(event.endDate),
+            calendarId: event.calendarId || null,
+            timestamp: now,
+          })
+          .onConflictDoUpdate({
+            target: calendarBackups.id,
+            set: {
+              ...encrypted,
+              startDate: new Date(event.startDate),
+              endDate: new Date(event.endDate),
+              calendarId: event.calendarId || null,
+              timestamp: now,
+            },
+          })
+      }
+    }
 
-    if (typeof encrypted_data !== 'string' || typeof iv !== 'string')
-      return NextResponse.json({ error: 'Invalid payload' }, { status: 400 })
+    if (Array.isArray(body?.calendars)) {
+      for (const [position, category] of body.calendars.entries()) {
+        if (!category?.id) continue
+        const encrypted = encryptServerJson(category, 'calendar-category')
+        await db
+          .insert(calendarCategories)
+          .values({
+            id: String(category.id),
+            userId: user.id,
+            ...encrypted,
+            position,
+            timestamp: now,
+          })
+          .onConflictDoUpdate({
+            target: calendarCategories.id,
+            set: { ...encrypted, position, timestamp: now },
+          })
+      }
+    }
 
-    await db
-      .insert(calendarBackups)
-      .values({
-        userId,
-        encryptedData: encrypted_data,
-        iv,
-        timestamp: new Date(),
-      })
-      .onConflictDoUpdate({
-        target: calendarBackups.userId,
-        set: { encryptedData: encrypted_data, iv, timestamp: new Date() },
-      })
+    if (body?.settings && typeof body.settings === 'object') {
+      await db
+        .insert(userSettings)
+        .values({ userId: user.id, settings: body.settings, timestamp: now })
+        .onConflictDoUpdate({
+          target: userSettings.userId,
+          set: { settings: body.settings, timestamp: now },
+        })
+    }
+
+    if (Array.isArray(body?.bookmarks)) {
+      await db
+        .delete(calendarBookmarks)
+        .where(eq(calendarBookmarks.userId, user.id))
+      for (const bookmark of body.bookmarks) {
+        const id = String(
+          bookmark?.id || bookmark?.eventId || crypto.randomUUID(),
+        )
+        const encrypted = encryptServerJson(bookmark, 'calendar-bookmark')
+        await db.insert(calendarBookmarks).values({
+          id,
+          userId: user.id,
+          eventId: String(bookmark?.eventId || bookmark?.id || ''),
+          ...encrypted,
+          timestamp: now,
+        })
+      }
+    }
+
+    if (Array.isArray(body?.countdowns)) {
+      await db
+        .delete(calendarCountdowns)
+        .where(eq(calendarCountdowns.userId, user.id))
+      for (const countdown of body.countdowns) {
+        const id = String(countdown?.id || crypto.randomUUID())
+        const encrypted = encryptServerJson(countdown, 'calendar-countdown')
+        await db.insert(calendarCountdowns).values({
+          id,
+          userId: user.id,
+          ...encrypted,
+          timestamp: now,
+        })
+      }
+    }
 
     log.audit?.({
-      action: 'calendar_backup.upsert',
+      action: 'calendar_data.upsert',
       actor: getAuditActor(log, {
         type: 'user',
-        id: userId,
-        ...(user?.email ? { email: user.email } : {}),
+        id: user.id,
+        email: user.email,
       }),
-      target: { type: 'calendar_backup', id: userId },
+      target: { type: 'calendar_data', id: user.id },
       outcome: 'success',
-      reason: 'User saved encrypted calendar backup',
+      reason: 'User saved server-encrypted calendar data',
     })
     return NextResponse.json({ success: true, backend: 'postgres' })
   } catch (e: unknown) {
@@ -76,103 +300,57 @@ export const POST = withEvlog(async function POST(req: NextRequest) {
   }
 })
 
-export const GET = withEvlog(async function GET(_req: NextRequest) {
+export const DELETE = withEvlog(async function DELETE(req: NextRequest) {
   try {
     const log = useLogger()
-    const session = await getServerSession()
-    const user = session?.user
-    const userId = user?.id
-
-    if (!userId) {
-      log.audit?.({
-        action: 'calendar_backup.export',
-        actor: getAuditActor(log),
-        target: { type: 'calendar_backup', id: 'unknown' },
-        outcome: 'denied',
-        reason: 'Authentication required',
-      })
-      return jsonNoStore({ error: 'Unauthorized' }, { status: 401 })
-    }
-
-    const [result] = await db
-      .select({
-        encryptedData: calendarBackups.encryptedData,
-        iv: calendarBackups.iv,
-        timestamp: calendarBackups.timestamp,
-      })
-      .from(calendarBackups)
-      .where(eq(calendarBackups.userId, userId))
-
-    if (!result) {
-      log.audit?.({
-        action: 'calendar_backup.export',
-        actor: getAuditActor(log, {
-          type: 'user',
-          id: userId,
-          ...(user?.email ? { email: user.email } : {}),
-        }),
-        target: { type: 'calendar_backup', id: userId },
-        outcome: 'failure',
-        reason: 'No encrypted calendar backup found',
-      })
-      return jsonNoStore({ error: 'Not found' }, { status: 404 })
-    }
-
-    log.audit?.({
-      action: 'calendar_backup.export',
-      actor: getAuditActor(log, {
-        type: 'user',
-        id: userId,
-        ...(user?.email ? { email: user.email } : {}),
-      }),
-      target: { type: 'calendar_backup', id: userId },
-      outcome: 'success',
-      reason: 'User exported encrypted calendar backup',
-    })
-
-    return jsonNoStore({
-      ciphertext: result.encryptedData,
-      iv: result.iv,
-      timestamp: result.timestamp,
-      backend: 'postgres',
-    })
-  } catch (e: unknown) {
-    const message = e instanceof Error ? e.message : 'Internal error'
-    return jsonNoStore({ error: message }, { status: 500 })
-  }
-})
-
-export const DELETE = withEvlog(async function DELETE(_req: NextRequest) {
-  try {
-    const log = useLogger()
-    const session = await getServerSession()
-    const user = session?.user
-    const userId = user?.id
-
-    if (!userId) {
-      log.audit?.({
-        action: 'calendar_backup.delete',
-        actor: getAuditActor(log),
-        target: { type: 'calendar_backup', id: 'unknown' },
-        outcome: 'denied',
-        reason: 'Authentication required',
-      })
+    const user = await requireUser(log)
+    if (!user)
       return NextResponse.json({ error: 'Unauthorized' }, { status: 401 })
+
+    const body = await req.json().catch(() => null)
+    if (body?.eventId) {
+      await db
+        .delete(calendarBackups)
+        .where(
+          and(
+            eq(calendarBackups.userId, user.id),
+            eq(calendarBackups.id, String(body.eventId)),
+          ),
+        )
+    } else if (body?.categoryId) {
+      if (body?.deleteEvents) {
+        await db
+          .delete(calendarBackups)
+          .where(
+            and(
+              eq(calendarBackups.userId, user.id),
+              eq(calendarBackups.calendarId, String(body.categoryId)),
+            ),
+          )
+      }
+      await db
+        .delete(calendarCategories)
+        .where(
+          and(
+            eq(calendarCategories.userId, user.id),
+            eq(calendarCategories.id, String(body.categoryId)),
+          ),
+        )
+    } else {
+      await Promise.all([
+        db.delete(calendarBackups).where(eq(calendarBackups.userId, user.id)),
+        db
+          .delete(calendarCategories)
+          .where(eq(calendarCategories.userId, user.id)),
+        db
+          .delete(calendarBookmarks)
+          .where(eq(calendarBookmarks.userId, user.id)),
+        db
+          .delete(calendarCountdowns)
+          .where(eq(calendarCountdowns.userId, user.id)),
+        db.delete(userSettings).where(eq(userSettings.userId, user.id)),
+      ])
     }
-
-    await db.delete(calendarBackups).where(eq(calendarBackups.userId, userId))
-
-    log.audit?.({
-      action: 'calendar_backup.delete',
-      actor: getAuditActor(log, {
-        type: 'user',
-        id: userId,
-        ...(user?.email ? { email: user.email } : {}),
-      }),
-      target: { type: 'calendar_backup', id: userId },
-      outcome: 'success',
-      reason: 'User deleted encrypted calendar backup',
-    })
 
     return NextResponse.json({ success: true, backend: 'postgres' })
   } catch (e: unknown) {

--- a/app/api/share/list/route.ts
+++ b/app/api/share/list/route.ts
@@ -1,35 +1,12 @@
 import { type NextRequest, NextResponse } from 'next/server'
 import { withEvlog, useLogger, getAuditActor } from '@/lib/evlog'
 import { getServerSession } from '@/lib/auth/server'
-import crypto from 'crypto'
 import { db } from '@/lib/drizzle/client'
-import { shares } from '@/lib/drizzle/schema'
-import { eq, desc } from 'drizzle-orm'
+import { calendarBackups, shares } from '@/lib/drizzle/schema'
+import { desc, eq, and } from 'drizzle-orm'
+import { decryptServerJson } from '@/lib/server-crypto'
 
 export const runtime = 'nodejs'
-
-const ALGORITHM = 'aes-256-gcm'
-
-function keyV2Unprotected(shareId: string) {
-  return crypto.createHash('sha256').update(shareId, 'utf8').digest()
-}
-
-function decryptWithKey(
-  encryptedData: string,
-  iv: string,
-  authTag: string,
-  key: Buffer,
-) {
-  const decipher = crypto.createDecipheriv(
-    ALGORITHM,
-    key,
-    Buffer.from(iv, 'hex'),
-  )
-  decipher.setAuthTag(Buffer.from(authTag, 'hex'))
-  let decrypted = decipher.update(encryptedData, 'hex', 'utf8')
-  decrypted += decipher.final('utf8')
-  return decrypted
-}
 
 export const GET = withEvlog(async function GET(_req: NextRequest) {
   const log = useLogger()
@@ -52,47 +29,40 @@ export const GET = withEvlog(async function GET(_req: NextRequest) {
     .where(eq(shares.userId, user.id))
     .orderBy(desc(shares.timestamp))
 
-  const shareList = result.map((row) => {
-    let eventId = ''
-    let eventTitle = ''
-    if (!row.isProtected) {
+  const shareList = await Promise.all(
+    result.map(async (row) => {
+      let eventTitle = row.isProtected ? '受保护' : ''
       try {
-        const decrypted = decryptWithKey(
-          row.encryptedData,
-          row.iv,
-          row.authTag,
-          keyV2Unprotected(row.shareId),
-        )
-        const dataObj = JSON.parse(decrypted)
-        eventId = dataObj.id ?? ''
-        eventTitle = dataObj.title ?? ''
+        const [eventRow] = await db
+          .select()
+          .from(calendarBackups)
+          .where(
+            and(
+              eq(calendarBackups.userId, user.id),
+              eq(calendarBackups.id, row.eventId),
+            ),
+          )
+        if (eventRow && !row.isProtected) {
+          const event = decryptServerJson<any>(
+            eventRow.encryptedData,
+            eventRow.iv,
+            eventRow.authTag,
+            'calendar-event',
+          )
+          eventTitle = event?.title ?? ''
+        }
       } catch {}
-    } else {
-      eventId = '受保护'
-      eventTitle = '受保护'
-    }
-    return {
-      id: row.shareId,
-      eventId,
-      eventTitle,
-      sharedBy: user.id,
-      shareDate: row.timestamp.toISOString(),
-      shareLink: `/share/${row.shareId}`,
-      isProtected: row.isProtected,
-    }
-  })
-
-  log.audit?.({
-    action: 'share.list',
-    actor: getAuditActor(log, {
-      type: 'user',
-      id: user.id,
-      email: user.email,
+      return {
+        id: row.shareId,
+        eventId: row.eventId,
+        eventTitle,
+        sharedBy: user.id,
+        shareDate: row.timestamp.toISOString(),
+        shareLink: `/share/${row.shareId}`,
+        isProtected: row.isProtected,
+      }
     }),
-    target: { type: 'share_collection', id: user.id },
-    outcome: 'success',
-    reason: 'User listed shares',
-  })
+  )
 
   return NextResponse.json({ shares: shareList })
 })

--- a/app/api/share/list/route.ts
+++ b/app/api/share/list/route.ts
@@ -31,7 +31,7 @@ export const GET = withEvlog(async function GET(_req: NextRequest) {
 
   const shareList = await Promise.all(
     result.map(async (row) => {
-      let eventTitle = row.isProtected ? '受保护' : ''
+      let eventTitle = ''
       try {
         const [eventRow] = await db
           .select()

--- a/app/api/share/route.ts
+++ b/app/api/share/route.ts
@@ -1,53 +1,17 @@
 import { type NextRequest, NextResponse } from 'next/server'
 import { withEvlog, useLogger, getAuditActor } from '@/lib/evlog'
 import { getServerSession } from '@/lib/auth/server'
-import crypto from 'crypto'
 import { db } from '@/lib/drizzle/client'
-import { shares } from '@/lib/drizzle/schema'
-import { eq, and } from 'drizzle-orm'
+import { calendarBackups, shares } from '@/lib/drizzle/schema'
+import { and, eq } from 'drizzle-orm'
+import {
+  decryptServerJson,
+  decryptSharePassword,
+  encryptServerJson,
+  encryptSharePassword,
+} from '@/lib/server-crypto'
 
 export const runtime = 'nodejs'
-
-const ALGORITHM = 'aes-256-gcm'
-
-function keyV2Unprotected(shareId: string) {
-  return crypto.createHash('sha256').update(shareId, 'utf8').digest()
-}
-
-function keyV3Password(password: string, shareId: string) {
-  return crypto.scryptSync(password, shareId, 32)
-}
-
-function encryptWithKey(
-  data: string,
-  key: Buffer,
-): { encryptedData: string; iv: string; authTag: string } {
-  const iv = crypto.randomBytes(16)
-  const cipher = crypto.createCipheriv(ALGORITHM, key, iv)
-  let encrypted = cipher.update(data, 'utf8', 'hex')
-  encrypted += cipher.final('hex')
-  const authTag = cipher.getAuthTag()
-  return {
-    encryptedData: encrypted,
-    iv: iv.toString('hex'),
-    authTag: authTag.toString('hex'),
-  }
-}
-
-function decryptWithKey(
-  encryptedData: string,
-  iv: string,
-  authTag: string,
-  key: Buffer,
-): string {
-  const ivBuffer = Buffer.from(iv, 'hex')
-  const authTagBuffer = Buffer.from(authTag, 'hex')
-  const decipher = crypto.createDecipheriv(ALGORITHM, key, ivBuffer)
-  decipher.setAuthTag(authTagBuffer)
-  let decrypted = decipher.update(encryptedData, 'hex', 'utf8')
-  decrypted += decipher.final('utf8')
-  return decrypted
-}
 
 export const POST = withEvlog(async function POST(request: NextRequest) {
   try {
@@ -55,15 +19,17 @@ export const POST = withEvlog(async function POST(request: NextRequest) {
     const body = await request.json()
     const { id, data, password, burnAfterRead } = body as {
       id?: string
-      data?: unknown
+      data?: any
       password?: string
       burnAfterRead?: boolean
     }
-    if (!id || data === undefined || data === null)
+    const eventId = String(data?.id || body?.eventId || '')
+    if (!id || !eventId) {
       return NextResponse.json(
         { error: 'Missing required fields' },
         { status: 400 },
       )
+    }
 
     const session = await getServerSession()
     const user = session?.user
@@ -79,12 +45,9 @@ export const POST = withEvlog(async function POST(request: NextRequest) {
     }
 
     const hasPassword = typeof password === 'string' && password.length > 0
-    const burn = !!burnAfterRead
-    const dataString = typeof data === 'string' ? data : JSON.stringify(data)
-    const key = hasPassword
-      ? keyV3Password(password as string, id)
-      : keyV2Unprotected(id)
-    const { encryptedData, iv, authTag } = encryptWithKey(dataString, key)
+    const encrypted = hasPassword
+      ? encryptSharePassword(password as string, id)
+      : encryptServerJson({ unprotected: true }, `share:${id}`)
     const now = new Date()
 
     await db
@@ -92,47 +55,35 @@ export const POST = withEvlog(async function POST(request: NextRequest) {
       .values({
         userId: user.id,
         shareId: id,
-        encryptedData,
-        iv,
-        authTag,
+        eventId,
+        encryptedData: encrypted.encryptedData,
+        iv: encrypted.iv,
+        authTag: encrypted.authTag,
         timestamp: now,
         isProtected: hasPassword,
-        isBurn: burn,
-        encVersion: hasPassword ? 3 : 2,
+        isBurn: Boolean(burnAfterRead),
+        encVersion: hasPassword ? 4 : 4,
       })
       .onConflictDoUpdate({
         target: shares.shareId,
         set: {
           userId: user.id,
-          encryptedData,
-          iv,
-          authTag,
+          eventId,
+          encryptedData: encrypted.encryptedData,
+          iv: encrypted.iv,
+          authTag: encrypted.authTag,
           timestamp: now,
           isProtected: hasPassword,
-          isBurn: burn,
-          encVersion: hasPassword ? 3 : 2,
+          isBurn: Boolean(burnAfterRead),
+          encVersion: 4,
         },
       })
-
-    log.audit?.({
-      action: 'share.create',
-      actor: getAuditActor(log, {
-        type: 'user',
-        id: user.id,
-        email: user.email,
-      }),
-      target: { type: 'share', id },
-      outcome: 'success',
-      reason: burn
-        ? 'User created burn-after-read share'
-        : 'User created share',
-    })
 
     return NextResponse.json({
       success: true,
       id,
       protected: hasPassword,
-      burnAfterRead: burn,
+      burnAfterRead: Boolean(burnAfterRead),
       shareLink: `/share/${id}`,
     })
   } catch (error) {
@@ -159,30 +110,41 @@ export const GET = withEvlog(async function GET(request: NextRequest) {
         .select()
         .from(shares)
         .where(eq(shares.shareId, id))
-
       if (!share) return { status: 404 as const }
-      if (share.isProtected && !password)
-        return { status: 401 as const, burnAfterRead: share.isBurn }
-
-      const key = share.isProtected
-        ? keyV3Password(password, id)
-        : keyV2Unprotected(id)
-      let decryptedData: string
-      try {
-        decryptedData = decryptWithKey(
+      if (share.isProtected) {
+        if (!password)
+          return { status: 401 as const, burnAfterRead: share.isBurn }
+        const expectedPassword = decryptSharePassword(
           share.encryptedData,
           share.iv,
           share.authTag,
-          key,
+          share.shareId,
         )
-      } catch {
-        return { status: 403 as const, protected: share.isProtected }
+        if (password !== expectedPassword) return { status: 403 as const }
       }
+
+      const [eventRow] = await tx
+        .select()
+        .from(calendarBackups)
+        .where(
+          and(
+            eq(calendarBackups.userId, share.userId),
+            eq(calendarBackups.id, share.eventId),
+          ),
+        )
+      if (!eventRow) return { status: 404 as const }
+
+      const event = decryptServerJson(
+        eventRow.encryptedData,
+        eventRow.iv,
+        eventRow.authTag,
+        'calendar-event',
+      )
       if (share.isBurn) await tx.delete(shares).where(eq(shares.shareId, id))
 
       return {
         status: 200 as const,
-        data: decryptedData,
+        data: JSON.stringify(event),
         timestamp: share.timestamp.toISOString(),
         protected: share.isProtected,
         burnAfterRead: share.isBurn,
@@ -195,18 +157,11 @@ export const GET = withEvlog(async function GET(request: NextRequest) {
         actor: getAuditActor(log),
         target: { type: 'share', id },
         outcome: 'failure',
-        reason: 'Share not found',
+        reason: 'Share or event not found',
       })
       return NextResponse.json({ error: 'Share not found' }, { status: 404 })
     }
     if (result.status === 401) {
-      log.audit?.({
-        action: 'share.export',
-        actor: getAuditActor(log),
-        target: { type: 'share', id },
-        outcome: 'denied',
-        reason: 'Password required',
-      })
       return NextResponse.json(
         {
           error: 'Password required',
@@ -217,34 +172,8 @@ export const GET = withEvlog(async function GET(request: NextRequest) {
       )
     }
     if (result.status === 403) {
-      log.audit?.({
-        action: 'share.export',
-        actor: getAuditActor(log),
-        target: { type: 'share', id },
-        outcome: 'denied',
-        reason: result.protected
-          ? 'Invalid password'
-          : 'Failed to decrypt share data',
-      })
-      return NextResponse.json(
-        {
-          error: result.protected
-            ? 'Invalid password'
-            : 'Failed to decrypt share data.',
-        },
-        { status: 403 },
-      )
+      return NextResponse.json({ error: 'Invalid password' }, { status: 403 })
     }
-
-    log.audit?.({
-      action: result.burnAfterRead ? 'share.burn_after_read' : 'share.export',
-      actor: getAuditActor(log),
-      target: { type: 'share', id },
-      outcome: 'success',
-      reason: result.burnAfterRead
-        ? 'Burn-after-read share exported and deleted'
-        : 'Share exported',
-    })
 
     return NextResponse.json({
       success: true,
@@ -287,18 +216,5 @@ export const DELETE = withEvlog(async function DELETE(request: NextRequest) {
   await db
     .delete(shares)
     .where(and(eq(shares.shareId, id), eq(shares.userId, user.id)))
-
-  log.audit?.({
-    action: 'share.delete',
-    actor: getAuditActor(log, {
-      type: 'user',
-      id: user.id,
-      email: user.email,
-    }),
-    target: { type: 'share', id },
-    outcome: 'success',
-    reason: 'User deleted share',
-  })
-
   return NextResponse.json({ success: true })
 })

--- a/components/app/auth-waiting-loading.tsx
+++ b/components/app/auth-waiting-loading.tsx
@@ -1,5 +1,6 @@
 'use client'
 
+import { Skeleton } from '@/components/ui/skeleton'
 import { translations, useLanguage } from '@/lib/i18n'
 import { useEffect, useState } from 'react'
 
@@ -19,37 +20,49 @@ export default function AuthWaitingLoading() {
   }, [])
 
   return (
-    <div className="flex min-h-screen items-center justify-center bg-white px-6 dark:bg-black">
-      <div className="flex flex-col items-center gap-5 text-center">
-        <svg
-          version="1.0"
-          xmlns="http://www.w3.org/2000/svg"
-          width="136"
-          height="136"
-          viewBox="0 0 1000 1000"
-          preserveAspectRatio="xMidYMid meet"
-          aria-label="One Calendar"
-          role="img"
-          className="text-black dark:text-white"
-        >
-          <g
-            transform="translate(0,1000) scale(0.1,-0.1)"
-            fill="currentColor"
-            stroke="none"
-          >
-            <path d="M4960 8206 c-87 -24 -164 -70 -231 -136 -101 -101 -149 -217 -149 -360 0 -144 48 -259 150 -360 102 -102 218 -150 360 -150 140 0 264 53 365 156 194 198 194 508 0 709 -67 69 -165 125 -253 144 -68 14 -184 13 -242 -3z" />
-            <path d="M3616 6859 c-109 -26 -239 -117 -307 -215 -97 -141 -111 -350 -34 -510 61 -126 166 -217 305 -264 55 -19 82 -21 175 -18 102 3 115 6 185 39 147 70 239 172 281 311 17 57 21 88 18 182 -4 109 -5 115 -46 198 -68 136 -202 245 -343 277 -54 13 -180 12 -234 0z" />
-            <path d="M4963 6855 c-228 -64 -383 -263 -383 -493 0 -149 45 -259 149 -363 105 -105 212 -149 362 -149 188 0 345 90 443 254 70 117 85 297 35 434 -48 130 -170 250 -306 302 -75 29 -225 37 -300 15z" />
-            <path d="M4940 5491 c-91 -29 -142 -61 -211 -130 -103 -103 -149 -214 -149 -361 0 -328 308 -570 629 -495 279 66 450 358 373 636 -46 164 -177 299 -340 349 -83 26 -224 26 -302 1z" />
-            <path d="M4980 4149 c-81 -16 -188 -76 -255 -145 -97 -100 -145 -215 -145 -354 0 -147 46 -258 149 -361 105 -105 212 -149 362 -149 455 0 680 547 358 869 -121 122 -296 174 -469 140z" />
-            <path d="M3601 2784 c-116 -31 -242 -125 -306 -229 -65 -105 -87 -283 -50 -410 61 -215 263 -365 490 -365 134 0 244 43 343 135 118 109 162 211 162 376 0 160 -46 267 -159 371 -103 96 -213 139 -351 137 -41 0 -99 -7 -129 -15z" />
-            <path d="M4959 2785 c-85 -23 -162 -69 -229 -135 -102 -101 -150 -216 -150 -360 0 -147 57 -278 162 -374 205 -187 515 -181 709 13 157 157 193 397 91 600 -56 112 -196 223 -326 257 -63 17 -195 17 -257 -1z" />
-            <path d="M6311 2784 c-76 -20 -146 -60 -212 -122 -113 -104 -159 -211 -159 -371 0 -189 74 -329 228 -431 103 -68 259 -97 385 -71 130 28 271 129 336 245 86 151 86 361 1 512 -38 65 -141 164 -208 198 -109 55 -256 71 -371 40z" />
-          </g>
-        </svg>
-        <p
-          className={`text-sm text-slate-700 dark:text-slate-300`}
-        >
+    <div className="flex min-h-screen bg-background px-6 py-8">
+      <div className="mx-auto flex w-full max-w-6xl flex-col gap-6">
+        <div className="flex items-center justify-between">
+          <div className="flex items-center gap-3">
+            <Skeleton className="h-9 w-9 rounded-full" />
+            <div className="space-y-2">
+              <Skeleton className="h-4 w-32" />
+              <Skeleton className="h-3 w-48" />
+            </div>
+          </div>
+          <Skeleton className="h-9 w-28" />
+        </div>
+        <div className="grid flex-1 gap-4 md:grid-cols-[220px_1fr]">
+          <aside className="space-y-5 rounded-lg border p-4">
+            <Skeleton className="h-10 w-full" />
+            <div className="grid grid-cols-7 gap-1">
+              {Array.from({ length: 35 }).map((_, index) => (
+                <Skeleton key={index} className="h-6 w-full" />
+              ))}
+            </div>
+            <div className="space-y-3">
+              {Array.from({ length: 4 }).map((_, index) => (
+                <div key={index} className="flex items-center gap-2">
+                  <Skeleton className="h-4 w-4 rounded-full" />
+                  <Skeleton className="h-4 w-28" />
+                </div>
+              ))}
+            </div>
+          </aside>
+          <main className="rounded-lg border p-4">
+            <div className="mb-4 grid grid-cols-7 gap-2">
+              {Array.from({ length: 7 }).map((_, index) => (
+                <Skeleton key={index} className="h-5 w-full" />
+              ))}
+            </div>
+            <div className="grid grid-cols-7 gap-2">
+              {Array.from({ length: 28 }).map((_, index) => (
+                <Skeleton key={index} className="h-20 w-full" />
+              ))}
+            </div>
+          </main>
+        </div>
+        <p className="text-center text-sm text-muted-foreground">
           {t.loadingCalendar}
           {'.'.repeat(dotCount)}
         </p>

--- a/components/app/calendar.tsx
+++ b/components/app/calendar.tsx
@@ -48,6 +48,7 @@ import { ScrollArea } from '@/components/ui/scroll-area'
 import Sidebar from '@/components/app/sidebar/sidebar'
 import { translations, useLanguage } from '@/lib/i18n'
 import { Button } from '@/components/ui/button'
+import { Skeleton } from '@/components/ui/skeleton'
 import { APP_CONFIG } from '@/lib/config'
 import {
   isCalendarView,
@@ -124,7 +125,13 @@ export default function Calendar({ className, ...props }: CalendarProps) {
   const [view, setView] = useState<ViewType>('week')
   const [eventDialogOpen, setEventDialogOpen] = useState(false)
   const [selectedEvent, setSelectedEvent] = useState<CalendarEvent | null>(null)
-  const { events, setEvents, calendars } = useCalendar()
+  const {
+    events,
+    setEvents,
+    calendars,
+    isLoadingCalendarData,
+    loadCalendarRange,
+  } = useCalendar()
   const [searchTerm, setSearchTerm] = useState('')
   const searchInputRef = useRef<HTMLDivElement>(null)
   const [isSearchFocused, setIsSearchFocused] = useState(false)
@@ -254,6 +261,61 @@ export default function Calendar({ className, ...props }: CalendarProps) {
       window.removeEventListener('storage', refreshBackupState)
     }
   }, [])
+
+  useEffect(() => {
+    if (!isSignedIn) return
+    let start: Date
+    let end: Date
+    if (view === 'year') {
+      start = new Date(date.getFullYear(), 0, 1)
+      end = new Date(date.getFullYear(), 11, 31, 23, 59, 59, 999)
+    } else {
+      start = new Date(date.getFullYear(), date.getMonth() - 1, 1)
+      end = new Date(
+        date.getFullYear(),
+        date.getMonth() + 2,
+        0,
+        23,
+        59,
+        59,
+        999,
+      )
+    }
+    void loadCalendarRange(start, end)
+  }, [date, view, isSignedIn, loadCalendarRange])
+
+  useEffect(() => {
+    if (!isSignedIn) return
+    const timer = window.setTimeout(() => {
+      void fetch('/api/blob', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({
+          settings: {
+            language,
+            firstDayOfWeek: normalizedFirstDayOfWeek,
+            timezone,
+            notificationSound,
+            defaultView,
+            enableShortcuts,
+            timeFormat,
+            toastPosition,
+          },
+        }),
+      })
+    }, 500)
+    return () => window.clearTimeout(timer)
+  }, [
+    isSignedIn,
+    language,
+    normalizedFirstDayOfWeek,
+    timezone,
+    notificationSound,
+    defaultView,
+    enableShortcuts,
+    timeFormat,
+    toastPosition,
+  ])
 
   const backupStatusIcon = useMemo(() => {
     if (!backupEnabled) return null
@@ -942,7 +1004,23 @@ export default function Calendar({ className, ...props }: CalendarProps) {
               />
             </div>
           </header>
-          <div className="flex-1 overflow-auto pr-14" ref={calendarRef}>
+          <div
+            className="relative flex-1 overflow-auto pr-14"
+            ref={calendarRef}
+          >
+            {isLoadingCalendarData && (
+              <div className="pointer-events-none absolute inset-0 z-30 space-y-3 bg-background/45 p-6 backdrop-blur-[1px]">
+                <div className="flex gap-2">
+                  <Skeleton className="h-4 w-4 rounded-full" />
+                  <Skeleton className="h-4 w-28" />
+                </div>
+                <div className="grid grid-cols-7 gap-2">
+                  {Array.from({ length: 21 }).map((_, index) => (
+                    <Skeleton key={index} className="h-16 w-full" />
+                  ))}
+                </div>
+              </div>
+            )}
             {view === 'day' && (
               <DayView
                 date={date}
@@ -967,7 +1045,6 @@ export default function Calendar({ className, ...props }: CalendarProps) {
 
                   updateEvent(updatedEvent)
                 }}
-                onBackToCalendar={() => setView(defaultView)}
               />
             )}
             {view === 'week' && (
@@ -1078,7 +1155,6 @@ export default function Calendar({ className, ...props }: CalendarProps) {
                 focusUserProfileSection={focusUserProfileSection}
                 toastPosition={toastPosition}
                 setToastPosition={setToastPosition}
-                onBackToCalendar={() => setView(defaultView)}
               />
             )}
           </div>

--- a/components/app/event/event-dialog.tsx
+++ b/components/app/event/event-dialog.tsx
@@ -654,7 +654,6 @@ export default function EventDialog({
                           setStartDateOpen(false)
                         }
                       }}
-                      initialFocus
                     />
                   </PopoverContent>
                 </Popover>
@@ -703,7 +702,6 @@ export default function EventDialog({
                           }
                         }
                       }}
-                      initialFocus
                       disabled={(date) => date < startDate}
                     />
                   </PopoverContent>

--- a/components/app/profile/user-profile-button.tsx
+++ b/components/app/profile/user-profile-button.tsx
@@ -1,27 +1,15 @@
 'use client'
 
-import { useEffect, useRef, useState } from 'react'
+import { useEffect, useState } from 'react'
 import {
-  LogOut,
+  BarChart2,
   CircleUser,
   CloudUpload,
-  Trash2,
-  KeyRound,
-  Mail,
-  Camera,
-  BarChart2,
+  LogOut,
   Settings,
+  Trash2,
 } from 'lucide-react'
 import { Button } from '@/components/ui/button'
-import type { CalendarEvent } from '@/components/app/calendar'
-import {
-  Dialog,
-  DialogContent,
-  DialogDescription,
-  DialogFooter,
-  DialogHeader,
-  DialogTitle,
-} from '@/components/ui/dialog'
 import {
   AlertDialog,
   AlertDialogAction,
@@ -33,6 +21,14 @@ import {
   AlertDialogTitle,
 } from '@/components/ui/alert-dialog'
 import {
+  Dialog,
+  DialogContent,
+  DialogDescription,
+  DialogFooter,
+  DialogHeader,
+  DialogTitle,
+} from '@/components/ui/dialog'
+import {
   DropdownMenu,
   DropdownMenuContent,
   DropdownMenuItem,
@@ -41,182 +37,15 @@ import {
 import { Input } from '@/components/ui/input'
 import { Label } from '@/components/ui/label'
 import { ScrollArea } from '@/components/ui/scroll-area'
-import { Spinner } from '@/components/ui/spinner'
 import { toast } from 'sonner'
 import { useCalendar } from '@/components/providers/calendar-context'
 import { translations, useLanguage } from '@/lib/i18n'
 import { authClient } from '@/lib/auth/client'
 import { useRouter } from 'next/navigation'
-import QRCodeStyling from 'qr-code-styling'
-import {
-  decryptLargePayload,
-  decryptWithDerivedKey,
-  encryptLargePayload,
-  isEncryptedPayload,
-} from '@/lib/crypto'
-import {
-  readInMemoryStorage,
-  clearEncryptionPassword,
-  isSensitiveStorageKey,
-  markEncryptedSnapshot,
-  removeInMemoryStorage,
-  readEncryptedLocalStorage,
-  setEncryptionPassword,
-  writeEncryptedLocalStorage,
-  writeInMemoryStorage,
-} from '@/hooks/useLocalStorage'
 import { cn } from '@/lib/utils'
 
 const AUTO_KEY = 'auto-backup-enabled'
 const BACKUP_STATUS_KEY = 'auto-backup-sync-status'
-const BACKUP_VERSION = 2
-const BACKUP_KEYS = [
-  'calendar-events',
-  'calendar-categories',
-  'bookmarked-events',
-  'shared-events',
-  'countdowns',
-  'timezone',
-  'notification-sound',
-  'enable-shortcuts',
-  'preferred-language',
-  'first-day-of-week',
-  'default-view',
-  'skip-landing',
-  'today-toast',
-  'toast-position',
-]
-
-function generateHighEntropyKey() {
-  const bytes = crypto.getRandomValues(new Uint8Array(32))
-  return Array.from(bytes, (b) => b.toString(16).padStart(2, '0')).join('')
-}
-
-const BACKUP_KEY_DEFAULTS: Record<string, unknown> = {
-  'calendar-events': [],
-  'calendar-categories': [],
-  'bookmarked-events': [],
-  'shared-events': [],
-  countdowns: [],
-  timezone: Intl.DateTimeFormat().resolvedOptions().timeZone,
-  'notification-sound': 'telegram',
-  'enable-shortcuts': true,
-  'preferred-language': null,
-  'first-day-of-week': 0,
-  'default-view': 'week',
-  'skip-landing': false,
-  'today-toast': null,
-  'toast-position': 'bottom-right',
-}
-
-async function apiGet() {
-  const r = await fetch('/api/blob', { cache: 'no-store' })
-  if (r.status === 404) return null
-  if (!r.ok) throw new Error()
-  return r.json()
-}
-
-async function apiPost(body: any) {
-  const r = await fetch('/api/blob', {
-    method: 'POST',
-    headers: { 'Content-Type': 'application/json' },
-    body: JSON.stringify(body),
-  })
-  if (!r.ok) throw new Error()
-}
-
-async function apiDelete() {
-  const r = await fetch('/api/blob', { method: 'DELETE' })
-  if (!r.ok) throw new Error()
-}
-
-async function collectLocalStorage() {
-  const storage: Record<string, string> = {}
-
-  await Promise.all(
-    BACKUP_KEYS.map(async (key) => {
-      const fallback = BACKUP_KEY_DEFAULTS[key] ?? null
-      const inMemoryValue = readInMemoryStorage(key)
-      if (inMemoryValue !== null) {
-        storage[key] = inMemoryValue
-        return
-      }
-
-      const hasRawItem = localStorage.getItem(key) !== null
-      const value = await readEncryptedLocalStorage(key, fallback)
-      if (value === null && !hasRawItem) return
-      storage[key] = JSON.stringify(value)
-    }),
-  )
-
-  return storage
-}
-
-async function normalizeCloudStorageValue(
-  value: string,
-  password: string,
-  keyCache?: Map<string, Promise<CryptoKey>>,
-): Promise<string> {
-  try {
-    const parsed = JSON.parse(value)
-    if (!isEncryptedPayload(parsed)) {
-      return value
-    }
-
-    return decryptWithDerivedKey(
-      password,
-      parsed.ciphertext,
-      parsed.iv,
-      keyCache,
-    )
-  } catch {
-    return value
-  }
-}
-
-function parseCloudBackupPayload(plain: string): {
-  storage?: Record<string, unknown>
-  events?: unknown
-  calendars?: unknown
-} | null {
-  try {
-    return JSON.parse(plain)
-  } catch {
-    return null
-  }
-}
-
-function normalizeStorageRecord(storage: Record<string, unknown>) {
-  return Object.fromEntries(
-    Object.entries(storage).map(([key, value]) => [key, String(value)]),
-  )
-}
-
-async function applyCloudStorageToMemory(storage: Record<string, string>) {
-  await Promise.all(
-    Object.entries(storage).map(async ([key, value]) => {
-      let parsedValue: unknown
-      try {
-        parsedValue = JSON.parse(value)
-      } catch {
-        parsedValue = value
-      }
-
-      await writeEncryptedLocalStorage(key, parsedValue)
-
-      if (isSensitiveStorageKey(key)) {
-        const normalized =
-          typeof parsedValue === 'string'
-            ? parsedValue
-            : JSON.stringify(parsedValue)
-        writeInMemoryStorage(key, normalized)
-        markEncryptedSnapshot(key, normalized)
-      } else {
-        removeInMemoryStorage(key)
-      }
-    }),
-  )
-}
 
 export type UserProfileSection =
   | 'profile'
@@ -234,6 +63,11 @@ type UserProfileButtonProps = {
   focusSection?: UserProfileSection | null
 }
 
+async function apiDelete() {
+  const response = await fetch('/api/blob', { method: 'DELETE' })
+  if (!response.ok) throw new Error('Failed to delete cloud data')
+}
+
 export default function UserProfileButton({
   variant = 'ghost',
   className = '',
@@ -244,87 +78,33 @@ export default function UserProfileButton({
 }: UserProfileButtonProps) {
   const [language] = useLanguage()
   const t = translations[language]
-  const { events, calendars, setEvents, setCalendars } = useCalendar()
+  const { events, calendars } = useCalendar()
   const { data: session } = authClient.useSession()
   const user: any = session?.user
   const isSignedIn = Boolean(session?.user)
   const router = useRouter()
-  const isAnySignedIn = isSignedIn
 
   const [enabled, setEnabled] = useState(false)
   const [profileOpen, setProfileOpen] = useState(false)
   const [backupOpen, setBackupOpen] = useState(false)
-  const [setPwdOpen, setSetPwdOpen] = useState(false)
-  const [unlockOpen, setUnlockOpen] = useState(false)
-  const [rotateOpen, setRotateOpen] = useState(false)
-  const [deleteAccountOpen, setDeleteAccountOpen] = useState(false)
   const [deleteCloudOpen, setDeleteCloudOpen] = useState(false)
-  const [isDeletingAccount, setIsDeletingAccount] = useState(false)
-  const [isUnlocking, setIsUnlocking] = useState(false)
-  const [deleteAccountConfirmText, setDeleteAccountConfirmText] = useState('')
+  const [deleteAccountOpen, setDeleteAccountOpen] = useState(false)
   const [deleteCloudConfirmText, setDeleteCloudConfirmText] = useState('')
-  const [profileSection, setProfileSection] = useState<
-    'basic' | 'emails' | 'twofa' | 'password'
-  >('basic')
-
-  const [password, setPassword] = useState('')
-  const [confirm, setConfirm] = useState('')
-  const [rotateStep, setRotateStep] = useState<'verify' | 'confirm'>('verify')
-  const [oldPassword, setOldPassword] = useState('')
-  const [error, setError] = useState('')
-  const [isVerifyingRotationKey, setIsVerifyingRotationKey] = useState(false)
-
+  const [deleteAccountConfirmText, setDeleteAccountConfirmText] = useState('')
   const [firstName, setFirstName] = useState('')
   const [lastName, setLastName] = useState('')
-  const [newEmail, setNewEmail] = useState('')
-  const [emailOtp, setEmailOtp] = useState('')
-  const [pendingEmail, setPendingEmail] = useState('')
-  const [changePasswordValue, setChangePasswordValue] = useState('')
-  const [emailStep, setEmailStep] = useState<1 | 2>(1)
-  const [twoFaStep, setTwoFaStep] = useState<1 | 2 | 3>(1)
   const [profileSaving, setProfileSaving] = useState(false)
-  const [avatarUploading, setAvatarUploading] = useState(false)
-  const [twoFactorPassword, setTwoFactorPassword] = useState('')
-  const [twoFactorCode, setTwoFactorCode] = useState('')
-  const [twoFactorPending, setTwoFactorPending] = useState(false)
-  const [twoFactorEnabled, setTwoFactorEnabled] = useState(false)
-  const [twoFactorUri, setTwoFactorUri] = useState('')
-  const [twoFactorQrCode, setTwoFactorQrCode] = useState('')
-  const twoFactorQrCodeRef = useRef<string | null>(null)
-
-  const keyRef = useRef<string | null>(null)
-  const lastBackupSnapshotRef = useRef<string | null>(null)
-  const restoredRef = useRef(false)
-  const skipNextAutoBackupRef = useRef(false)
-  const timerRef = useRef<any>(null)
-  const [backupTick, setBackupTick] = useState(0)
-
-  const broadcastBackupStatus = (status: 'uploading' | 'failed' | 'done') => {
-    localStorage.setItem(BACKUP_STATUS_KEY, status)
-    window.dispatchEvent(
-      new CustomEvent('backup-status-change', { detail: { status } }),
-    )
-  }
-
-  useEffect(() => {
-    if (mode !== 'settings' || !focusSection) return
-    const target = document.getElementById(`settings-account-${focusSection}`)
-    target?.scrollIntoView({ behavior: 'smooth', block: 'center' })
-  }, [focusSection, mode])
-
-  useEffect(() => {
-    if (!deleteAccountOpen) {
-      setDeleteAccountConfirmText('')
-    }
-  }, [deleteAccountOpen])
 
   useEffect(() => {
     setEnabled(localStorage.getItem(AUTO_KEY) === 'true')
   }, [])
 
   useEffect(() => {
-    setTwoFactorEnabled(Boolean((session as any)?.user?.twoFactorEnabled))
-  }, [session])
+    if (mode !== 'settings' || !focusSection) return
+    document
+      .getElementById(`settings-account-${focusSection}`)
+      ?.scrollIntoView({ behavior: 'smooth', block: 'center' })
+  }, [focusSection, mode])
 
   useEffect(() => {
     if (!user) return
@@ -334,68 +114,12 @@ export default function UserProfileButton({
     setLastName(parts.slice(1).join(' '))
   }, [user])
 
-  useEffect(() => {
-    return () => {
-      if (twoFactorQrCodeRef.current) {
-        URL.revokeObjectURL(twoFactorQrCodeRef.current)
-      }
-    }
-  }, [])
-
-  useEffect(() => {
-    if (mode === 'settings') return
-    if (!isAnySignedIn || keyRef.current || restoredRef.current) return
-    apiGet().then((cloud) => {
-      if (cloud) setUnlockOpen(true)
-    })
-  }, [isAnySignedIn, mode])
-
-  useEffect(() => {
-    const watchKeys = new Set(BACKUP_KEYS)
-    const handleLocalWrite = (event: Event) => {
-      const customEvent = event as CustomEvent<{ key?: string }>
-      if (!customEvent.detail?.key || watchKeys.has(customEvent.detail.key)) {
-        setBackupTick((prev) => prev + 1)
-      }
-    }
-
-    window.addEventListener('local-storage-written', handleLocalWrite)
-    const handleLanguageChange = () => setBackupTick((prev) => prev + 1)
-    window.addEventListener('languagechange', handleLanguageChange)
-    return () => {
-      window.removeEventListener('local-storage-written', handleLocalWrite)
-      window.removeEventListener('languagechange', handleLanguageChange)
-    }
-  }, [])
-
-  useEffect(() => {
-    if (!enabled || !keyRef.current || !restoredRef.current) return
-    if (skipNextAutoBackupRef.current) {
-      skipNextAutoBackupRef.current = false
-      return
-    }
-    if (timerRef.current) clearTimeout(timerRef.current)
-
-    timerRef.current = setTimeout(async () => {
-      try {
-        broadcastBackupStatus('uploading')
-        const storage = await collectLocalStorage()
-        const snapshot = JSON.stringify({ v: BACKUP_VERSION, storage })
-        if (lastBackupSnapshotRef.current === snapshot) {
-          broadcastBackupStatus('done')
-          return
-        }
-        const payload = await encryptLargePayload(keyRef.current!, snapshot)
-        await apiPost(payload)
-        lastBackupSnapshotRef.current = snapshot
-        broadcastBackupStatus('done')
-      } catch {
-        broadcastBackupStatus('failed')
-      } finally {
-        timerRef.current = null
-      }
-    }, 800)
-  }, [enabled, backupTick])
+  function setBackupStatus(status: 'uploading' | 'failed' | 'done') {
+    localStorage.setItem(BACKUP_STATUS_KEY, status)
+    window.dispatchEvent(
+      new CustomEvent('backup-status-change', { detail: { status } }),
+    )
+  }
 
   async function saveProfile() {
     if (!user) return
@@ -404,1211 +128,317 @@ export default function UserProfileButton({
       const name = `${firstName} ${lastName}`.trim()
       const { error } = await authClient.updateUser({ name: name || undefined })
       if (error) throw new Error(error.message || 'Failed to update profile')
-      toast(t.profileUpdated)
-    } catch (e: any) {
-      toast(t.profileUpdateFailed, {
-        description: e?.errors?.[0]?.longMessage || e?.message || '',
+      toast(t.profileUpdated || 'Profile updated')
+    } catch (error: any) {
+      toast(t.profileUpdateFailed || 'Failed to update profile', {
+        description: error?.message || '',
       })
     } finally {
       setProfileSaving(false)
     }
   }
 
-  async function updateAvatar(file?: File | null) {
-    if (!user || !file) return
-    try {
-      setAvatarUploading(true)
-      const MAX_OUTPUT_BYTES = 4 * 1024 * 1024
-      const MAX_SOURCE_BYTES = 20 * 1024 * 1024
-      const MAX_DIMENSION = 512
-      const INITIAL_QUALITY = 0.92
-      const MIN_QUALITY = 0.5
-      const QUALITY_STEP = 0.08
-      if (file.size > MAX_SOURCE_BYTES) {
-        throw new Error('Image is too large. Please choose a smaller file.')
-      }
-      const image = await new Promise<string>((resolve, reject) => {
-        const img = new Image()
-        const reader = new FileReader()
-        reader.onload = () => {
-          img.src = String(reader.result || '')
-        }
-        reader.onerror = () => reject(new Error('Failed to read file'))
-        img.onload = () => {
-          const side = Math.min(img.width, img.height)
-          const sx = Math.floor((img.width - side) / 2)
-          const sy = Math.floor((img.height - side) / 2)
-          const target = Math.min(side, MAX_DIMENSION)
-          const canvas = document.createElement('canvas')
-          canvas.width = target
-          canvas.height = target
-          const ctx = canvas.getContext('2d')
-          if (!ctx) return reject(new Error('Failed to process image'))
-          ctx.drawImage(img, sx, sy, side, side, 0, 0, target, target)
-          let quality = INITIAL_QUALITY
-          let data = canvas.toDataURL('image/jpeg', quality)
-          const getDataBytes = (base64DataUrl: string) => {
-            const payload = base64DataUrl.split(',')[1] || ''
-            return atob(payload).length
-          }
-          while (
-            getDataBytes(data) > MAX_OUTPUT_BYTES &&
-            quality > MIN_QUALITY
-          ) {
-            quality -= QUALITY_STEP
-            data = canvas.toDataURL('image/jpeg', quality)
-          }
-          if (getDataBytes(data) > MAX_OUTPUT_BYTES) {
-            return reject(
-              new Error(
-                'Image is too large after processing. Please choose a smaller file.',
-              ),
-            )
-          }
-          resolve(data)
-        }
-        img.onerror = () => reject(new Error('Unsupported image format'))
-        reader.readAsDataURL(file)
-      })
-      const { error } = await authClient.updateUser({ image })
-      if (error) throw new Error(error.message || 'Failed to update avatar')
-      toast(t.avatarUpdated)
-    } catch (e: any) {
-      toast(t.avatarUpdateFailed, {
-        description: e?.errors?.[0]?.longMessage || e?.message || '',
-      })
-    } finally {
-      setAvatarUploading(false)
-    }
-  }
-
-  async function sendEmailChangeOtp() {
-    if (!newEmail || !twoFactorPassword) return
-    setTwoFactorPending(true)
-    const nextEmail = newEmail.trim().toLowerCase()
-    const primary = await authClient.emailOtp.sendVerificationOtp({
-      email: nextEmail,
-      type: 'email-verification',
-    })
-    const res = primary.error
-      ? await authClient.emailOtp.sendVerificationOtp({
-          email: nextEmail,
-          type: 'sign-in',
-        })
-      : primary
-    if (res.error) {
-      toast(res.error.message || 'Failed to send verification code.')
-      setTwoFactorPending(false)
-      return
-    }
-    setPendingEmail(nextEmail)
-    setEmailStep(2)
-    setTwoFactorPending(false)
-    toast('Verification code sent to the new email.')
-  }
-
-  async function confirmEmailChange() {
-    if (!pendingEmail || !emailOtp || !twoFactorPassword) return
-    setTwoFactorPending(true)
-    const verifyRes = await authClient.emailOtp.verifyEmail({
-      email: pendingEmail,
-      otp: emailOtp,
-      type: 'email-verification',
-    } as any)
-    if (verifyRes.error) {
-      toast(verifyRes.error.message || 'Invalid verification code.')
-      setTwoFactorPending(false)
-      return
-    }
-    const updateRes = await authClient.changeEmail({
-      newEmail: pendingEmail,
-      callbackURL: '/app',
-      password: twoFactorPassword,
-    } as any)
-    if (updateRes.error) {
-      toast(updateRes.error.message || 'Failed to update email.')
-      setTwoFactorPending(false)
-      return
-    }
-    setNewEmail('')
-    setPendingEmail('')
-    setEmailOtp('')
-    toast('Email updated successfully.')
-    await authClient.getSession()
-    setEmailStep(1)
-    setTwoFactorPassword('')
-    setTwoFactorPending(false)
-  }
-
-  async function confirmChangePassword() {
-    if (!changePasswordValue || !twoFactorPassword) return
-    const updateRes = await authClient.changePassword({
-      currentPassword: twoFactorPassword,
-      newPassword: changePasswordValue,
-      revokeOtherSessions: false,
-    } as any)
-    if (updateRes.error) {
-      toast(updateRes.error.message || 'Failed to change password.')
-      return
-    }
-    setChangePasswordValue('')
-    toast('Password updated successfully.')
-  }
-
-  const hydrateEvent = (raw: any): CalendarEvent => {
-    const startDate = raw?.startDate ? new Date(raw.startDate) : new Date()
-    const endDate = raw?.endDate
-      ? new Date(raw.endDate)
-      : new Date(startDate.getTime() + 60 * 60 * 1000)
-
-    return {
-      id: raw?.id || `${Date.now()}-${Math.random().toString(36).slice(2, 8)}`,
-      title: raw?.title || t.unnamedEvent,
-      startDate,
-      endDate:
-        endDate < startDate
-          ? new Date(startDate.getTime() + 60 * 60 * 1000)
-          : endDate,
-      isAllDay: Boolean(raw?.isAllDay),
-      recurrence: ['none', 'daily', 'weekly', 'monthly', 'yearly'].includes(
-        raw?.recurrence,
-      )
-        ? raw.recurrence
-        : 'none',
-      location: raw?.location,
-      participants: Array.isArray(raw?.participants) ? raw.participants : [],
-      notification:
-        typeof raw?.notification === 'number' ? raw.notification : 0,
-      description: raw?.description,
-      color: raw?.color || 'bg-blue-500',
-      calendarId: raw?.calendarId || '1',
-    }
-  }
-
-  async function unlock() {
-    if (!password) return
-
-    try {
-      setIsUnlocking(true)
-      const cloud = await apiGet()
-      if (!cloud) return
-
-      const keyCache = new Map<string, Promise<CryptoKey>>()
-
-      let plain
-      try {
-        plain = await decryptLargePayload(password, cloud.ciphertext, cloud.iv)
-      } catch {
-        toast(t.incorrectPassword)
-        return
-      }
-
-      try {
-        const data = parseCloudBackupPayload(plain)
-        const storage = data?.storage
-        const fallbackEvents = data?.events
-        const fallbackCalendars = data?.calendars
-
-        await setEncryptionPassword(password)
-
-        if (storage && typeof storage === 'object') {
-          const normalizedStorageRecord = normalizeStorageRecord(storage)
-          const normalizedStorage = Object.fromEntries(
-            await Promise.all(
-              Object.entries(normalizedStorageRecord).map(
-                async ([key, value]) => [
-                  key,
-                  await normalizeCloudStorageValue(value, password, keyCache),
-                ],
-              ),
-            ),
-          )
-          await applyCloudStorageToMemory(normalizedStorage)
-        } else if (fallbackEvents || fallbackCalendars) {
-          const fallbackStorage: Record<string, string> = {}
-          if (fallbackEvents)
-            fallbackStorage['calendar-events'] = JSON.stringify(fallbackEvents)
-          if (fallbackCalendars)
-            fallbackStorage['calendar-categories'] =
-              JSON.stringify(fallbackCalendars)
-          await applyCloudStorageToMemory(fallbackStorage)
-        }
-
-        const [restoredEvents, restoredCalendars, restoredLanguage] =
-          await Promise.all([
-            readEncryptedLocalStorage('calendar-events', []),
-            readEncryptedLocalStorage('calendar-categories', []),
-            readEncryptedLocalStorage<string | null>(
-              'preferred-language',
-              null,
-            ),
-          ])
-        setEvents(restoredEvents)
-        setCalendars(restoredCalendars)
-        if (restoredLanguage) {
-          window.dispatchEvent(
-            new CustomEvent('languagechange', {
-              detail: { language: restoredLanguage },
-            }),
-          )
-        }
-        window.dispatchEvent(new CustomEvent('backup-restored'))
-      } catch {}
-
-      keyRef.current = password
-      restoredRef.current = true
-      skipNextAutoBackupRef.current = true
-      localStorage.setItem(AUTO_KEY, 'true')
-      setEnabled(true)
-      broadcastBackupStatus('done')
-
-      setPassword('')
-      setUnlockOpen(false)
-      toast(t.dataRestoredAutoBackupEnabled)
-    } finally {
-      setIsUnlocking(false)
-    }
-  }
-
-  async function enable() {
-    if (!password) {
-      setError(t.setEncryptionPasswordDescription || 'Encryption key not ready')
-      return
-    }
-    await setEncryptionPassword(password)
-    const payload = await encryptLargePayload(
-      password,
-      JSON.stringify({
-        v: BACKUP_VERSION,
-        storage: await collectLocalStorage(),
-      }),
-    )
-    await apiPost(payload)
-    lastBackupSnapshotRef.current = JSON.stringify({
-      v: BACKUP_VERSION,
-      storage: await collectLocalStorage(),
-    })
+  async function enableAutoBackup() {
     localStorage.setItem(AUTO_KEY, 'true')
-    keyRef.current = password
-    restoredRef.current = true
     setEnabled(true)
-    broadcastBackupStatus('done')
-    setPassword('')
-    setConfirm('')
-    setSetPwdOpen(false)
-    toast(t.autoBackupEnabled)
-  }
-
-  async function rotate() {
-    if (!password) {
-      setError(t.setEncryptionPasswordDescription || 'Encryption key not ready')
-      return
-    }
-    const cloud = await apiGet()
-    if (!cloud) return
-
+    setBackupStatus('uploading')
     try {
-      await decryptLargePayload(oldPassword, cloud.ciphertext, cloud.iv)
+      await fetch('/api/blob', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ events, calendars }),
+      })
+      setBackupStatus('done')
+      toast(t.autoBackupEnabled || 'Server backup enabled')
     } catch {
-      toast(t.incorrectOldPassword)
-      return
+      setBackupStatus('failed')
+      toast(t.backupFailed || 'Backup failed')
     }
-
-    const next = await encryptLargePayload(
-      password,
-      JSON.stringify({
-        v: BACKUP_VERSION,
-        storage: await collectLocalStorage(),
-      }),
-    )
-    await apiPost(next)
-    lastBackupSnapshotRef.current = JSON.stringify({
-      v: BACKUP_VERSION,
-      storage: await collectLocalStorage(),
-    })
-    await setEncryptionPassword(password)
-    keyRef.current = password
-    setRotateOpen(false)
-    setOldPassword('')
-    setPassword('')
-    setConfirm('')
-    toast(t.encryptionKeyUpdated)
-  }
-
-  async function verifyOldPasswordForRotation() {
-    if (!oldPassword) {
-      setError(t.enterPasswordDescription)
-      return
-    }
-    const cloud = await apiGet()
-    if (!cloud) return
-    setIsVerifyingRotationKey(true)
-    try {
-      await decryptLargePayload(oldPassword, cloud.ciphertext, cloud.iv)
-      const generated = generateHighEntropyKey()
-      setPassword(generated)
-      setConfirm(generated)
-      setError('')
-      setRotateStep('confirm')
-    } catch {
-      setError(t.incorrectOldPassword)
-      toast(t.incorrectOldPassword)
-    } finally {
-      setIsVerifyingRotationKey(false)
-    }
+    setBackupOpen(false)
   }
 
   function disableAutoBackup() {
     localStorage.removeItem(AUTO_KEY)
     localStorage.removeItem(BACKUP_STATUS_KEY)
-    keyRef.current = null
-    lastBackupSnapshotRef.current = null
-    restoredRef.current = false
     setEnabled(false)
-    clearEncryptionPassword()
-    toast(t.autoBackupDisabled)
+    window.dispatchEvent(new CustomEvent('backup-status-change'))
+    toast(t.autoBackupDisabled || 'Server backup disabled')
   }
 
-  async function destroy() {
+  async function destroyCloudData() {
     await apiDelete()
     localStorage.removeItem(AUTO_KEY)
     localStorage.removeItem(BACKUP_STATUS_KEY)
-    keyRef.current = null
-    lastBackupSnapshotRef.current = null
-    restoredRef.current = false
     setEnabled(false)
-    toast(t.cloudDataDeleted)
+    window.dispatchEvent(new CustomEvent('backup-status-change'))
+    toast(t.cloudDataDeleted || 'Cloud data deleted')
   }
 
-  const openProfileSection = (
-    section: 'basic' | 'emails' | 'twofa' | 'password',
-  ) => {
-    setProfileSection(section)
-    setProfileOpen(true)
+  async function signOut() {
+    await authClient.signOut()
+    router.push('/sign-in')
   }
 
-  function resetTwoFactorFlow() {
-    setTwoFaStep(1)
-    setTwoFactorCode('')
-    setTwoFactorPassword('')
-    if (twoFactorQrCodeRef.current) {
-      URL.revokeObjectURL(twoFactorQrCodeRef.current)
-      twoFactorQrCodeRef.current = null
-    }
-    setTwoFactorQrCode('')
-    setTwoFactorUri('')
-  }
-
-  async function enableTwoFactor() {
-    if (!twoFactorPassword) return
-    setTwoFactorPending(true)
-    const setupRes = await authClient.twoFactor.enable({
-      password: twoFactorPassword,
-    })
-    if (setupRes.error) {
-      toast(setupRes.error.message || 'Failed to enable 2FA')
-      setTwoFactorPending(false)
-      return
-    }
-    const totpUri =
-      (setupRes as any).data?.totpURI || (setupRes as any).data?.totpUri || ''
-    setTwoFactorUri(totpUri)
-    if (totpUri) {
-      const qrCode = new QRCodeStyling({
-        width: 220,
-        height: 220,
-        type: 'canvas',
-        data: totpUri,
-        margin: 2,
-      })
-      const qrBlob = await qrCode.getRawData('png')
-      if (qrBlob instanceof Blob) {
-        if (twoFactorQrCodeRef.current) {
-          URL.revokeObjectURL(twoFactorQrCodeRef.current)
-        }
-        const qrUrl = URL.createObjectURL(qrBlob)
-        twoFactorQrCodeRef.current = qrUrl
-        setTwoFactorQrCode(qrUrl)
-      }
-    }
-    setTwoFactorEnabled(true)
-    setTwoFaStep(2)
-    setTwoFactorPending(false)
-    toast(t.twoFactorAuthentication)
-  }
-
-  async function disableTwoFactor() {
-    if (!twoFactorPassword) return
-    setTwoFactorPending(true)
-    const disableRes = await authClient.twoFactor.disable({
-      password: twoFactorPassword,
-    })
-    if (disableRes.error) {
-      toast(disableRes.error.message || 'Failed to disable 2FA')
-      setTwoFactorPending(false)
-      return
-    }
-    setTwoFactorEnabled(false)
-    resetTwoFactorFlow()
-    setTwoFactorPending(false)
-    toast(t.twoFactorAuthentication)
-  }
-
-  async function verifyTwoFactorSetup() {
-    if (twoFactorCode.length < 6) return
-    setTwoFactorPending(true)
-    const verifyRes = await authClient.twoFactor.verifyTotp({
-      code: twoFactorCode,
-      trustDevice: true,
-    })
-    if (verifyRes.error) {
-      toast(verifyRes.error.message || `Invalid ${t.otpCode}`)
-      setTwoFactorPending(false)
-      return
-    }
-    toast('2FA setup verified.')
-    setTwoFactorCode('')
-    setTwoFaStep(3)
-    setTwoFactorPending(false)
-  }
   async function deleteAccount() {
-    if (!user || deleteAccountConfirmText !== 'DELETE MY ACCOUNT') return
-    try {
-      setIsDeletingAccount(true)
-      const response = await fetch('/api/account', { method: 'DELETE' })
-      if (!response.ok) {
-        const data = await response.json().catch(() => ({}))
-        throw new Error(data?.error || 'Failed to delete account data')
-      }
-
-      await user.delete()
-
-      toast(t.accountDeleted)
-      router.replace('/')
-    } catch (e: any) {
-      toast(t.deleteAccountFailed, {
-        description: e?.message || '',
-      })
-    } finally {
-      setIsDeletingAccount(false)
-      setDeleteAccountOpen(false)
-    }
+    await fetch('/api/account', { method: 'DELETE' })
+    await authClient.signOut()
+    router.push('/sign-in')
   }
+
+  if (!isSignedIn && mode === 'dropdown') {
+    return (
+      <Button
+        variant={variant}
+        className={className}
+        onClick={() => router.push('/sign-in')}
+      >
+        <CircleUser className="h-4 w-4" />
+      </Button>
+    )
+  }
+
+  const settingsContent = (
+    <div className="grid gap-4 md:grid-cols-2">
+      <section
+        id="settings-account-profile"
+        className="rounded-lg border bg-card p-4"
+      >
+        <div className="mb-3 flex items-center gap-2 font-semibold">
+          <CircleUser className="h-4 w-4" />
+          {t.profile || 'Profile'}
+        </div>
+        <div className="space-y-3">
+          <div className="grid gap-3 sm:grid-cols-2">
+            <div className="space-y-2">
+              <Label>{t.firstName || 'First name'}</Label>
+              <Input
+                value={firstName}
+                onChange={(event) => setFirstName(event.target.value)}
+              />
+            </div>
+            <div className="space-y-2">
+              <Label>{t.lastName || 'Last name'}</Label>
+              <Input
+                value={lastName}
+                onChange={(event) => setLastName(event.target.value)}
+              />
+            </div>
+          </div>
+          <div className="text-sm text-muted-foreground">{user?.email}</div>
+          <Button onClick={saveProfile} disabled={profileSaving}>
+            {profileSaving ? t.saving || 'Saving' : t.save || 'Save'}
+          </Button>
+        </div>
+      </section>
+
+      <section
+        id="settings-account-backup"
+        className="rounded-lg border bg-card p-4"
+      >
+        <div className="mb-3 flex items-center gap-2 font-semibold">
+          <CloudUpload className="h-4 w-4" />
+          {t.autoBackup || 'Server backup'}
+        </div>
+        <p className="mb-4 text-sm text-muted-foreground">
+          {enabled
+            ? t.autoBackupStatusEnabled ||
+              'Your calendar data is encrypted on the server.'
+            : t.autoBackupStatusDisabled ||
+              'Enable server-side encrypted calendar storage.'}
+        </p>
+        {enabled ? (
+          <Button variant="outline" onClick={disableAutoBackup}>
+            {t.disable || 'Disable'}
+          </Button>
+        ) : (
+          <Button onClick={enableAutoBackup}>{t.enable || 'Enable'}</Button>
+        )}
+      </section>
+
+      <section
+        id="settings-account-delete"
+        className="rounded-lg border bg-card p-4 md:col-span-2"
+      >
+        <div className="mb-3 flex items-center gap-2 font-semibold text-destructive">
+          <Trash2 className="h-4 w-4" />
+          {t.delete || 'Delete'}
+        </div>
+        <div className="flex flex-wrap gap-2">
+          <Button
+            variant="destructive"
+            onClick={() => setDeleteCloudOpen(true)}
+          >
+            {t.deleteData || 'Delete cloud data'}
+          </Button>
+          <Button
+            variant="destructive"
+            onClick={() => setDeleteAccountOpen(true)}
+          >
+            {t.deleteAccount || 'Delete account'}
+          </Button>
+        </div>
+      </section>
+    </div>
+  )
 
   return (
     <>
-      {mode === 'dropdown' ? (
+      {mode === 'settings' ? (
+        settingsContent
+      ) : (
         <DropdownMenu>
           <DropdownMenuTrigger asChild>
-            {isSignedIn ? (
-              <Button
-                variant={variant}
-                size="icon"
-                className={cn(
-                  'rounded-full overflow-hidden h-8 w-8 p-0',
-                  className,
-                )}
-              >
-                <img
-                  src={user?.image || '/user.png'}
-                  alt="avatar"
-                  width={32}
-                  height={32}
-                  className="rounded-full object-cover"
-                  loading="lazy"
-                  referrerPolicy="no-referrer"
-                />
-              </Button>
-            ) : (
-              <Button variant={variant} size="icon" className={className}>
-                <CircleUser className="h-4 w-4" />
-              </Button>
-            )}
+            <Button variant={variant} className={cn(className)}>
+              <CircleUser className="h-4 w-4" />
+            </Button>
           </DropdownMenuTrigger>
-
-          <DropdownMenuContent align="end">
-            {!isAnySignedIn ? (
-              <>
-                <DropdownMenuItem onClick={() => router.push('/sign-in')}>
-                  {t.signIn}
-                </DropdownMenuItem>
-                <DropdownMenuItem onClick={() => router.push('/sign-up')}>
-                  {t.signUp}
-                </DropdownMenuItem>
-              </>
-            ) : null}
-            <DropdownMenuItem onClick={() => onNavigateToView?.('settings')}>
-              <Settings className="mr-2 h-4 w-4" />
-              {t.settings}
+          <DropdownMenuContent align="end" className="w-56">
+            <DropdownMenuItem onClick={() => setProfileOpen(true)}>
+              <CircleUser className="mr-2 h-4 w-4" />
+              {t.profile || 'Profile'}
+            </DropdownMenuItem>
+            <DropdownMenuItem
+              onClick={() =>
+                onNavigateToSettings?.('backup') ?? setBackupOpen(true)
+              }
+            >
+              <CloudUpload className="mr-2 h-4 w-4" />
+              {t.autoBackup || 'Server backup'}
             </DropdownMenuItem>
             <DropdownMenuItem onClick={() => onNavigateToView?.('analytics')}>
               <BarChart2 className="mr-2 h-4 w-4" />
-              {t.analytics}
+              {t.analytics || 'Analytics'}
+            </DropdownMenuItem>
+            <DropdownMenuItem
+              onClick={() =>
+                onNavigateToSettings?.('profile') ??
+                onNavigateToView?.('settings')
+              }
+            >
+              <Settings className="mr-2 h-4 w-4" />
+              {t.settings || 'Settings'}
+            </DropdownMenuItem>
+            <DropdownMenuItem
+              onClick={signOut}
+              className="text-destructive focus:text-destructive"
+            >
+              <LogOut className="mr-2 h-4 w-4" />
+              {t.signOut || 'Sign out'}
             </DropdownMenuItem>
           </DropdownMenuContent>
         </DropdownMenu>
-      ) : (
-        <div className="rounded-lg border p-4 space-y-4">
-          {isAnySignedIn ? (
-            <>
-              <div className="flex items-center gap-3">
-                <img
-                  src={user?.image || '/user.png'}
-                  alt="avatar"
-                  width={40}
-                  height={40}
-                  className="h-10 w-10 rounded-full border object-cover"
-                  loading="lazy"
-                  referrerPolicy="no-referrer"
-                />
-                <div className="min-w-0">
-                  <p className="font-medium truncate">{user?.name || 'User'}</p>
-                  <p className="text-sm text-muted-foreground truncate">
-                    {user?.email || ''}
-                  </p>
-                </div>
-              </div>
-              <div className="space-y-4">
-                {isSignedIn ? (
-                  <>
-                    <div className="space-y-3 rounded-md border p-3">
-                      <p className="text-sm font-semibold">{t.basicInfo}</p>
-                      <p className="text-xs text-muted-foreground">
-                        {t.editProfileDescription}
-                      </p>
-                      <Button
-                        id="settings-account-profile"
-                        variant="outline"
-                        onClick={() => openProfileSection('basic')}
-                      >
-                        <CircleUser className="h-4 w-4 mr-2" />
-                        {t.openBasicInfo}
-                      </Button>
-                    </div>
-
-                    <div className="space-y-3 rounded-md border p-3">
-                      <p className="text-sm font-semibold">
-                        {t.emailManagement}
-                      </p>
-                      <p className="text-xs text-muted-foreground">
-                        {t.manageEmailAddressesDescription}
-                      </p>
-                      <Button
-                        variant="outline"
-                        onClick={() => openProfileSection('emails')}
-                      >
-                        <Mail className="h-4 w-4 mr-2" />
-                        {t.openEmailSettings}
-                      </Button>
-                    </div>
-
-                    <div className="space-y-3 rounded-md border p-3">
-                      <p className="text-sm font-semibold">
-                        {t.twoFactorAuthentication}
-                      </p>
-                      <p className="text-xs text-muted-foreground">
-                        {t.twoFactorAuthenticationDescription}
-                      </p>
-                      <Button
-                        variant="outline"
-                        onClick={() => openProfileSection('twofa')}
-                      >
-                        <KeyRound className="h-4 w-4 mr-2" />
-                        {t.openTwoFactorSettings}
-                      </Button>
-                    </div>
-
-                    <div className="space-y-3 rounded-md border p-3">
-                      <p className="text-sm font-semibold">
-                        {t.changePassword}
-                      </p>
-                      <p className="text-xs text-muted-foreground">
-                        {t.changePasswordDescription}
-                      </p>
-                      <Button
-                        variant="outline"
-                        onClick={() => openProfileSection('password')}
-                      >
-                        <KeyRound className="h-4 w-4 mr-2" />
-                        {t.openPasswordSettings}
-                      </Button>
-                    </div>
-                  </>
-                ) : null}
-
-                <div className="space-y-3 rounded-md border p-3">
-                  <p className="text-sm font-semibold">{t.autoBackup}</p>
-                  <p className="text-xs text-muted-foreground">
-                    {t.autoBackupHelp}
-                  </p>
-                  <Button
-                    id="settings-account-backup"
-                    variant="outline"
-                    onClick={() => setBackupOpen(true)}
-                  >
-                    <CloudUpload className="h-4 w-4 mr-2" />
-                    {t.openBackupSettings}
-                  </Button>
-                </div>
-
-                <div className="space-y-3 rounded-md border p-3">
-                  <p className="text-sm font-semibold">{t.changeKey}</p>
-                  <p className="text-xs text-muted-foreground">
-                    {t.rotateKeyHelp}
-                  </p>
-                  <Button
-                    id="settings-account-key"
-                    variant="outline"
-                    onClick={() => {
-                      setRotateStep('verify')
-                      setOldPassword('')
-                      setPassword('')
-                      setConfirm('')
-                      setError('')
-                      setRotateOpen(true)
-                    }}
-                  >
-                    <KeyRound className="h-4 w-4 mr-2" />
-                    {t.changeEncryptionKeyAction}
-                  </Button>
-                </div>
-
-                <div className="space-y-3 rounded-md border p-3">
-                  <p className="text-sm font-semibold">{t.signOut}</p>
-                  <p className="text-xs text-muted-foreground">
-                    {t.signOutHelp}
-                  </p>
-                  {isSignedIn ? (
-                    <Button
-                      id="settings-account-signout"
-                      variant="outline"
-                      onClick={async () => {
-                        await authClient.signOut()
-                        router.refresh()
-                      }}
-                    >
-                      <LogOut className="h-4 w-4 mr-2" />
-                      {t.signOut}
-                    </Button>
-                  ) : (
-                    <Button
-                      id="settings-account-signout"
-                      variant="outline"
-                      onClick={async () => {
-                        await authClient.signOut()
-                        router.refresh()
-                      }}
-                    >
-                      <LogOut className="h-4 w-4 mr-2" />
-                      {t.signOut}
-                    </Button>
-                  )}
-                </div>
-
-                <div className="rounded-md border border-destructive/70 p-3 space-y-3 bg-destructive/5">
-                  <p className="text-sm font-semibold text-destructive">
-                    {t.dangerZone}
-                  </p>
-                  <div className="space-y-3 rounded-md border border-destructive/50 p-3">
-                    <p className="text-sm font-semibold text-destructive">
-                      {t.deleteData}
-                    </p>
-                    <p className="text-xs text-muted-foreground">
-                      {t.deleteAccountDataHelp}
-                    </p>
-                    <Button
-                      id="settings-account-delete"
-                      variant="destructive"
-                      onClick={() => setDeleteCloudOpen(true)}
-                    >
-                      <Trash2 className="h-4 w-4 mr-2" />
-                      {t.deleteData}
-                    </Button>
-                  </div>
-                  {isSignedIn ? (
-                    <div className="space-y-3 rounded-md border border-destructive/50 p-3">
-                      <p className="text-sm font-semibold text-destructive">
-                        {t.deleteAccount}
-                      </p>
-                      <p className="text-xs text-muted-foreground">
-                        {t.deleteAccountPermanentHelp}
-                      </p>
-                      <Button
-                        variant="destructive"
-                        onClick={() => setDeleteAccountOpen(true)}
-                      >
-                        <Trash2 className="h-4 w-4 mr-2" />
-                        {t.deleteAccount}
-                      </Button>
-                    </div>
-                  ) : null}
-                </div>
-              </div>
-            </>
-          ) : (
-            <div className="grid gap-2 sm:grid-cols-2">
-              <Button variant="outline" onClick={() => router.push('/sign-in')}>
-                {t.signIn}
-              </Button>
-              <Button onClick={() => router.push('/sign-up')}>
-                {t.signUp}
-              </Button>
-            </div>
-          )}
-        </div>
       )}
 
       <Dialog open={profileOpen} onOpenChange={setProfileOpen}>
-        <DialogContent className="sm:max-w-2xl">
+        <DialogContent>
           <DialogHeader>
-            <DialogTitle>{t.profile}</DialogTitle>
-            <DialogDescription>{t.manageProfileDescription}</DialogDescription>
+            <DialogTitle>{t.profile || 'Profile'}</DialogTitle>
+            <DialogDescription>{user?.email}</DialogDescription>
           </DialogHeader>
-
-          <ScrollArea className="max-h-[70vh] pr-4">
-            <div className="space-y-6 py-1">
-              <section
-                className="space-y-3 rounded-lg border p-4"
-                hidden={profileSection !== 'basic'}
-              >
-                <h3 className="font-medium">{t.basicInfo}</h3>
-                <div className="space-y-2">
-                  <Label>{t.avatar}</Label>
-                  <div className="flex items-center gap-3">
-                    <img
-                      src={user?.image || '/user.png'}
-                      alt="avatar"
-                      width={52}
-                      height={52}
-                      className="h-12 w-12 rounded-full border object-cover"
-                      loading="lazy"
-                      referrerPolicy="no-referrer"
-                    />
-                    <Label
-                      htmlFor="profile-avatar-input"
-                      className="inline-flex items-center gap-2 rounded-md border px-3 py-2 text-sm cursor-pointer hover:bg-accent"
-                    >
-                      <Camera className="h-4 w-4" />
-                      {avatarUploading ? t.uploading : t.changeAvatar}
-                    </Label>
-                    <Input
-                      id="profile-avatar-input"
-                      type="file"
-                      accept="image/*"
-                      className="hidden"
-                      disabled={avatarUploading}
-                      onChange={(e) => {
-                        void updateAvatar(e.target.files?.[0])
-                        e.currentTarget.value = ''
-                      }}
-                    />
-                  </div>
-                </div>
-                <div className="grid grid-cols-1 sm:grid-cols-2 gap-3">
-                  <div className="space-y-2">
-                    <Label>{t.firstName}</Label>
-                    <Input
-                      value={firstName}
-                      onChange={(e) => setFirstName(e.target.value)}
-                    />
-                  </div>
-                  <div className="space-y-2">
-                    <Label>{t.lastName}</Label>
-                    <Input
-                      value={lastName}
-                      onChange={(e) => setLastName(e.target.value)}
-                    />
-                  </div>
-                </div>
-                <Button onClick={saveProfile} disabled={profileSaving}>
-                  {profileSaving ? t.saving : t.saveProfile}
-                </Button>
-              </section>
-
-              <section
-                className="space-y-3 rounded-lg border p-4"
-                hidden={profileSection !== 'emails'}
-              >
-                <h3 className="font-medium flex items-center gap-2">
-                  <Mail className="h-4 w-4" />
-                  {t.accountEmailManagement}
-                </h3>
-                {emailStep === 1 ? (
-                  <>
-                    <div className="rounded-md border px-3 py-2 text-sm">
-                      <p className="text-muted-foreground">{t.currentEmail}</p>
-                      <p className="font-medium">{user?.email || '-'}</p>
-                    </div>
-                    <div className="space-y-2">
-                      <Label>{t.currentPassword}</Label>
-                      <Input
-                        type="password"
-                        value={twoFactorPassword}
-                        onChange={(e) => setTwoFactorPassword(e.target.value)}
-                      />
-                    </div>
-                    <div className="space-y-2">
-                      <Label>{t.newEmail}</Label>
-                      <Input
-                        type="email"
-                        value={newEmail}
-                        onChange={(e) => setNewEmail(e.target.value)}
-                      />
-                    </div>
-                    <div className="flex gap-2">
-                      <Button variant="outline" onClick={sendEmailChangeOtp}>
-                        {t.next}
-                      </Button>
-                    </div>
-                  </>
-                ) : (
-                  <div className="space-y-2">
-                    <Label>{t.emailOtpCode}</Label>
-                    <Input
-                      value={emailOtp}
-                      onChange={(e) =>
-                        setEmailOtp(
-                          e.target.value.replace(/\D/g, '').slice(0, 6),
-                        )
-                      }
-                    />
-                    <div className="flex gap-2">
-                      <Button variant="outline" onClick={confirmEmailChange}>
-                        {t.verifyAndUpdateEmail}
-                      </Button>
-                      <Button variant="outline" onClick={() => setEmailStep(1)}>
-                        {t.back}
-                      </Button>
-                    </div>
-                  </div>
-                )}
-              </section>
-
-              <section
-                className="space-y-3 rounded-lg border p-4"
-                hidden={profileSection !== 'twofa'}
-              >
-                <h3 className="font-medium">{t.twoFactorAuthentication}</h3>
-                {twoFaStep === 1 ? (
-                  <>
-                    <div className="space-y-2">
-                      <Label>{t.currentPassword}</Label>
-                      <Input
-                        type="password"
-                        value={twoFactorPassword}
-                        onChange={(e) => setTwoFactorPassword(e.target.value)}
-                      />
-                    </div>
-                    <div className="flex gap-2">
-                      <Button
-                        variant="outline"
-                        onClick={enableTwoFactor}
-                        disabled={
-                          twoFactorPending ||
-                          twoFactorEnabled ||
-                          !twoFactorPassword
-                        }
-                      >
-                        {t.next}
-                      </Button>
-                      <Button
-                        variant="outline"
-                        onClick={disableTwoFactor}
-                        disabled={
-                          twoFactorPending ||
-                          !twoFactorEnabled ||
-                          !twoFactorPassword
-                        }
-                      >
-                        {t.disable2fa}
-                      </Button>
-                    </div>
-                  </>
-                ) : null}
-                {twoFaStep === 2 && twoFactorUri ? (
-                  <div className="space-y-3">
-                    <div className="space-y-2">
-                      <Label>{t.scanQrFor2fa}</Label>
-                      <img
-                        src={twoFactorQrCode}
-                        alt={t.twoFactorQrCodeAlt}
-                        className="h-44 w-44 rounded-md border"
-                      />
-                    </div>
-                    <div className="space-y-2">
-                      <Label>{t.otpCode}</Label>
-                      <Input
-                        value={twoFactorCode}
-                        onChange={(e) =>
-                          setTwoFactorCode(
-                            e.target.value.replace(/\D/g, '').slice(0, 6),
-                          )
-                        }
-                      />
-                    </div>
-                    <div className="flex gap-2">
-                      <Button
-                        variant="outline"
-                        onClick={verifyTwoFactorSetup}
-                        disabled={twoFactorPending || twoFactorCode.length < 6}
-                      >
-                        {t.verify2faCode}
-                      </Button>
-                      <Button variant="outline" onClick={() => setTwoFaStep(1)}>
-                        {t.back}
-                      </Button>
-                      <Button
-                        variant="ghost"
-                        onClick={resetTwoFactorFlow}
-                        disabled={twoFactorPending}
-                      >
-                        Close
-                      </Button>
-                    </div>
-                  </div>
-                ) : null}
-                {twoFaStep === 3 ? (
-                  <p className="text-sm text-muted-foreground">
-                    {t.twoFactorEnabledMessage}
-                  </p>
-                ) : null}
-              </section>
-
-              <section
-                className="space-y-3 rounded-lg border p-4"
-                hidden={profileSection !== 'password'}
-              >
-                <h3 className="font-medium">{t.changePassword}</h3>
-                <div className="space-y-2 pt-2 border-t">
-                  <Label>{t.currentPassword}</Label>
-                  <Input
-                    type="password"
-                    value={twoFactorPassword}
-                    onChange={(e) => setTwoFactorPassword(e.target.value)}
-                  />
-                  <Label>{t.newPassword || 'New password'}</Label>
-                  <Input
-                    type="password"
-                    value={changePasswordValue}
-                    onChange={(e) => setChangePasswordValue(e.target.value)}
-                  />
-                  <Button variant="outline" onClick={confirmChangePassword}>
-                    {t.updatePassword || 'Update password'}
-                  </Button>
-                </div>
-              </section>
-            </div>
+          <ScrollArea className="max-h-[70vh] pr-3">
+            {settingsContent}
           </ScrollArea>
         </DialogContent>
       </Dialog>
 
-      <AlertDialog open={deleteAccountOpen} onOpenChange={setDeleteAccountOpen}>
-        <AlertDialogContent>
-          <AlertDialogHeader>
-            <AlertDialogTitle>{t.deleteAccountConfirmTitle}</AlertDialogTitle>
-            <AlertDialogDescription>
-              {t.deleteAccountConfirmDescription}
-            </AlertDialogDescription>
-          </AlertDialogHeader>
-          <div className="space-y-2">
-            <Label htmlFor="delete-account-confirm-input">
-              DELETE MY ACCOUNT
-            </Label>
-            <Input
-              id="delete-account-confirm-input"
-              value={deleteAccountConfirmText}
-              onChange={(e) => setDeleteAccountConfirmText(e.target.value)}
-              placeholder="DELETE MY ACCOUNT"
-              autoComplete="off"
-            />
-          </div>
-          <AlertDialogFooter>
-            <AlertDialogCancel>{t.cancel}</AlertDialogCancel>
-            <AlertDialogAction
-              className="bg-destructive text-destructive-foreground hover:bg-destructive/90"
-              onClick={(e) => {
-                e.preventDefault()
-                void deleteAccount()
-              }}
-              disabled={
-                isDeletingAccount ||
-                deleteAccountConfirmText !== 'DELETE MY ACCOUNT'
-              }
-            >
-              {isDeletingAccount ? t.deleting : t.confirmDeleteAccount}
-            </AlertDialogAction>
-          </AlertDialogFooter>
-        </AlertDialogContent>
-      </AlertDialog>
-
-      <AlertDialog
-        open={deleteCloudOpen}
-        onOpenChange={(open: boolean) => setDeleteCloudOpen(open)}
-      >
-        <AlertDialogContent>
-          <AlertDialogHeader>
-            <AlertDialogTitle>{t.deleteCloudConfirmTitle}</AlertDialogTitle>
-            <AlertDialogDescription>
-              {t.deleteCloudConfirmDescription}
-            </AlertDialogDescription>
-          </AlertDialogHeader>
-          <div className="space-y-2">
-            <Label htmlFor="delete-cloud-confirm-input">
-              DELETE CLOUD DATA
-            </Label>
-            <Input
-              id="delete-cloud-confirm-input"
-              value={deleteCloudConfirmText}
-              onChange={(e) => setDeleteCloudConfirmText(e.target.value)}
-              placeholder="DELETE CLOUD DATA"
-              autoComplete="off"
-            />
-          </div>
-          <AlertDialogFooter>
-            <AlertDialogCancel>{t.cancel}</AlertDialogCancel>
-            <AlertDialogAction
-              className="bg-destructive text-destructive-foreground hover:bg-destructive/90"
-              onClick={(e) => {
-                e.preventDefault()
-                if (deleteCloudConfirmText !== 'DELETE CLOUD DATA') return
-                void destroy().finally(() => {
-                  setDeleteCloudOpen(false)
-                  setDeleteCloudConfirmText('')
-                })
-              }}
-              disabled={deleteCloudConfirmText !== 'DELETE CLOUD DATA'}
-            >
-              {t.confirmDeleteData}
-            </AlertDialogAction>
-          </AlertDialogFooter>
-        </AlertDialogContent>
-      </AlertDialog>
       <Dialog open={backupOpen} onOpenChange={setBackupOpen}>
         <DialogContent>
           <DialogHeader>
-            <DialogTitle>{t.autoBackup}</DialogTitle>
+            <DialogTitle>{t.autoBackup || 'Server backup'}</DialogTitle>
             <DialogDescription>
-              {enabled ? t.autoBackupStatusEnabled : t.autoBackupStatusDisabled}
+              {enabled
+                ? t.autoBackupStatusEnabled || 'Server backup is enabled.'
+                : t.autoBackupStatusDisabled || 'Server backup is disabled.'}
             </DialogDescription>
           </DialogHeader>
           <DialogFooter>
             {enabled ? (
               <Button variant="destructive" onClick={disableAutoBackup}>
-                {t.disable}
+                {t.disable || 'Disable'}
               </Button>
             ) : (
-              <Button
-                onClick={() => {
-                  setBackupOpen(false)
-                  const generated = generateHighEntropyKey()
-                  setPassword(generated)
-                  setConfirm(generated)
-                  setSetPwdOpen(true)
-                }}
-              >
-                {t.enable}
-              </Button>
+              <Button onClick={enableAutoBackup}>{t.enable || 'Enable'}</Button>
             )}
           </DialogFooter>
         </DialogContent>
       </Dialog>
 
-      <Dialog open={setPwdOpen} onOpenChange={setSetPwdOpen}>
-        <DialogContent>
-          <DialogHeader>
-            <DialogTitle>{t.setEncryptionPassword}</DialogTitle>
-            <DialogDescription>
-              {t.setEncryptionPasswordDescription}
-            </DialogDescription>
-          </DialogHeader>
-          <Label>{t.password}</Label>
-          <Input type="text" value={password} readOnly />
-          <Label>{t.confirmPassword}</Label>
-          <Input type="text" value={confirm} readOnly />
-          {error && <p className="text-sm text-red-500">{error}</p>}
-          <DialogFooter>
-            <Button onClick={enable}>{t.confirm}</Button>
-          </DialogFooter>
-        </DialogContent>
-      </Dialog>
+      <AlertDialog open={deleteCloudOpen} onOpenChange={setDeleteCloudOpen}>
+        <AlertDialogContent>
+          <AlertDialogHeader>
+            <AlertDialogTitle>
+              {t.deleteCloudConfirmTitle || 'Delete cloud data?'}
+            </AlertDialogTitle>
+            <AlertDialogDescription>
+              {t.deleteCloudConfirmDescription ||
+                'This permanently removes server-side calendar data.'}
+            </AlertDialogDescription>
+          </AlertDialogHeader>
+          <div className="space-y-2">
+            <Label>DELETE CLOUD DATA</Label>
+            <Input
+              value={deleteCloudConfirmText}
+              onChange={(event) =>
+                setDeleteCloudConfirmText(event.target.value)
+              }
+              placeholder="DELETE CLOUD DATA"
+            />
+          </div>
+          <AlertDialogFooter>
+            <AlertDialogCancel>{t.cancel || 'Cancel'}</AlertDialogCancel>
+            <AlertDialogAction
+              className="bg-destructive text-destructive-foreground"
+              disabled={deleteCloudConfirmText !== 'DELETE CLOUD DATA'}
+              onClick={(event) => {
+                event.preventDefault()
+                void destroyCloudData().finally(() => {
+                  setDeleteCloudOpen(false)
+                  setDeleteCloudConfirmText('')
+                })
+              }}
+            >
+              {t.confirmDeleteData || 'Delete'}
+            </AlertDialogAction>
+          </AlertDialogFooter>
+        </AlertDialogContent>
+      </AlertDialog>
 
-      <Dialog
-        open={unlockOpen}
-        onOpenChange={(open) => {
-          if (open) setUnlockOpen(true)
-        }}
-      >
-        <DialogContent
-          onInteractOutside={(e: Event) => e.preventDefault()}
-          onEscapeKeyDown={(e: KeyboardEvent) => e.preventDefault()}
-        >
-          <DialogHeader>
-            <DialogTitle>{t.enterPasswordTitle}</DialogTitle>
-            <DialogDescription>{t.enterPasswordDescription}</DialogDescription>
-          </DialogHeader>
-          <Input
-            type="password"
-            value={password}
-            onChange={(e) => setPassword(e.target.value)}
-          />
-          <DialogFooter>
-            <Button onClick={unlock} disabled={isUnlocking}>
-              {isUnlocking ? (
-                <span className="flex items-center">
-                  <Spinner className="mr-2" />
-                  {t.verifying}
-                </span>
-              ) : (
-                t.confirm
-              )}
-            </Button>
-          </DialogFooter>
-        </DialogContent>
-      </Dialog>
-
-      <Dialog open={rotateOpen} onOpenChange={setRotateOpen}>
-        <DialogContent>
-          <DialogHeader>
-            <DialogTitle>{t.changeEncryptionKey}</DialogTitle>
-          </DialogHeader>
-          {rotateStep === 'verify' ? (
-            <>
-              <Label>{t.oldPassword}</Label>
-              <Input
-                type="password"
-                value={oldPassword}
-                onChange={(e) => setOldPassword(e.target.value)}
-              />
-              {error && <p className="text-sm text-red-500">{error}</p>}
-              <DialogFooter>
-                <Button
-                  onClick={verifyOldPasswordForRotation}
-                  disabled={isVerifyingRotationKey}
-                >
-                  {isVerifyingRotationKey ? t.verifying : t.next || 'Next'}
-                </Button>
-              </DialogFooter>
-            </>
-          ) : (
-            <>
-              <Label>{t.newPassword}</Label>
-              <Input type="text" value={password} readOnly />
-              <Label>{t.confirmNewPassword}</Label>
-              <Input type="text" value={confirm} readOnly />
-              {error && <p className="text-sm text-red-500">{error}</p>}
-              <DialogFooter>
-                <Button
-                  variant="outline"
-                  onClick={() => setRotateStep('verify')}
-                >
-                  {t.back || 'Back'}
-                </Button>
-                <Button onClick={rotate}>{t.confirmChange}</Button>
-              </DialogFooter>
-            </>
-          )}
-        </DialogContent>
-      </Dialog>
+      <AlertDialog open={deleteAccountOpen} onOpenChange={setDeleteAccountOpen}>
+        <AlertDialogContent>
+          <AlertDialogHeader>
+            <AlertDialogTitle>
+              {t.deleteAccount || 'Delete account'}
+            </AlertDialogTitle>
+            <AlertDialogDescription>
+              {t.deleteAccountConfirmDescription ||
+                'This action cannot be undone.'}
+            </AlertDialogDescription>
+          </AlertDialogHeader>
+          <div className="space-y-2">
+            <Label>DELETE ACCOUNT</Label>
+            <Input
+              value={deleteAccountConfirmText}
+              onChange={(event) =>
+                setDeleteAccountConfirmText(event.target.value)
+              }
+              placeholder="DELETE ACCOUNT"
+            />
+          </div>
+          <AlertDialogFooter>
+            <AlertDialogCancel>{t.cancel || 'Cancel'}</AlertDialogCancel>
+            <AlertDialogAction
+              className="bg-destructive text-destructive-foreground"
+              disabled={deleteAccountConfirmText !== 'DELETE ACCOUNT'}
+              onClick={(event) => {
+                event.preventDefault()
+                void deleteAccount()
+              }}
+            >
+              {t.confirmDeleteData || 'Delete'}
+            </AlertDialogAction>
+          </AlertDialogFooter>
+        </AlertDialogContent>
+      </AlertDialog>
     </>
   )
 }

--- a/components/app/sidebar/countdown.tsx
+++ b/components/app/sidebar/countdown.tsx
@@ -670,7 +670,6 @@ export function CountdownTool({ open, onOpenChange }: CountdownToolProps) {
                     setSelectedDate(date)
                     setCalendarOpen(false)
                   }}
-                  initialFocus
                   locale={isZh ? zhCN : enUS}
                 />
               </PopoverContent>

--- a/components/app/sidebar/sidebar.tsx
+++ b/components/app/sidebar/sidebar.tsx
@@ -20,6 +20,7 @@ import { translations, type Language } from '@/lib/i18n'
 import { Calendar } from '@/components/ui/calendar'
 import { Checkbox } from '@/components/ui/checkbox'
 import { Button } from '@/components/ui/button'
+import { Skeleton } from '@/components/ui/skeleton'
 import { Input } from '@/components/ui/input'
 import { Label } from '@/components/ui/label'
 import {
@@ -97,6 +98,7 @@ export default function Sidebar({
     removeCategory: removeCategoryFromContext,
     updateCategory: updateCategoryInContext,
     moveCategory: moveCategoryInContext,
+    isLoadingCalendarData,
   } = useCalendar()
 
   const [newCategoryName, setNewCategoryName] = useState('')
@@ -217,7 +219,15 @@ export default function Sidebar({
           events.filter((event) => event.calendarId !== categoryToDelete),
         )
       }
-      removeCategoryFromContext(categoryToDelete)
+      void fetch('/api/blob', {
+        method: 'DELETE',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({
+          categoryId: categoryToDelete,
+          deleteEvents: deleteCategoryEvents,
+        }),
+      })
+      removeCategoryFromContext(categoryToDelete, deleteCategoryEvents)
       toast(deleteText.toastSuccess, {
         description: deleteCategoryEvents
           ? t.categoryDeletedWithEvents
@@ -285,6 +295,16 @@ export default function Sidebar({
           <div className="flex items-center justify-between">
             <span className="text-sm font-medium">{t.myCalendars}</span>
           </div>
+          {isLoadingCalendarData && calendars.length === 0 && (
+            <div className="space-y-2">
+              {Array.from({ length: 3 }).map((_, index) => (
+                <div key={index} className="flex items-center gap-2">
+                  <Skeleton className="h-4 w-4 rounded-full" />
+                  <Skeleton className="h-4 w-28" />
+                </div>
+              ))}
+            </div>
+          )}
           {calendars.map((calendar) => (
             <div
               key={calendar.id}

--- a/components/providers/calendar-context.tsx
+++ b/components/providers/calendar-context.tsx
@@ -2,7 +2,7 @@
 
 import type { Dispatch, SetStateAction } from 'react'
 import type React from 'react'
-import { useEffect, useRef } from 'react'
+import { useCallback, useEffect, useRef } from 'react'
 import { create } from 'zustand'
 import {
   readEncryptedLocalStorage,
@@ -36,8 +36,15 @@ interface CalendarContextType {
   setCalendars: Dispatch<SetStateAction<CalendarCategory[]>>
   events: CalendarEvent[]
   setEvents: Dispatch<SetStateAction<CalendarEvent[]>>
+  isLoadingCalendarData: boolean
+  loadedRanges: Array<{ start: Date; end: Date }>
+  loadCalendarRange: (
+    start: Date,
+    end: Date,
+    replace?: boolean,
+  ) => Promise<void>
   addCategory: (category: CalendarCategory) => void
-  removeCategory: (id: string) => void
+  removeCategory: (id: string, deleteEvents?: boolean) => void
   updateCategory: (id: string, category: Partial<CalendarCategory>) => void
   moveCategory: (id: string, direction: 'up' | 'down') => void
   addEvent: (newEvent: CalendarEvent) => void
@@ -46,111 +53,241 @@ interface CalendarContextType {
 interface CalendarState {
   calendars: CalendarCategory[]
   events: CalendarEvent[]
+  isLoadingCalendarData: boolean
+  loadedRanges: Array<{ start: Date; end: Date }>
   setCalendars: (value: SetStateAction<CalendarCategory[]>) => void
   setEvents: (value: SetStateAction<CalendarEvent[]>) => void
+  setLoading: (loading: boolean) => void
+  addLoadedRange: (range: { start: Date; end: Date }) => void
+  mergeEvents: (
+    events: CalendarEvent[],
+    range?: { start: Date; end: Date },
+    replace?: boolean,
+  ) => void
   addCategory: (category: CalendarCategory) => void
-  removeCategory: (id: string) => void
+  removeCategory: (id: string, deleteEvents?: boolean) => void
   updateCategory: (id: string, category: Partial<CalendarCategory>) => void
   moveCategory: (id: string, direction: 'up' | 'down') => void
   addEvent: (newEvent: CalendarEvent) => void
 }
 
+function toEvent(raw: any): CalendarEvent {
+  return {
+    ...raw,
+    id: String(raw?.id || crypto.randomUUID()),
+    title: String(raw?.title || ''),
+    startDate: raw?.startDate ? new Date(raw.startDate) : new Date(),
+    endDate: raw?.endDate ? new Date(raw.endDate) : new Date(),
+    isAllDay: Boolean(raw?.isAllDay),
+    recurrence: ['none', 'daily', 'weekly', 'monthly', 'yearly'].includes(
+      raw?.recurrence,
+    )
+      ? raw.recurrence
+      : 'none',
+    participants: Array.isArray(raw?.participants) ? raw.participants : [],
+    notification: Number.isFinite(Number(raw?.notification))
+      ? Number(raw.notification)
+      : 0,
+    color: String(raw?.color || 'bg-blue-500'),
+    calendarId: String(raw?.calendarId || ''),
+  }
+}
+
+function eventInRange(event: CalendarEvent, range: { start: Date; end: Date }) {
+  return event.startDate <= range.end && event.endDate >= range.start
+}
+
 const useCalendarStore = create<CalendarState>()((set) => ({
   calendars: [],
   events: [],
-  setCalendars: (value: SetStateAction<CalendarCategory[]>) =>
-    set((state: CalendarState) => ({
+  isLoadingCalendarData: true,
+  loadedRanges: [],
+  setCalendars: (value) =>
+    set((state) => ({
       calendars: typeof value === 'function' ? value(state.calendars) : value,
     })),
-  setEvents: (value: SetStateAction<CalendarEvent[]>) =>
-    set((state: CalendarState) => ({
+  setEvents: (value) =>
+    set((state) => ({
       events: typeof value === 'function' ? value(state.events) : value,
     })),
-  addCategory: (category: CalendarCategory) =>
-    set((state: CalendarState) => ({ calendars: [...state.calendars, category] })),
-  removeCategory: (id: string) =>
-    set((state: CalendarState) => ({
+  setLoading: (loading) => set({ isLoadingCalendarData: loading }),
+  addLoadedRange: (range) =>
+    set((state) => ({ loadedRanges: [...state.loadedRanges, range] })),
+  mergeEvents: (incoming, range, replace) =>
+    set((state) => {
+      const incomingMap = new Map(incoming.map((event) => [event.id, event]))
+      const kept = replace
+        ? []
+        : state.events.filter(
+            (event) =>
+              !incomingMap.has(event.id) &&
+              (!range || !eventInRange(event, range)),
+          )
+      return {
+        events: [...kept, ...incoming].sort(
+          (a, b) => a.startDate.getTime() - b.startDate.getTime(),
+        ),
+      }
+    }),
+  addCategory: (category) =>
+    set((state) => ({ calendars: [...state.calendars, category] })),
+  removeCategory: (id, deleteEvents = false) =>
+    set((state) => ({
       calendars: state.calendars.filter((cal) => cal.id !== id),
+      events: deleteEvents
+        ? state.events.filter((event) => event.calendarId !== id)
+        : state.events,
     })),
-  updateCategory: (id: string, category: Partial<CalendarCategory>) =>
-    set((state: CalendarState) => ({
+  updateCategory: (id, category) =>
+    set((state) => ({
       calendars: state.calendars.map((cal) =>
         cal.id === id ? { ...cal, ...category } : cal,
       ),
     })),
-  moveCategory: (id: string, direction: 'up' | 'down') =>
-    set((state: CalendarState) => {
+  moveCategory: (id, direction) =>
+    set((state) => {
       const currentIndex = state.calendars.findIndex((cal) => cal.id === id)
-      if (currentIndex === -1) return { calendars: state.calendars }
-
       const targetIndex =
         direction === 'up' ? currentIndex - 1 : currentIndex + 1
-
-      if (targetIndex < 0 || targetIndex >= state.calendars.length) {
-        return { calendars: state.calendars }
-      }
-
+      if (
+        currentIndex === -1 ||
+        targetIndex < 0 ||
+        targetIndex >= state.calendars.length
+      )
+        return {}
       const nextCalendars = [...state.calendars]
       const [movedCalendar] = nextCalendars.splice(currentIndex, 1)
       nextCalendars.splice(targetIndex, 0, movedCalendar)
-
       return { calendars: nextCalendars }
     }),
-  addEvent: (newEvent: CalendarEvent) =>
-    set((state: CalendarState) => {
-      const eventExists = state.events.some((event) => event.id === newEvent.id)
-
-      if (eventExists) {
-        return {
-          events: state.events.map((event) =>
+  addEvent: (newEvent) =>
+    set((state) => ({
+      events: state.events.some((event) => event.id === newEvent.id)
+        ? state.events.map((event) =>
             event.id === newEvent.id ? newEvent : event,
-          ),
-        }
-      }
-
-      return { events: [...state.events, newEvent] }
-    }),
+          )
+        : [...state.events, newEvent],
+    })),
 }))
+
+async function isSignedIn() {
+  try {
+    const response = await fetch('/api/auth/get-session', { cache: 'no-store' })
+    const data = response.ok ? await response.json() : null
+    return Boolean(data && typeof data === 'object' && 'session' in data)
+  } catch {
+    return false
+  }
+}
+
+async function postCalendarData(body: unknown) {
+  const response = await fetch('/api/blob', {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify(body),
+  })
+  return response.ok
+}
 
 export function CalendarProvider({ children }: { children: React.ReactNode }) {
   const calendars = useCalendarStore((state) => state.calendars)
   const events = useCalendarStore((state) => state.events)
   const setCalendars = useCalendarStore((state) => state.setCalendars)
   const setEvents = useCalendarStore((state) => state.setEvents)
+  const mergeEvents = useCalendarStore((state) => state.mergeEvents)
+  const setLoading = useCalendarStore((state) => state.setLoading)
+  const addLoadedRange = useCalendarStore((state) => state.addLoadedRange)
+  const signedInRef = useRef(false)
   const hydratedRef = useRef(false)
+  const skipPersistRef = useRef(true)
+
+  const loadCalendarRange = useCallback(
+    async (start: Date, end: Date, replace = false) => {
+      if (!signedInRef.current) return
+      setLoading(true)
+      try {
+        const params = new URLSearchParams({
+          start: start.toISOString(),
+          end: end.toISOString(),
+        })
+        const response = await fetch(`/api/blob?${params}`, {
+          cache: 'no-store',
+        })
+        if (response.status === 404) return
+        if (!response.ok) throw new Error('Failed to load calendar data')
+        const data = await response.json()
+        skipPersistRef.current = true
+        if (Array.isArray(data.calendars)) setCalendars(data.calendars)
+        mergeEvents(
+          Array.isArray(data.events) ? data.events.map(toEvent) : [],
+          { start, end },
+          replace,
+        )
+        addLoadedRange({ start, end })
+      } finally {
+        setLoading(false)
+        window.setTimeout(() => {
+          skipPersistRef.current = false
+        }, 0)
+      }
+    },
+    [addLoadedRange, mergeEvents, setCalendars, setLoading],
+  )
 
   useEffect(() => {
     const hydrate = async () => {
-      const storedCalendars = await readEncryptedLocalStorage<
-        CalendarCategory[]
-      >('calendar-categories', [])
-      const storedEvents = await readEncryptedLocalStorage<CalendarEvent[]>(
-        'calendar-events',
-        [],
-      )
-
-      setCalendars(storedCalendars)
-      setEvents(
-        storedEvents.map((event) => ({
-          ...event,
-          startDate: new Date(event.startDate),
-          endDate: new Date(event.endDate),
-        })),
-      )
+      signedInRef.current = await isSignedIn()
+      if (signedInRef.current) {
+        const now = new Date()
+        await loadCalendarRange(
+          new Date(now.getFullYear(), now.getMonth() - 1, 1),
+          new Date(now.getFullYear(), now.getMonth() + 2, 0, 23, 59, 59, 999),
+          true,
+        )
+      } else {
+        const storedCalendars = await readEncryptedLocalStorage<
+          CalendarCategory[]
+        >('calendar-categories', [])
+        const storedEvents = await readEncryptedLocalStorage<CalendarEvent[]>(
+          'calendar-events',
+          [],
+        )
+        setCalendars(storedCalendars)
+        setEvents(storedEvents.map(toEvent))
+        setLoading(false)
+        skipPersistRef.current = false
+      }
       hydratedRef.current = true
     }
-
     void hydrate()
-  }, [setCalendars, setEvents])
+  }, [loadCalendarRange, setCalendars, setEvents, setLoading])
 
   useEffect(() => {
-    if (!hydratedRef.current) return
+    if (!hydratedRef.current || skipPersistRef.current) return undefined
+    if (signedInRef.current) {
+      const timer = window.setTimeout(() => {
+        void postCalendarData({ calendars })
+      }, 500)
+      return () => {
+        window.clearTimeout(timer)
+      }
+    }
     void writeEncryptedLocalStorage('calendar-categories', calendars)
+    return undefined
   }, [calendars])
 
   useEffect(() => {
-    if (!hydratedRef.current) return
+    if (!hydratedRef.current || skipPersistRef.current) return undefined
+    if (signedInRef.current) {
+      const timer = window.setTimeout(() => {
+        void postCalendarData({ events })
+      }, 500)
+      return () => {
+        window.clearTimeout(timer)
+      }
+    }
     void writeEncryptedLocalStorage('calendar-events', events)
+    return undefined
   }, [events])
 
   return children
@@ -163,6 +300,35 @@ export function useCalendar(): CalendarContextType {
     setCalendars: store.setCalendars,
     events: store.events,
     setEvents: store.setEvents,
+    isLoadingCalendarData: store.isLoadingCalendarData,
+    loadedRanges: store.loadedRanges,
+    loadCalendarRange: async (start, end, replace) => {
+      useCalendarStore.getState().setLoading(true)
+      try {
+        const params = new URLSearchParams({
+          start: start.toISOString(),
+          end: end.toISOString(),
+        })
+        const response = await fetch(`/api/blob?${params}`, {
+          cache: 'no-store',
+        })
+        if (!response.ok) return
+        const data = await response.json()
+        useCalendarStore
+          .getState()
+          .setCalendars(Array.isArray(data.calendars) ? data.calendars : [])
+        useCalendarStore
+          .getState()
+          .mergeEvents(
+            Array.isArray(data.events) ? data.events.map(toEvent) : [],
+            { start, end },
+            replace,
+          )
+        useCalendarStore.getState().addLoadedRange({ start, end })
+      } finally {
+        useCalendarStore.getState().setLoading(false)
+      }
+    },
     addCategory: store.addCategory,
     removeCategory: store.removeCategory,
     updateCategory: store.updateCategory,

--- a/components/providers/calendar-context.tsx
+++ b/components/providers/calendar-context.tsx
@@ -2,7 +2,13 @@
 
 import type { Dispatch, SetStateAction } from 'react'
 import type React from 'react'
-import { useCallback, useEffect, useRef } from 'react'
+import {
+  createContext,
+  useCallback,
+  useContext,
+  useEffect,
+  useRef,
+} from 'react'
 import { create } from 'zustand'
 import {
   readEncryptedLocalStorage,
@@ -31,6 +37,14 @@ export interface CalendarEvent {
   calendarId: string
 }
 
+type LoadCalendarRange = (
+  start: Date,
+  end: Date,
+  replace?: boolean,
+) => Promise<void>
+
+const CalendarLoadRangeContext = createContext<LoadCalendarRange | null>(null)
+
 interface CalendarContextType {
   calendars: CalendarCategory[]
   setCalendars: Dispatch<SetStateAction<CalendarCategory[]>>
@@ -38,11 +52,7 @@ interface CalendarContextType {
   setEvents: Dispatch<SetStateAction<CalendarEvent[]>>
   isLoadingCalendarData: boolean
   loadedRanges: Array<{ start: Date; end: Date }>
-  loadCalendarRange: (
-    start: Date,
-    end: Date,
-    replace?: boolean,
-  ) => Promise<void>
+  loadCalendarRange: LoadCalendarRange
   addCategory: (category: CalendarCategory) => void
   removeCategory: (id: string, deleteEvents?: boolean) => void
   updateCategory: (id: string, category: Partial<CalendarCategory>) => void
@@ -290,11 +300,17 @@ export function CalendarProvider({ children }: { children: React.ReactNode }) {
     return undefined
   }, [events])
 
-  return children
+  return (
+    <CalendarLoadRangeContext.Provider value={loadCalendarRange}>
+      {children}
+    </CalendarLoadRangeContext.Provider>
+  )
 }
 
 export function useCalendar(): CalendarContextType {
   const store = useCalendarStore()
+  const loadCalendarRange = useContext(CalendarLoadRangeContext)
+
   return {
     calendars: store.calendars,
     setCalendars: store.setCalendars,
@@ -302,33 +318,7 @@ export function useCalendar(): CalendarContextType {
     setEvents: store.setEvents,
     isLoadingCalendarData: store.isLoadingCalendarData,
     loadedRanges: store.loadedRanges,
-    loadCalendarRange: async (start, end, replace) => {
-      useCalendarStore.getState().setLoading(true)
-      try {
-        const params = new URLSearchParams({
-          start: start.toISOString(),
-          end: end.toISOString(),
-        })
-        const response = await fetch(`/api/blob?${params}`, {
-          cache: 'no-store',
-        })
-        if (!response.ok) return
-        const data = await response.json()
-        useCalendarStore
-          .getState()
-          .setCalendars(Array.isArray(data.calendars) ? data.calendars : [])
-        useCalendarStore
-          .getState()
-          .mergeEvents(
-            Array.isArray(data.events) ? data.events.map(toEvent) : [],
-            { start, end },
-            replace,
-          )
-        useCalendarStore.getState().addLoadedRange({ start, end })
-      } finally {
-        useCalendarStore.getState().setLoading(false)
-      }
-    },
+    loadCalendarRange: loadCalendarRange ?? (async () => {}),
     addCategory: store.addCategory,
     removeCategory: store.removeCategory,
     updateCategory: store.updateCategory,

--- a/components/ui/calendar.tsx
+++ b/components/ui/calendar.tsx
@@ -87,7 +87,6 @@ function Calendar({
             : "flex items-center gap-1 rounded-(--cell-radius) text-sm [&>svg]:size-3.5 [&>svg]:text-muted-foreground",
           defaultClassNames.caption_label
         ),
-        table: "w-full border-collapse",
         weekdays: cn("flex", defaultClassNames.weekdays),
         weekday: cn(
           "flex-1 rounded-(--cell-radius) text-[0.8rem] font-normal text-muted-foreground select-none",

--- a/components/ui/skeleton.tsx
+++ b/components/ui/skeleton.tsx
@@ -1,0 +1,13 @@
+import { cn } from '@/lib/utils'
+
+function Skeleton({ className, ...props }: React.ComponentProps<'div'>) {
+  return (
+    <div
+      data-slot="skeleton"
+      className={cn('animate-pulse rounded-md bg-muted', className)}
+      {...props}
+    />
+  )
+}
+
+export { Skeleton }

--- a/lib/drizzle/schema.ts
+++ b/lib/drizzle/schema.ts
@@ -1,29 +1,142 @@
-import { pgTable, serial, text, timestamp, boolean, integer, index, uniqueIndex } from 'drizzle-orm/pg-core';
-import { relations } from 'drizzle-orm';
+import {
+  pgTable,
+  serial,
+  text,
+  timestamp,
+  boolean,
+  integer,
+  index,
+  uniqueIndex,
+  jsonb,
+} from 'drizzle-orm/pg-core'
+import { relations } from 'drizzle-orm'
 
 // --- Share (@@map("shares")) ---
-export const shares = pgTable('shares', {
-  id: serial('id').primaryKey(),
-  userId: text('user_id').notNull(),
-  shareId: text('share_id').unique().notNull(),
-  encryptedData: text('encrypted_data').notNull(),
-  iv: text('iv').notNull(),
-  authTag: text('auth_tag').notNull(),
-  timestamp: timestamp('timestamp', { precision: 3, withTimezone: true }).notNull(),
-  isProtected: boolean('is_protected').default(false).notNull(),
-  isBurn: boolean('is_burn').default(false).notNull(),
-  encVersion: integer('enc_version'),
-}, (table) => ({
-  userIdIdx: index('idx_shares_user_id').on(table.userId),
-}));
+export const shares = pgTable(
+  'shares',
+  {
+    id: serial('id').primaryKey(),
+    userId: text('user_id').notNull(),
+    shareId: text('share_id').unique().notNull(),
+    eventId: text('event_id').notNull(),
+    encryptedData: text('encrypted_data').notNull(),
+    iv: text('iv').notNull(),
+    authTag: text('auth_tag').notNull(),
+    timestamp: timestamp('timestamp', {
+      precision: 3,
+      withTimezone: true,
+    }).notNull(),
+    isProtected: boolean('is_protected').default(false).notNull(),
+    isBurn: boolean('is_burn').default(false).notNull(),
+    encVersion: integer('enc_version'),
+  },
+  (table) => ({
+    userIdIdx: index('idx_shares_user_id').on(table.userId),
+    eventIdIdx: index('idx_shares_event_id').on(table.eventId),
+  }),
+)
 
 // --- CalendarBackup (@@map("calendar_backups")) ---
-export const calendarBackups = pgTable('calendar_backups', {
+export const calendarBackups = pgTable(
+  'calendar_backups',
+  {
+    id: text('id').primaryKey(),
+    userId: text('user_id').notNull(),
+    encryptedData: text('encrypted_data').notNull(),
+    iv: text('iv').notNull(),
+    authTag: text('auth_tag').notNull(),
+    startDate: timestamp('start_date', {
+      precision: 3,
+      withTimezone: true,
+    }).notNull(),
+    endDate: timestamp('end_date', {
+      precision: 3,
+      withTimezone: true,
+    }).notNull(),
+    calendarId: text('calendar_id'),
+    timestamp: timestamp('timestamp', {
+      precision: 3,
+      withTimezone: true,
+    }).notNull(),
+  },
+  (table) => ({
+    userIdIdx: index('idx_calendar_backups_user_id').on(table.userId),
+    rangeIdx: index('idx_calendar_backups_user_range').on(
+      table.userId,
+      table.startDate,
+      table.endDate,
+    ),
+    categoryIdx: index('idx_calendar_backups_user_category').on(
+      table.userId,
+      table.calendarId,
+    ),
+  }),
+)
+
+export const calendarCategories = pgTable(
+  'calendar_categories',
+  {
+    id: text('id').primaryKey(),
+    userId: text('user_id').notNull(),
+    encryptedData: text('encrypted_data').notNull(),
+    iv: text('iv').notNull(),
+    authTag: text('auth_tag').notNull(),
+    position: integer('position').default(0).notNull(),
+    timestamp: timestamp('timestamp', {
+      precision: 3,
+      withTimezone: true,
+    }).notNull(),
+  },
+  (table) => ({
+    userIdIdx: index('idx_calendar_categories_user_id').on(table.userId),
+  }),
+)
+
+export const userSettings = pgTable('user_settings', {
   userId: text('user_id').primaryKey(),
-  encryptedData: text('encrypted_data').notNull(),
-  iv: text('iv').notNull(),
-  timestamp: timestamp('timestamp', { precision: 3, withTimezone: true }).notNull(),
-});
+  settings: jsonb('settings').notNull(),
+  timestamp: timestamp('timestamp', {
+    precision: 3,
+    withTimezone: true,
+  }).notNull(),
+})
+
+export const calendarBookmarks = pgTable(
+  'calendar_bookmarks',
+  {
+    id: text('id').primaryKey(),
+    userId: text('user_id').notNull(),
+    eventId: text('event_id').notNull(),
+    encryptedData: text('encrypted_data').notNull(),
+    iv: text('iv').notNull(),
+    authTag: text('auth_tag').notNull(),
+    timestamp: timestamp('timestamp', {
+      precision: 3,
+      withTimezone: true,
+    }).notNull(),
+  },
+  (table) => ({
+    userIdIdx: index('idx_calendar_bookmarks_user_id').on(table.userId),
+  }),
+)
+
+export const calendarCountdowns = pgTable(
+  'calendar_countdowns',
+  {
+    id: text('id').primaryKey(),
+    userId: text('user_id').notNull(),
+    encryptedData: text('encrypted_data').notNull(),
+    iv: text('iv').notNull(),
+    authTag: text('auth_tag').notNull(),
+    timestamp: timestamp('timestamp', {
+      precision: 3,
+      withTimezone: true,
+    }).notNull(),
+  },
+  (table) => ({
+    userIdIdx: index('idx_calendar_countdowns_user_id').on(table.userId),
+  }),
+)
 
 // --- User (Table name: "User") ---
 export const user = pgTable('User', {
@@ -33,50 +146,91 @@ export const user = pgTable('User', {
   emailVerified: boolean('emailVerified').default(false).notNull(),
   image: text('image'),
   twoFactorEnabled: boolean('twoFactorEnabled'),
-  createdAt: timestamp('createdAt', { precision: 3, withTimezone: true }).notNull(),
-  updatedAt: timestamp('updatedAt', { precision: 3, withTimezone: true }).notNull(),
-});
+  createdAt: timestamp('createdAt', {
+    precision: 3,
+    withTimezone: true,
+  }).notNull(),
+  updatedAt: timestamp('updatedAt', {
+    precision: 3,
+    withTimezone: true,
+  }).notNull(),
+})
 
 // --- Session (Table name: "Session") ---
 export const session = pgTable('Session', {
   id: text('id').primaryKey(),
-  expiresAt: timestamp('expiresAt', { precision: 3, withTimezone: true }).notNull(),
+  expiresAt: timestamp('expiresAt', {
+    precision: 3,
+    withTimezone: true,
+  }).notNull(),
   token: text('token').unique().notNull(),
-  createdAt: timestamp('createdAt', { precision: 3, withTimezone: true }).notNull(),
-  updatedAt: timestamp('updatedAt', { precision: 3, withTimezone: true }).notNull(),
+  createdAt: timestamp('createdAt', {
+    precision: 3,
+    withTimezone: true,
+  }).notNull(),
+  updatedAt: timestamp('updatedAt', {
+    precision: 3,
+    withTimezone: true,
+  }).notNull(),
   ipAddress: text('ipAddress'),
   userAgent: text('userAgent'),
-  userId: text('userId').notNull().references(() => user.id, { onDelete: 'cascade' }),
-});
+  userId: text('userId')
+    .notNull()
+    .references(() => user.id, { onDelete: 'cascade' }),
+})
 
 // --- Account (Table name: "Account") ---
-export const account = pgTable('Account', {
-  id: text('id').primaryKey(),
-  accountId: text('accountId').notNull(),
-  providerId: text('providerId').notNull(),
-  userId: text('userId').notNull().references(() => user.id, { onDelete: 'cascade' }),
-  accessToken: text('accessToken'),
-  refreshToken: text('refreshToken'),
-  idToken: text('idToken'),
-  accessTokenExpiresAt: timestamp('accessTokenExpiresAt', { precision: 3, withTimezone: true }),
-  refreshTokenExpiresAt: timestamp('refreshTokenExpiresAt', { precision: 3, withTimezone: true }),
-  scope: text('scope'),
-  password: text('password'),
-  createdAt: timestamp('createdAt', { precision: 3, withTimezone: true }).notNull(),
-  updatedAt: timestamp('updatedAt', { precision: 3, withTimezone: true }).notNull(),
-}, (table) => ({
-  accountUnique: uniqueIndex('Account_providerId_accountId_key').on(table.providerId, table.accountId),
-}));
+export const account = pgTable(
+  'Account',
+  {
+    id: text('id').primaryKey(),
+    accountId: text('accountId').notNull(),
+    providerId: text('providerId').notNull(),
+    userId: text('userId')
+      .notNull()
+      .references(() => user.id, { onDelete: 'cascade' }),
+    accessToken: text('accessToken'),
+    refreshToken: text('refreshToken'),
+    idToken: text('idToken'),
+    accessTokenExpiresAt: timestamp('accessTokenExpiresAt', {
+      precision: 3,
+      withTimezone: true,
+    }),
+    refreshTokenExpiresAt: timestamp('refreshTokenExpiresAt', {
+      precision: 3,
+      withTimezone: true,
+    }),
+    scope: text('scope'),
+    password: text('password'),
+    createdAt: timestamp('createdAt', {
+      precision: 3,
+      withTimezone: true,
+    }).notNull(),
+    updatedAt: timestamp('updatedAt', {
+      precision: 3,
+      withTimezone: true,
+    }).notNull(),
+  },
+  (table) => ({
+    accountUnique: uniqueIndex('Account_providerId_accountId_key').on(
+      table.providerId,
+      table.accountId,
+    ),
+  }),
+)
 
 // --- Verification (Table name: "Verification") ---
 export const verification = pgTable('Verification', {
   id: text('id').primaryKey(),
   identifier: text('identifier').notNull(),
   value: text('value').notNull(),
-  expiresAt: timestamp('expiresAt', { precision: 3, withTimezone: true }).notNull(),
+  expiresAt: timestamp('expiresAt', {
+    precision: 3,
+    withTimezone: true,
+  }).notNull(),
   createdAt: timestamp('createdAt', { precision: 3, withTimezone: true }),
   updatedAt: timestamp('updatedAt', { precision: 3, withTimezone: true }),
-});
+})
 
 // --- TwoFactor (@@map("twoFactor")) ---
 export const twoFactor = pgTable('twoFactor', {
@@ -84,24 +238,27 @@ export const twoFactor = pgTable('twoFactor', {
   secret: text('secret').notNull(),
   backupCodes: text('backupCodes').notNull(),
   verified: boolean('verified').default(false).notNull(),
-  userId: text('userId').unique().notNull().references(() => user.id, { onDelete: 'cascade' }),
-});
+  userId: text('userId')
+    .unique()
+    .notNull()
+    .references(() => user.id, { onDelete: 'cascade' }),
+})
 
 // --- Relations ---
 export const userRelations = relations(user, ({ many, one }) => ({
   sessions: many(session),
   accounts: many(account),
   twoFactor: one(twoFactor),
-}));
+}))
 
 export const sessionRelations = relations(session, ({ one }) => ({
   user: one(user, { fields: [session.userId], references: [user.id] }),
-}));
+}))
 
 export const accountRelations = relations(account, ({ one }) => ({
   user: one(user, { fields: [account.userId], references: [user.id] }),
-}));
+}))
 
 export const twoFactorRelations = relations(twoFactor, ({ one }) => ({
   user: one(user, { fields: [twoFactor.userId], references: [user.id] }),
-}));
+}))

--- a/lib/server-crypto.ts
+++ b/lib/server-crypto.ts
@@ -1,0 +1,76 @@
+import crypto from 'crypto'
+
+const ALGORITHM = 'aes-256-gcm'
+const IV_LENGTH = 12
+
+function getBackupSalt() {
+  const salt = process.env.BACKUP_SALT
+  if (!salt) {
+    if (process.env.NODE_ENV === 'production') {
+      throw new Error('BACKUP_SALT is required in production')
+    }
+    return 'development-backup-salt-change-me'
+  }
+  return salt
+}
+
+function key(scope: string) {
+  return crypto
+    .createHash('sha256')
+    .update(getBackupSalt(), 'utf8')
+    .update(':')
+    .update(scope, 'utf8')
+    .digest()
+}
+
+export function encryptServerJson(value: unknown, scope = 'calendar') {
+  const iv = crypto.randomBytes(IV_LENGTH)
+  const cipher = crypto.createCipheriv(ALGORITHM, key(scope), iv)
+  const plaintext = JSON.stringify(value)
+  const encrypted = Buffer.concat([
+    cipher.update(plaintext, 'utf8'),
+    cipher.final(),
+  ])
+  return {
+    encryptedData: encrypted.toString('base64'),
+    iv: iv.toString('base64'),
+    authTag: cipher.getAuthTag().toString('base64'),
+  }
+}
+
+export function decryptServerJson<T = unknown>(
+  encryptedData: string,
+  iv: string,
+  authTag: string,
+  scope = 'calendar',
+): T {
+  const decipher = crypto.createDecipheriv(
+    ALGORITHM,
+    key(scope),
+    Buffer.from(iv, 'base64'),
+  )
+  decipher.setAuthTag(Buffer.from(authTag, 'base64'))
+  const decrypted = Buffer.concat([
+    decipher.update(Buffer.from(encryptedData, 'base64')),
+    decipher.final(),
+  ]).toString('utf8')
+  return JSON.parse(decrypted) as T
+}
+
+export function encryptSharePassword(password: string, shareId: string) {
+  return encryptServerJson({ password }, `share-password:${shareId}`)
+}
+
+export function decryptSharePassword(
+  encryptedData: string,
+  iv: string,
+  authTag: string,
+  shareId: string,
+) {
+  return decryptServerJson<{ password: string }>(
+    encryptedData,
+    iv,
+    authTag,
+    `share-password:${shareId}`,
+  ).password
+}


### PR DESCRIPTION
### Motivation
- Remove fragile end-to-end, client-managed backup/encryption and centralize encryption on the server using a stable server secret (`BACKUP_SALT`).
- Normalize calendar backup storage so each event is a separate row for incremental loading and safer per-event operations.
- Make sharing simpler by turning share records into links to server-stored events while supporting optional password-protected shares.
- Simplify UI flow by removing client key management and showing skeletons while server-encrypted data loads.

### Description
- Added server crypto utilities in `lib/server-crypto.ts` implementing AES-256-GCM JSON encryption/decryption keyed by `process.env.BACKUP_SALT` and helper functions `encryptServerJson`, `decryptServerJson`, `encryptSharePassword`, and `decryptSharePassword`.
- Reworked DB schema in `lib/drizzle/schema.ts` to store one encrypted row per event in `calendar_backups`, added `calendar_categories`, `user_settings` (JSONB), `calendar_bookmarks`, and `calendar_countdowns`, and updated `shares` to reference `eventId`.
- Replaced old blob API with a range-aware server API in `app/api/blob/route.ts` that: decrypts/encrypts per-row JSON server-side, supports GET range queries (load by start/end), POST upserts for individual events/calendars/settings/bookmarks/countdowns, and DELETE for event/category/global deletion.
- Reworked share endpoints (`app/api/share/route.ts` and `app/api/share/list/route.ts`) to store a link to an event, to use server-side encryption for optional share passwords, and to decrypt the linked event when reading a share.
- Client changes: updated calendar provider (`components/providers/calendar-context.tsx`) to hydrate signed-in users from server-encrypted range data, support `loadCalendarRange` and merge ranges; updated `components/app/calendar.tsx` and `components/app/sidebar/sidebar.tsx` to request month +/-1 or full-year ranges on year view and display skeletons while server data is loading; added `components/ui/skeleton.tsx` and replaced waiting/loading screens accordingly.
- Simplified profile/backup UI (`components/app/profile/user-profile-button.tsx`) to use server backup flows (POST/DELETE `/api/blob`) and removed client-side key management flows.

### Testing
- Ran static type checks via `pnpm run type-check` and `tsc --noEmit`, which completed successfully.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a22a4ad037c8332a911b80a991a56bd)

## Summary by Sourcery

重构日历备份和共享机制，使其使用服务端 AES 加密的按事件存储和基于区间的 API，同时简化个人资料/备份界面并新增加载骨架屏。

New Features:
- 引入服务端 AES-256-GCM 工具以及按事件加密的日历存储，支持基于区间的加载。
- 将用户设置、日历书签和倒计时持久化存储到数据库中，由服务器端统一管理加密。
- 启用由服务器管理的事件共享功能，将共享记录与已存储事件关联，并支持可选的密码保护和共享列表展示。

Enhancements:
- 简化日历个人资料和备份流程，改为依赖服务器备份，而非客户端密钥管理和本地 blob 加密。
- 扩展日历提供方和 UI，以支持增量的服务器区间加载、骨架加载状态以及自动设置同步。
- 规范化并扩展日历数据的数据库结构，包括日历类别，以及以用户为键的按事件备份。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Refactor calendar backup and sharing to use server-side AES-encrypted, per-event storage with range-based APIs, while simplifying profile/backup UI and adding loading skeletons.

New Features:
- Introduce server-side AES-256-GCM utilities and per-event encrypted calendar storage with range-based loading.
- Add user settings, calendar bookmarks, and countdowns persistence in the database with server-managed encryption.
- Enable server-managed event sharing that links shares to stored events with optional password protection and share listing.

Enhancements:
- Simplify calendar profile and backup flows to rely on server backups instead of client-side key management and local blob encryption.
- Extend the calendar provider and UI to support incremental server-loaded ranges, skeleton loading states, and automatic settings sync.
- Normalize and expand database schema for calendar data, including calendar categories and per-event backups keyed by user.

</details>