### PR TITLE
fix: rebuild calendar data architecture

### DIFF
--- a/app/api/blob/route.ts
+++ b/app/api/blob/route.ts
@@ -2,8 +2,16 @@ import { NextRequest, NextResponse } from 'next/server'
 import { withEvlog, useLogger, getAuditActor } from '@/lib/evlog'
 import { getServerSession } from '@/lib/auth/server'
 import { db } from '@/lib/drizzle/client'
-import { calendarBackups } from '@/lib/drizzle/schema'
-import { eq } from 'drizzle-orm'
+import {
+  calendarBackups,
+  calendarBookmarks,
+  calendarCategories,
+  calendarCountdowns,
+  userSettings,
+} from '@/lib/drizzle/schema'
+import { and, eq, gte, lte, or } from 'drizzle-orm'
+import { decryptServerJson, encryptServerJson } from '@/lib/server-crypto'
+import { randomUUID } from 'crypto'
 
 export const runtime = 'nodejs'
 export const dynamic = 'force-dynamic'
@@ -14,6 +22,31 @@ const NO_STORE_HEADERS = {
   Expires: '0',
 }
 
+type CalendarEventPayload = {
+  id?: string
+  title?: string
+  startDate?: string | Date
+  endDate?: string | Date
+  isAllDay?: boolean
+  recurrence?: string
+  location?: string
+  participants?: string[]
+  notification?: number
+  description?: string
+  color?: string
+  calendarId?: string
+  [key: string]: unknown
+}
+
+type CalendarCategoryPayload = {
+  id?: string
+  name?: string
+  color?: string
+  keywords?: string[]
+  position?: number
+  [key: string]: unknown
+}
+
 function jsonNoStore(body: unknown, init?: ResponseInit) {
   return NextResponse.json(body, {
     ...init,
@@ -21,62 +54,127 @@ function jsonNoStore(body: unknown, init?: ResponseInit) {
   })
 }
 
-export const POST = withEvlog(async function POST(req: NextRequest) {
-  try {
-    const log = useLogger()
-    const [session, body] = await Promise.all([getServerSession(), req.json()])
-    const user = session?.user
-    const userId = user?.id
+function id(prefix: string) {
+  return `${prefix}_${randomUUID()}`
+}
 
-    if (!userId) {
-      log.audit?.({
-        action: 'calendar_backup.upsert',
-        actor: getAuditActor(log),
-        target: { type: 'calendar_backup', id: 'unknown' },
-        outcome: 'denied',
-        reason: 'Authentication required',
-      })
-      return NextResponse.json({ error: 'Unauthorized' }, { status: 401 })
-    }
+function asDate(value: unknown, fallback = new Date()) {
+  const date = value ? new Date(value as string | Date) : fallback
+  if (Number.isNaN(date.getTime())) return fallback
+  return date
+}
 
-    const encrypted_data = body?.ciphertext
-    const iv = body?.iv
+function eventContext(userId: string, eventId: string) {
+  return `calendar-event:${userId}:${eventId}`
+}
 
-    if (typeof encrypted_data !== 'string' || typeof iv !== 'string')
-      return NextResponse.json({ error: 'Invalid payload' }, { status: 400 })
+function categoryContext(userId: string, categoryId: string) {
+  return `calendar-category:${userId}:${categoryId}`
+}
 
-    await db
-      .insert(calendarBackups)
-      .values({
-        userId,
-        encryptedData: encrypted_data,
-        iv,
-        timestamp: new Date(),
-      })
-      .onConflictDoUpdate({
-        target: calendarBackups.userId,
-        set: { encryptedData: encrypted_data, iv, timestamp: new Date() },
-      })
+function bookmarkContext(userId: string, bookmarkId: string) {
+  return `calendar-bookmark:${userId}:${bookmarkId}`
+}
 
-    log.audit?.({
-      action: 'calendar_backup.upsert',
-      actor: getAuditActor(log, {
-        type: 'user',
-        id: userId,
-        ...(user?.email ? { email: user.email } : {}),
-      }),
-      target: { type: 'calendar_backup', id: userId },
-      outcome: 'success',
-      reason: 'User saved encrypted calendar backup',
-    })
-    return NextResponse.json({ success: true, backend: 'postgres' })
-  } catch (e: unknown) {
-    const message = e instanceof Error ? e.message : 'Internal error'
-    return NextResponse.json({ error: message }, { status: 500 })
+function countdownContext(userId: string, countdownId: string) {
+  return `calendar-countdown:${userId}:${countdownId}`
+}
+
+function serializeEvent(row: typeof calendarBackups.$inferSelect) {
+  const extra = decryptServerJson<Record<string, unknown>>(
+    row.encryptedData,
+    row.iv,
+    row.authTag,
+    eventContext(row.userId, row.id),
+    {},
+  )
+  return {
+    ...extra,
+    id: row.id,
+    title: row.title,
+    startDate: row.startDate.toISOString(),
+    endDate: row.endDate.toISOString(),
+    isAllDay: row.isAllDay,
+    recurrence: row.recurrence,
+    color: row.color,
+    calendarId: row.calendarId ?? '',
   }
-})
+}
 
-export const GET = withEvlog(async function GET(_req: NextRequest) {
+function serializeCategory(row: typeof calendarCategories.$inferSelect) {
+  const extra = decryptServerJson<Record<string, unknown>>(
+    row.encryptedData,
+    row.iv,
+    row.authTag,
+    categoryContext(row.userId, row.id),
+    {},
+  )
+  return {
+    ...extra,
+    id: row.id,
+    name: row.name,
+    color: row.color,
+    keywords: row.keywords,
+    position: row.position,
+  }
+}
+
+function eventValues(userId: string, input: CalendarEventPayload) {
+  const eventId = input.id || id('evt')
+  const startDate = asDate(input.startDate)
+  const endDate = asDate(input.endDate, startDate)
+  const title = typeof input.title === 'string' ? input.title : 'Untitled event'
+  const calendarId =
+    typeof input.calendarId === 'string' && input.calendarId
+      ? input.calendarId
+      : null
+  const extra = {
+    description: input.description ?? '',
+    location: input.location ?? '',
+    participants: Array.isArray(input.participants) ? input.participants : [],
+    notification:
+      typeof input.notification === 'number' ? input.notification : 0,
+    extensions: Object.fromEntries(
+      Object.entries(input).filter(
+        ([key]) =>
+          ![
+            'id',
+            'title',
+            'startDate',
+            'endDate',
+            'isAllDay',
+            'recurrence',
+            'calendarId',
+            'color',
+          ].includes(key),
+      ),
+    ),
+  }
+  const encrypted = encryptServerJson(extra, eventContext(userId, eventId))
+  const now = new Date()
+  return {
+    id: eventId,
+    userId,
+    title,
+    startDate,
+    endDate,
+    isAllDay: Boolean(input.isAllDay),
+    recurrence:
+      typeof input.recurrence === 'string' ? input.recurrence : 'none',
+    calendarId,
+    color:
+      typeof input.color === 'string' && input.color ? input.color : '#3b82f6',
+    searchableText: [title, input.description, input.location]
+      .filter(Boolean)
+      .join(' ')
+      .toLowerCase(),
+    ...encrypted,
+    createdAt: now,
+    updatedAt: now,
+  }
+}
+
+export const GET = withEvlog(async function GET(req: NextRequest) {
   try {
     const log = useLogger()
     const session = await getServerSession()
@@ -84,56 +182,93 @@ export const GET = withEvlog(async function GET(_req: NextRequest) {
     const userId = user?.id
 
     if (!userId) {
-      log.audit?.({
-        action: 'calendar_backup.export',
-        actor: getAuditActor(log),
-        target: { type: 'calendar_backup', id: 'unknown' },
-        outcome: 'denied',
-        reason: 'Authentication required',
-      })
       return jsonNoStore({ error: 'Unauthorized' }, { status: 401 })
     }
 
-    const [result] = await db
-      .select({
-        encryptedData: calendarBackups.encryptedData,
-        iv: calendarBackups.iv,
-        timestamp: calendarBackups.timestamp,
-      })
-      .from(calendarBackups)
-      .where(eq(calendarBackups.userId, userId))
+    const start = req.nextUrl.searchParams.get('start')
+    const end = req.nextUrl.searchParams.get('end')
+    const where =
+      start && end
+        ? and(
+            eq(calendarBackups.userId, userId),
+            or(
+              and(
+                gte(calendarBackups.startDate, asDate(start)),
+                lte(calendarBackups.startDate, asDate(end)),
+              ),
+              and(
+                gte(calendarBackups.endDate, asDate(start)),
+                lte(calendarBackups.endDate, asDate(end)),
+              ),
+            ),
+          )
+        : eq(calendarBackups.userId, userId)
 
-    if (!result) {
-      log.audit?.({
-        action: 'calendar_backup.export',
-        actor: getAuditActor(log, {
-          type: 'user',
-          id: userId,
-          ...(user?.email ? { email: user.email } : {}),
-        }),
-        target: { type: 'calendar_backup', id: userId },
-        outcome: 'failure',
-        reason: 'No encrypted calendar backup found',
-      })
-      return jsonNoStore({ error: 'Not found' }, { status: 404 })
-    }
+    const [events, categories, settings, bookmarks, countdowns] =
+      await Promise.all([
+        db.select().from(calendarBackups).where(where),
+        db
+          .select()
+          .from(calendarCategories)
+          .where(eq(calendarCategories.userId, userId)),
+        db.select().from(userSettings).where(eq(userSettings.userId, userId)),
+        db
+          .select()
+          .from(calendarBookmarks)
+          .where(eq(calendarBookmarks.userId, userId)),
+        db
+          .select()
+          .from(calendarCountdowns)
+          .where(eq(calendarCountdowns.userId, userId)),
+      ])
 
     log.audit?.({
-      action: 'calendar_backup.export',
+      action: 'calendar_data.range_export',
       actor: getAuditActor(log, {
         type: 'user',
         id: userId,
         ...(user?.email ? { email: user.email } : {}),
       }),
-      target: { type: 'calendar_backup', id: userId },
+      target: { type: 'calendar_data', id: userId },
       outcome: 'success',
-      reason: 'User exported encrypted calendar backup',
+      reason:
+        start && end
+          ? 'User loaded calendar data by range'
+          : 'User exported calendar data',
     })
 
     return jsonNoStore({
-      ciphertext: result.encryptedData,
-      iv: result.iv,
-      timestamp: result.timestamp,
+      events: events.map(serializeEvent),
+      categories: categories.map(serializeCategory),
+      settings: settings[0]?.settings ?? {},
+      bookmarks: bookmarks.map((row) => ({
+        ...decryptServerJson(
+          row.encryptedData,
+          row.iv,
+          row.authTag,
+          bookmarkContext(row.userId, row.id),
+          {},
+        ),
+        id: row.id,
+        eventId: row.eventId,
+        title: row.title,
+        startDate: row.startDate.toISOString(),
+        endDate: row.endDate.toISOString(),
+        color: row.color,
+      })),
+      countdowns: countdowns.map((row) => ({
+        ...decryptServerJson(
+          row.encryptedData,
+          row.iv,
+          row.authTag,
+          countdownContext(row.userId, row.id),
+          {},
+        ),
+        id: row.id,
+        title: row.title,
+        dueDate: row.dueDate.toISOString(),
+        eventId: row.eventId ?? '',
+      })),
       backend: 'postgres',
     })
   } catch (e: unknown) {
@@ -142,37 +277,198 @@ export const GET = withEvlog(async function GET(_req: NextRequest) {
   }
 })
 
-export const DELETE = withEvlog(async function DELETE(_req: NextRequest) {
+export const POST = withEvlog(async function POST(req: NextRequest) {
   try {
     const log = useLogger()
-    const session = await getServerSession()
+    const [session, body] = await Promise.all([getServerSession(), req.json()])
     const user = session?.user
     const userId = user?.id
 
-    if (!userId) {
-      log.audit?.({
-        action: 'calendar_backup.delete',
-        actor: getAuditActor(log),
-        target: { type: 'calendar_backup', id: 'unknown' },
-        outcome: 'denied',
-        reason: 'Authentication required',
-      })
+    if (!userId)
       return NextResponse.json({ error: 'Unauthorized' }, { status: 401 })
-    }
 
-    await db.delete(calendarBackups).where(eq(calendarBackups.userId, userId))
+    const events = Array.isArray(body?.events)
+      ? body.events
+      : body?.event
+        ? [body.event]
+        : body?.ciphertext
+          ? []
+          : []
+    const categories = Array.isArray(body?.categories) ? body.categories : []
+    const now = new Date()
+
+    await db.transaction(async (tx) => {
+      for (const event of events as CalendarEventPayload[]) {
+        const values = eventValues(userId, event)
+        const [existing] = await tx
+          .select({ userId: calendarBackups.userId })
+          .from(calendarBackups)
+          .where(eq(calendarBackups.id, values.id))
+        if (existing && existing.userId !== userId)
+          throw new Error('Event ID already exists')
+        await tx
+          .insert(calendarBackups)
+          .values(values)
+          .onConflictDoUpdate({
+            target: calendarBackups.id,
+            set: {
+              userId: values.userId,
+              title: values.title,
+              startDate: values.startDate,
+              endDate: values.endDate,
+              isAllDay: values.isAllDay,
+              recurrence: values.recurrence,
+              calendarId: values.calendarId,
+              color: values.color,
+              searchableText: values.searchableText,
+              encryptedData: values.encryptedData,
+              iv: values.iv,
+              authTag: values.authTag,
+              updatedAt: now,
+            },
+          })
+      }
+
+      for (const category of categories as CalendarCategoryPayload[]) {
+        const categoryId = category.id || id('cat')
+        const encrypted = encryptServerJson(
+          { extensions: category },
+          categoryContext(userId, categoryId),
+        )
+        const values = {
+          id: categoryId,
+          userId,
+          name: typeof category.name === 'string' ? category.name : 'Untitled',
+          color:
+            typeof category.color === 'string' ? category.color : '#3b82f6',
+          keywords: Array.isArray(category.keywords) ? category.keywords : [],
+          position:
+            typeof category.position === 'number' ? category.position : 0,
+          ...encrypted,
+          createdAt: now,
+          updatedAt: now,
+        }
+        const [existing] = await tx
+          .select({ userId: calendarCategories.userId })
+          .from(calendarCategories)
+          .where(eq(calendarCategories.id, values.id))
+        if (existing && existing.userId !== userId)
+          throw new Error('Category ID already exists')
+        await tx
+          .insert(calendarCategories)
+          .values(values)
+          .onConflictDoUpdate({
+            target: calendarCategories.id,
+            set: {
+              userId: values.userId,
+              name: values.name,
+              color: values.color,
+              keywords: values.keywords,
+              position: values.position,
+              encryptedData: values.encryptedData,
+              iv: values.iv,
+              authTag: values.authTag,
+              updatedAt: now,
+            },
+          })
+      }
+
+      if (body?.settings && typeof body.settings === 'object') {
+        await tx
+          .insert(userSettings)
+          .values({
+            userId,
+            settings: body.settings,
+            createdAt: now,
+            updatedAt: now,
+          })
+          .onConflictDoUpdate({
+            target: userSettings.userId,
+            set: { settings: body.settings, updatedAt: now },
+          })
+      }
+    })
 
     log.audit?.({
-      action: 'calendar_backup.delete',
+      action: 'calendar_data.upsert',
       actor: getAuditActor(log, {
         type: 'user',
         id: userId,
         ...(user?.email ? { email: user.email } : {}),
       }),
-      target: { type: 'calendar_backup', id: userId },
+      target: { type: 'calendar_data', id: userId },
       outcome: 'success',
-      reason: 'User deleted encrypted calendar backup',
+      reason: 'User saved event-level calendar data',
     })
+    return NextResponse.json({ success: true, backend: 'postgres' })
+  } catch (e: unknown) {
+    const message = e instanceof Error ? e.message : 'Internal error'
+    return NextResponse.json({ error: message }, { status: 500 })
+  }
+})
+
+export const DELETE = withEvlog(async function DELETE(req: NextRequest) {
+  try {
+    const session = await getServerSession()
+    const userId = session?.user?.id
+    if (!userId)
+      return NextResponse.json({ error: 'Unauthorized' }, { status: 401 })
+
+    const body = await req.json().catch(() => ({}))
+    if (typeof body?.eventId === 'string') {
+      await db
+        .delete(calendarBackups)
+        .where(
+          and(
+            eq(calendarBackups.userId, userId),
+            eq(calendarBackups.id, body.eventId),
+          ),
+        )
+      await db
+        .delete(calendarBookmarks)
+        .where(
+          and(
+            eq(calendarBookmarks.userId, userId),
+            eq(calendarBookmarks.eventId, body.eventId),
+          ),
+        )
+    } else if (typeof body?.categoryId === 'string') {
+      await db.transaction(async (tx) => {
+        await tx
+          .delete(calendarCategories)
+          .where(
+            and(
+              eq(calendarCategories.userId, userId),
+              eq(calendarCategories.id, body.categoryId),
+            ),
+          )
+        await tx
+          .update(calendarBackups)
+          .set({ calendarId: null, updatedAt: new Date() })
+          .where(
+            and(
+              eq(calendarBackups.userId, userId),
+              eq(calendarBackups.calendarId, body.categoryId),
+            ),
+          )
+      })
+    } else {
+      await db.transaction(async (tx) => {
+        await tx
+          .delete(calendarBackups)
+          .where(eq(calendarBackups.userId, userId))
+        await tx
+          .delete(calendarCategories)
+          .where(eq(calendarCategories.userId, userId))
+        await tx
+          .delete(calendarBookmarks)
+          .where(eq(calendarBookmarks.userId, userId))
+        await tx
+          .delete(calendarCountdowns)
+          .where(eq(calendarCountdowns.userId, userId))
+        await tx.delete(userSettings).where(eq(userSettings.userId, userId))
+      })
+    }
 
     return NextResponse.json({ success: true, backend: 'postgres' })
   } catch (e: unknown) {

--- a/app/api/share/list/route.ts
+++ b/app/api/share/list/route.ts
@@ -1,35 +1,11 @@
 import { type NextRequest, NextResponse } from 'next/server'
 import { withEvlog, useLogger, getAuditActor } from '@/lib/evlog'
 import { getServerSession } from '@/lib/auth/server'
-import crypto from 'crypto'
 import { db } from '@/lib/drizzle/client'
-import { shares } from '@/lib/drizzle/schema'
-import { eq, desc } from 'drizzle-orm'
+import { calendarBackups, shares } from '@/lib/drizzle/schema'
+import { desc, eq } from 'drizzle-orm'
 
 export const runtime = 'nodejs'
-
-const ALGORITHM = 'aes-256-gcm'
-
-function keyV2Unprotected(shareId: string) {
-  return crypto.createHash('sha256').update(shareId, 'utf8').digest()
-}
-
-function decryptWithKey(
-  encryptedData: string,
-  iv: string,
-  authTag: string,
-  key: Buffer,
-) {
-  const decipher = crypto.createDecipheriv(
-    ALGORITHM,
-    key,
-    Buffer.from(iv, 'hex'),
-  )
-  decipher.setAuthTag(Buffer.from(authTag, 'hex'))
-  let decrypted = decipher.update(encryptedData, 'hex', 'utf8')
-  decrypted += decipher.final('utf8')
-  return decrypted
-}
 
 export const GET = withEvlog(async function GET(_req: NextRequest) {
   const log = useLogger()
@@ -47,51 +23,36 @@ export const GET = withEvlog(async function GET(_req: NextRequest) {
   }
 
   const result = await db
-    .select()
+    .select({
+      shareId: shares.shareId,
+      eventId: shares.eventId,
+      isProtected: shares.isProtected,
+      isBurn: shares.isBurn,
+      updatedAt: shares.updatedAt,
+      title: calendarBackups.title,
+    })
     .from(shares)
+    .leftJoin(calendarBackups, eq(shares.eventId, calendarBackups.id))
     .where(eq(shares.userId, user.id))
-    .orderBy(desc(shares.timestamp))
+    .orderBy(desc(shares.updatedAt))
 
-  const shareList = result.map((row) => {
-    let eventId = ''
-    let eventTitle = ''
-    if (!row.isProtected) {
-      try {
-        const decrypted = decryptWithKey(
-          row.encryptedData,
-          row.iv,
-          row.authTag,
-          keyV2Unprotected(row.shareId),
-        )
-        const dataObj = JSON.parse(decrypted)
-        eventId = dataObj.id ?? ''
-        eventTitle = dataObj.title ?? ''
-      } catch {}
-    } else {
-      eventId = '受保护'
-      eventTitle = '受保护'
-    }
-    return {
-      id: row.shareId,
-      eventId,
-      eventTitle,
-      sharedBy: user.id,
-      shareDate: row.timestamp.toISOString(),
-      shareLink: `/share/${row.shareId}`,
-      isProtected: row.isProtected,
-    }
-  })
+  const shareList = result.map((row) => ({
+    id: row.shareId,
+    eventId: row.eventId ?? '',
+    eventTitle: row.title ?? '',
+    sharedBy: user.id,
+    shareDate: row.updatedAt.toISOString(),
+    shareLink: `/share/${row.shareId}`,
+    isProtected: row.isProtected,
+    burnAfterRead: row.isBurn,
+  }))
 
   log.audit?.({
     action: 'share.list',
-    actor: getAuditActor(log, {
-      type: 'user',
-      id: user.id,
-      email: user.email,
-    }),
+    actor: getAuditActor(log, { type: 'user', id: user.id, email: user.email }),
     target: { type: 'share_collection', id: user.id },
     outcome: 'success',
-    reason: 'User listed shares',
+    reason: 'User listed link-based shares',
   })
 
   return NextResponse.json({ shares: shareList })

--- a/app/api/share/route.ts
+++ b/app/api/share/route.ts
@@ -1,69 +1,57 @@
 import { type NextRequest, NextResponse } from 'next/server'
 import { withEvlog, useLogger, getAuditActor } from '@/lib/evlog'
 import { getServerSession } from '@/lib/auth/server'
-import crypto from 'crypto'
 import { db } from '@/lib/drizzle/client'
-import { shares } from '@/lib/drizzle/schema'
-import { eq, and } from 'drizzle-orm'
+import { calendarBackups, shares } from '@/lib/drizzle/schema'
+import { and, eq } from 'drizzle-orm'
+import { compare, hash } from 'bcryptjs'
+import { randomUUID } from 'crypto'
+import { decryptServerJson } from '@/lib/server-crypto'
 
 export const runtime = 'nodejs'
 
-const ALGORITHM = 'aes-256-gcm'
-
-function keyV2Unprotected(shareId: string) {
-  return crypto.createHash('sha256').update(shareId, 'utf8').digest()
+function eventContext(userId: string, eventId: string) {
+  return `calendar-event:${userId}:${eventId}`
 }
 
-function keyV3Password(password: string, shareId: string) {
-  return crypto.scryptSync(password, shareId, 32)
-}
-
-function encryptWithKey(
-  data: string,
-  key: Buffer,
-): { encryptedData: string; iv: string; authTag: string } {
-  const iv = crypto.randomBytes(16)
-  const cipher = crypto.createCipheriv(ALGORITHM, key, iv)
-  let encrypted = cipher.update(data, 'utf8', 'hex')
-  encrypted += cipher.final('hex')
-  const authTag = cipher.getAuthTag()
+function serializeEvent(row: typeof calendarBackups.$inferSelect) {
+  const extra = decryptServerJson<Record<string, unknown>>(
+    row.encryptedData,
+    row.iv,
+    row.authTag,
+    eventContext(row.userId, row.id),
+    {},
+  )
   return {
-    encryptedData: encrypted,
-    iv: iv.toString('hex'),
-    authTag: authTag.toString('hex'),
+    ...extra,
+    id: row.id,
+    title: row.title,
+    startDate: row.startDate.toISOString(),
+    endDate: row.endDate.toISOString(),
+    isAllDay: row.isAllDay,
+    recurrence: row.recurrence,
+    color: row.color,
+    calendarId: row.calendarId ?? '',
+    sharedBy: row.userId,
   }
-}
-
-function decryptWithKey(
-  encryptedData: string,
-  iv: string,
-  authTag: string,
-  key: Buffer,
-): string {
-  const ivBuffer = Buffer.from(iv, 'hex')
-  const authTagBuffer = Buffer.from(authTag, 'hex')
-  const decipher = crypto.createDecipheriv(ALGORITHM, key, ivBuffer)
-  decipher.setAuthTag(authTagBuffer)
-  let decrypted = decipher.update(encryptedData, 'hex', 'utf8')
-  decrypted += decipher.final('utf8')
-  return decrypted
 }
 
 export const POST = withEvlog(async function POST(request: NextRequest) {
   try {
     const log = useLogger()
     const body = await request.json()
-    const { id, data, password, burnAfterRead } = body as {
+    const { id, eventId, data, password, burnAfterRead } = body as {
       id?: string
-      data?: unknown
+      eventId?: string
+      data?: { id?: string }
       password?: string
       burnAfterRead?: boolean
     }
-    if (!id || data === undefined || data === null)
-      return NextResponse.json(
-        { error: 'Missing required fields' },
-        { status: 400 },
-      )
+    const shareId = id || randomUUID()
+    const targetEventId = eventId || data?.id
+    if (!targetEventId) {
+      return NextResponse.json({ error: 'Missing event ID' }, { status: 400 })
+    }
 
     const session = await getServerSession()
     const user = session?.user
@@ -71,46 +59,48 @@ export const POST = withEvlog(async function POST(request: NextRequest) {
       log.audit?.({
         action: 'share.create',
         actor: getAuditActor(log),
-        target: { type: 'share', id },
+        target: { type: 'share', id: shareId },
         outcome: 'denied',
         reason: 'Authentication required',
       })
       return NextResponse.json({ error: 'Unauthorized' }, { status: 401 })
     }
 
-    const hasPassword = typeof password === 'string' && password.length > 0
-    const burn = !!burnAfterRead
-    const dataString = typeof data === 'string' ? data : JSON.stringify(data)
-    const key = hasPassword
-      ? keyV3Password(password as string, id)
-      : keyV2Unprotected(id)
-    const { encryptedData, iv, authTag } = encryptWithKey(dataString, key)
-    const now = new Date()
+    const [event] = await db
+      .select({ id: calendarBackups.id })
+      .from(calendarBackups)
+      .where(
+        and(
+          eq(calendarBackups.id, targetEventId),
+          eq(calendarBackups.userId, user.id),
+        ),
+      )
+    if (!event)
+      return NextResponse.json({ error: 'Event not found' }, { status: 404 })
 
+    const hasPassword = typeof password === 'string' && password.length > 0
+    const now = new Date()
     await db
       .insert(shares)
       .values({
         userId: user.id,
-        shareId: id,
-        encryptedData,
-        iv,
-        authTag,
-        timestamp: now,
+        shareId,
+        eventId: targetEventId,
+        passwordHash: hasPassword ? await hash(password, 12) : null,
         isProtected: hasPassword,
-        isBurn: burn,
-        encVersion: hasPassword ? 3 : 2,
+        isBurn: Boolean(burnAfterRead),
+        createdAt: now,
+        updatedAt: now,
       })
       .onConflictDoUpdate({
         target: shares.shareId,
         set: {
           userId: user.id,
-          encryptedData,
-          iv,
-          authTag,
-          timestamp: now,
+          eventId: targetEventId,
+          passwordHash: hasPassword ? await hash(password, 12) : null,
           isProtected: hasPassword,
-          isBurn: burn,
-          encVersion: hasPassword ? 3 : 2,
+          isBurn: Boolean(burnAfterRead),
+          updatedAt: now,
         },
       })
 
@@ -121,19 +111,17 @@ export const POST = withEvlog(async function POST(request: NextRequest) {
         id: user.id,
         email: user.email,
       }),
-      target: { type: 'share', id },
+      target: { type: 'share', id: shareId },
       outcome: 'success',
-      reason: burn
-        ? 'User created burn-after-read share'
-        : 'User created share',
+      reason: 'User created link-based share',
     })
 
     return NextResponse.json({
       success: true,
-      id,
+      id: shareId,
       protected: hasPassword,
-      burnAfterRead: burn,
-      shareLink: `/share/${id}`,
+      burnAfterRead: Boolean(burnAfterRead),
+      shareLink: `/share/${shareId}`,
     })
   } catch (error) {
     return NextResponse.json(
@@ -159,31 +147,38 @@ export const GET = withEvlog(async function GET(request: NextRequest) {
         .select()
         .from(shares)
         .where(eq(shares.shareId, id))
-
-      if (!share) return { status: 404 as const }
-      if (share.isProtected && !password)
-        return { status: 401 as const, burnAfterRead: share.isBurn }
-
-      const key = share.isProtected
-        ? keyV3Password(password, id)
-        : keyV2Unprotected(id)
-      let decryptedData: string
-      try {
-        decryptedData = decryptWithKey(
-          share.encryptedData,
-          share.iv,
-          share.authTag,
-          key,
-        )
-      } catch {
-        return { status: 403 as const, protected: share.isProtected }
+      if (!share || !share.eventId) return { status: 404 as const }
+      if (share.expiresAt && share.expiresAt.getTime() < Date.now()) {
+        await tx.delete(shares).where(eq(shares.shareId, id))
+        return { status: 404 as const }
       }
+      if (share.isProtected) {
+        if (!password)
+          return { status: 401 as const, burnAfterRead: share.isBurn }
+        if (
+          !share.passwordHash ||
+          !(await compare(password, share.passwordHash))
+        ) {
+          return { status: 403 as const, protected: true }
+        }
+      }
+
+      const [event] = await tx
+        .select()
+        .from(calendarBackups)
+        .where(
+          and(
+            eq(calendarBackups.id, share.eventId),
+            eq(calendarBackups.userId, share.userId),
+          ),
+        )
+      if (!event) return { status: 404 as const }
       if (share.isBurn) await tx.delete(shares).where(eq(shares.shareId, id))
 
       return {
         status: 200 as const,
-        data: decryptedData,
-        timestamp: share.timestamp.toISOString(),
+        data: JSON.stringify(serializeEvent(event)),
+        timestamp: share.updatedAt.toISOString(),
         protected: share.isProtected,
         burnAfterRead: share.isBurn,
       }
@@ -200,13 +195,6 @@ export const GET = withEvlog(async function GET(request: NextRequest) {
       return NextResponse.json({ error: 'Share not found' }, { status: 404 })
     }
     if (result.status === 401) {
-      log.audit?.({
-        action: 'share.export',
-        actor: getAuditActor(log),
-        target: { type: 'share', id },
-        outcome: 'denied',
-        reason: 'Password required',
-      })
       return NextResponse.json(
         {
           error: 'Password required',
@@ -217,23 +205,7 @@ export const GET = withEvlog(async function GET(request: NextRequest) {
       )
     }
     if (result.status === 403) {
-      log.audit?.({
-        action: 'share.export',
-        actor: getAuditActor(log),
-        target: { type: 'share', id },
-        outcome: 'denied',
-        reason: result.protected
-          ? 'Invalid password'
-          : 'Failed to decrypt share data',
-      })
-      return NextResponse.json(
-        {
-          error: result.protected
-            ? 'Invalid password'
-            : 'Failed to decrypt share data.',
-        },
-        { status: 403 },
-      )
+      return NextResponse.json({ error: 'Invalid password' }, { status: 403 })
     }
 
     log.audit?.({
@@ -241,9 +213,7 @@ export const GET = withEvlog(async function GET(request: NextRequest) {
       actor: getAuditActor(log),
       target: { type: 'share', id },
       outcome: 'success',
-      reason: result.burnAfterRead
-        ? 'Burn-after-read share exported and deleted'
-        : 'Share exported',
+      reason: 'Share exported through server-side decryption',
     })
 
     return NextResponse.json({
@@ -290,11 +260,7 @@ export const DELETE = withEvlog(async function DELETE(request: NextRequest) {
 
   log.audit?.({
     action: 'share.delete',
-    actor: getAuditActor(log, {
-      type: 'user',
-      id: user.id,
-      email: user.email,
-    }),
+    actor: getAuditActor(log, { type: 'user', id: user.id, email: user.email }),
     target: { type: 'share', id },
     outcome: 'success',
     reason: 'User deleted share',

--- a/components/app/calendar.tsx
+++ b/components/app/calendar.tsx
@@ -41,7 +41,18 @@ import UserProfileButton, {
 import { useState, useEffect, useRef, useMemo } from 'react'
 import { useCalendar } from '@/components/providers/calendar-context'
 import RightSidebar from '@/components/app/sidebar/right-sidebar'
-import { addDays, addYears, subDays, subYears } from 'date-fns'
+import {
+  addDays,
+  addMonths,
+  addYears,
+  endOfMonth,
+  endOfYear,
+  startOfMonth,
+  startOfYear,
+  subDays,
+  subMonths,
+  subYears,
+} from 'date-fns'
 import EventPreview from '@/components/app/event/event-preview'
 import EventDialog from '@/components/app/event/event-dialog'
 import { ScrollArea } from '@/components/ui/scroll-area'
@@ -124,7 +135,8 @@ export default function Calendar({ className, ...props }: CalendarProps) {
   const [view, setView] = useState<ViewType>('week')
   const [eventDialogOpen, setEventDialogOpen] = useState(false)
   const [selectedEvent, setSelectedEvent] = useState<CalendarEvent | null>(null)
-  const { events, setEvents, calendars } = useCalendar()
+  const { events, setEvents, calendars, loadRange, saveEvents, deleteEvent } =
+    useCalendar()
   const [searchTerm, setSearchTerm] = useState('')
   const searchInputRef = useRef<HTMLDivElement>(null)
   const [isSearchFocused, setIsSearchFocused] = useState(false)
@@ -266,6 +278,18 @@ export default function Calendar({ className, ...props }: CalendarProps) {
     }
     return <CheckCircle2 className="h-4 w-4 text-emerald-500" />
   }, [backupEnabled, backupSyncStatus])
+
+  useEffect(() => {
+    if (view === 'analytics' || view === 'settings') return
+    const range =
+      view === 'year'
+        ? { start: startOfYear(date), end: endOfYear(date) }
+        : {
+            start: startOfMonth(subMonths(date, 1)),
+            end: endOfMonth(addMonths(date, 1)),
+          }
+    void loadRange(range)
+  }, [date, loadRange, view])
 
   useEffect(() => {
     const prefetch = () => {
@@ -462,6 +486,7 @@ export default function Calendar({ className, ...props }: CalendarProps) {
     }
 
     setEvents((prevEvents) => [...prevEvents, newEvent])
+    void saveEvents([newEvent])
     toast(t.eventCreated)
     setEventDialogOpen(false)
     setSelectedEvent(null)
@@ -474,6 +499,7 @@ export default function Calendar({ className, ...props }: CalendarProps) {
         event.id === updatedEvent.id ? updatedEvent : event,
       ),
     )
+    void saveEvents([updatedEvent])
     toast(t.eventUpdated)
     setEventDialogOpen(false)
     setSelectedEvent(null)
@@ -540,6 +566,7 @@ export default function Calendar({ className, ...props }: CalendarProps) {
     setEvents((prevEvents) =>
       prevEvents.filter((event) => event.id !== deletedEvent.id),
     )
+    void deleteEvent(deletedEvent.id)
     void readEncryptedLocalStorage<any[]>('bookmarked-events', []).then(
       (bookmarks) =>
         writeEncryptedLocalStorage(
@@ -579,6 +606,7 @@ export default function Calendar({ className, ...props }: CalendarProps) {
       id: event.id || Math.random().toString(36).substring(7),
     })) as CalendarEvent[]
     setEvents((prevEvents) => [...prevEvents, ...newEvents])
+    void saveEvents(newEvents)
   }
 
   const handleEventEdit = (event?: CalendarEvent) => {
@@ -598,6 +626,7 @@ export default function Calendar({ className, ...props }: CalendarProps) {
       id: Math.random().toString(36).substring(7),
     }
     setEvents((prevEvents) => [...prevEvents, duplicatedEvent])
+    void saveEvents([duplicatedEvent])
     setPreviewOpen(false)
     setPreviewAnchorRect(null)
   }
@@ -967,7 +996,6 @@ export default function Calendar({ className, ...props }: CalendarProps) {
 
                   updateEvent(updatedEvent)
                 }}
-                onBackToCalendar={() => setView(defaultView)}
               />
             )}
             {view === 'week' && (
@@ -1078,7 +1106,6 @@ export default function Calendar({ className, ...props }: CalendarProps) {
                 focusUserProfileSection={focusUserProfileSection}
                 toastPosition={toastPosition}
                 setToastPosition={setToastPosition}
-                onBackToCalendar={() => setView(defaultView)}
               />
             )}
           </div>

--- a/components/app/event/event-dialog.tsx
+++ b/components/app/event/event-dialog.tsx
@@ -654,7 +654,6 @@ export default function EventDialog({
                           setStartDateOpen(false)
                         }
                       }}
-                      initialFocus
                     />
                   </PopoverContent>
                 </Popover>
@@ -703,7 +702,6 @@ export default function EventDialog({
                           }
                         }
                       }}
-                      initialFocus
                       disabled={(date) => date < startDate}
                     />
                   </PopoverContent>

--- a/components/app/profile/user-profile-button.tsx
+++ b/components/app/profile/user-profile-button.tsx
@@ -41,7 +41,6 @@ import {
 import { Input } from '@/components/ui/input'
 import { Label } from '@/components/ui/label'
 import { ScrollArea } from '@/components/ui/scroll-area'
-import { Spinner } from '@/components/ui/spinner'
 import { toast } from 'sonner'
 import { useCalendar } from '@/components/providers/calendar-context'
 import { translations, useLanguage } from '@/lib/i18n'
@@ -670,6 +669,24 @@ export default function UserProfileButton({
     }
   }
 
+  async function enableServerBackup() {
+    const [events, categories] = await Promise.all([
+      readEncryptedLocalStorage('calendar-events', []),
+      readEncryptedLocalStorage('calendar-categories', []),
+    ])
+    await apiPost({
+      events,
+      categories,
+      settings: { backupMode: 'server-managed' },
+    })
+    localStorage.setItem(AUTO_KEY, 'true')
+    restoredRef.current = true
+    setEnabled(true)
+    setBackupOpen(false)
+    broadcastBackupStatus('done')
+    toast(t.autoBackupEnabled)
+  }
+
   async function enable() {
     if (!password) {
       setError(t.setEncryptionPasswordDescription || 'Encryption key not ready')
@@ -1048,28 +1065,6 @@ export default function UserProfileButton({
                   >
                     <CloudUpload className="h-4 w-4 mr-2" />
                     {t.openBackupSettings}
-                  </Button>
-                </div>
-
-                <div className="space-y-3 rounded-md border p-3">
-                  <p className="text-sm font-semibold">{t.changeKey}</p>
-                  <p className="text-xs text-muted-foreground">
-                    {t.rotateKeyHelp}
-                  </p>
-                  <Button
-                    id="settings-account-key"
-                    variant="outline"
-                    onClick={() => {
-                      setRotateStep('verify')
-                      setOldPassword('')
-                      setPassword('')
-                      setConfirm('')
-                      setError('')
-                      setRotateOpen(true)
-                    }}
-                  >
-                    <KeyRound className="h-4 w-4 mr-2" />
-                    {t.changeEncryptionKeyAction}
                   </Button>
                 </div>
 
@@ -1497,116 +1492,11 @@ export default function UserProfileButton({
                 {t.disable}
               </Button>
             ) : (
-              <Button
-                onClick={() => {
-                  setBackupOpen(false)
-                  const generated = generateHighEntropyKey()
-                  setPassword(generated)
-                  setConfirm(generated)
-                  setSetPwdOpen(true)
-                }}
-              >
+              <Button onClick={() => void enableServerBackup()}>
                 {t.enable}
               </Button>
             )}
           </DialogFooter>
-        </DialogContent>
-      </Dialog>
-
-      <Dialog open={setPwdOpen} onOpenChange={setSetPwdOpen}>
-        <DialogContent>
-          <DialogHeader>
-            <DialogTitle>{t.setEncryptionPassword}</DialogTitle>
-            <DialogDescription>
-              {t.setEncryptionPasswordDescription}
-            </DialogDescription>
-          </DialogHeader>
-          <Label>{t.password}</Label>
-          <Input type="text" value={password} readOnly />
-          <Label>{t.confirmPassword}</Label>
-          <Input type="text" value={confirm} readOnly />
-          {error && <p className="text-sm text-red-500">{error}</p>}
-          <DialogFooter>
-            <Button onClick={enable}>{t.confirm}</Button>
-          </DialogFooter>
-        </DialogContent>
-      </Dialog>
-
-      <Dialog
-        open={unlockOpen}
-        onOpenChange={(open) => {
-          if (open) setUnlockOpen(true)
-        }}
-      >
-        <DialogContent
-          onInteractOutside={(e: Event) => e.preventDefault()}
-          onEscapeKeyDown={(e: KeyboardEvent) => e.preventDefault()}
-        >
-          <DialogHeader>
-            <DialogTitle>{t.enterPasswordTitle}</DialogTitle>
-            <DialogDescription>{t.enterPasswordDescription}</DialogDescription>
-          </DialogHeader>
-          <Input
-            type="password"
-            value={password}
-            onChange={(e) => setPassword(e.target.value)}
-          />
-          <DialogFooter>
-            <Button onClick={unlock} disabled={isUnlocking}>
-              {isUnlocking ? (
-                <span className="flex items-center">
-                  <Spinner className="mr-2" />
-                  {t.verifying}
-                </span>
-              ) : (
-                t.confirm
-              )}
-            </Button>
-          </DialogFooter>
-        </DialogContent>
-      </Dialog>
-
-      <Dialog open={rotateOpen} onOpenChange={setRotateOpen}>
-        <DialogContent>
-          <DialogHeader>
-            <DialogTitle>{t.changeEncryptionKey}</DialogTitle>
-          </DialogHeader>
-          {rotateStep === 'verify' ? (
-            <>
-              <Label>{t.oldPassword}</Label>
-              <Input
-                type="password"
-                value={oldPassword}
-                onChange={(e) => setOldPassword(e.target.value)}
-              />
-              {error && <p className="text-sm text-red-500">{error}</p>}
-              <DialogFooter>
-                <Button
-                  onClick={verifyOldPasswordForRotation}
-                  disabled={isVerifyingRotationKey}
-                >
-                  {isVerifyingRotationKey ? t.verifying : t.next || 'Next'}
-                </Button>
-              </DialogFooter>
-            </>
-          ) : (
-            <>
-              <Label>{t.newPassword}</Label>
-              <Input type="text" value={password} readOnly />
-              <Label>{t.confirmNewPassword}</Label>
-              <Input type="text" value={confirm} readOnly />
-              {error && <p className="text-sm text-red-500">{error}</p>}
-              <DialogFooter>
-                <Button
-                  variant="outline"
-                  onClick={() => setRotateStep('verify')}
-                >
-                  {t.back || 'Back'}
-                </Button>
-                <Button onClick={rotate}>{t.confirmChange}</Button>
-              </DialogFooter>
-            </>
-          )}
         </DialogContent>
       </Dialog>
     </>

--- a/components/app/sidebar/countdown.tsx
+++ b/components/app/sidebar/countdown.tsx
@@ -670,7 +670,6 @@ export function CountdownTool({ open, onOpenChange }: CountdownToolProps) {
                     setSelectedDate(date)
                     setCalendarOpen(false)
                   }}
-                  initialFocus
                   locale={isZh ? zhCN : enUS}
                 />
               </PopoverContent>

--- a/components/providers/calendar-context.tsx
+++ b/components/providers/calendar-context.tsx
@@ -2,7 +2,7 @@
 
 import type { Dispatch, SetStateAction } from 'react'
 import type React from 'react'
-import { useEffect, useRef } from 'react'
+import { useCallback, useEffect, useMemo, useRef } from 'react'
 import { create } from 'zustand'
 import {
   readEncryptedLocalStorage,
@@ -14,6 +14,7 @@ export interface CalendarCategory {
   name: string
   color: string
   keywords?: string[]
+  position?: number
 }
 
 export interface CalendarEvent {
@@ -31,6 +32,8 @@ export interface CalendarEvent {
   calendarId: string
 }
 
+type DateRange = { start: Date; end: Date }
+
 interface CalendarContextType {
   calendars: CalendarCategory[]
   setCalendars: Dispatch<SetStateAction<CalendarCategory[]>>
@@ -41,6 +44,9 @@ interface CalendarContextType {
   updateCategory: (id: string, category: Partial<CalendarCategory>) => void
   moveCategory: (id: string, direction: 'up' | 'down') => void
   addEvent: (newEvent: CalendarEvent) => void
+  loadRange: (range: DateRange) => Promise<void>
+  saveEvents: (events: CalendarEvent[]) => Promise<void>
+  deleteEvent: (eventId: string) => Promise<void>
 }
 
 interface CalendarState {
@@ -55,6 +61,32 @@ interface CalendarState {
   addEvent: (newEvent: CalendarEvent) => void
 }
 
+function normalizeEvent(event: CalendarEvent): CalendarEvent {
+  return {
+    ...event,
+    startDate: new Date(event.startDate),
+    endDate: new Date(event.endDate),
+    participants: Array.isArray(event.participants) ? event.participants : [],
+    notification:
+      typeof event.notification === 'number' ? event.notification : 0,
+    recurrence: event.recurrence ?? 'none',
+    calendarId: event.calendarId ?? '',
+    color: event.color ?? '#3b82f6',
+  }
+}
+
+function mergeEvents(current: CalendarEvent[], incoming: CalendarEvent[]) {
+  const map = new Map(current.map((event) => [event.id, event]))
+  incoming.forEach((event) => map.set(event.id, normalizeEvent(event)))
+  return Array.from(map.values()).sort(
+    (a, b) => new Date(a.startDate).getTime() - new Date(b.startDate).getTime(),
+  )
+}
+
+function rangeKey(range: DateRange) {
+  return `${range.start.toISOString()}..${range.end.toISOString()}`
+}
+
 const useCalendarStore = create<CalendarState>()((set) => ({
   calendars: [],
   events: [],
@@ -67,11 +99,22 @@ const useCalendarStore = create<CalendarState>()((set) => ({
       events: typeof value === 'function' ? value(state.events) : value,
     })),
   addCategory: (category: CalendarCategory) =>
-    set((state: CalendarState) => ({ calendars: [...state.calendars, category] })),
-  removeCategory: (id: string) =>
+    set((state: CalendarState) => ({
+      calendars: [...state.calendars, category],
+    })),
+  removeCategory: (id: string) => {
+    void fetch('/api/blob', {
+      method: 'DELETE',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ categoryId: id }),
+    }).catch(() => undefined)
     set((state: CalendarState) => ({
       calendars: state.calendars.filter((cal) => cal.id !== id),
-    })),
+      events: state.events.map((event) =>
+        event.calendarId === id ? { ...event, calendarId: '' } : event,
+      ),
+    }))
+  },
   updateCategory: (id: string, category: Partial<CalendarCategory>) =>
     set((state: CalendarState) => ({
       calendars: state.calendars.map((cal) =>
@@ -82,34 +125,20 @@ const useCalendarStore = create<CalendarState>()((set) => ({
     set((state: CalendarState) => {
       const currentIndex = state.calendars.findIndex((cal) => cal.id === id)
       if (currentIndex === -1) return { calendars: state.calendars }
-
       const targetIndex =
         direction === 'up' ? currentIndex - 1 : currentIndex + 1
-
       if (targetIndex < 0 || targetIndex >= state.calendars.length) {
         return { calendars: state.calendars }
       }
-
       const nextCalendars = [...state.calendars]
       const [movedCalendar] = nextCalendars.splice(currentIndex, 1)
       nextCalendars.splice(targetIndex, 0, movedCalendar)
-
       return { calendars: nextCalendars }
     }),
   addEvent: (newEvent: CalendarEvent) =>
-    set((state: CalendarState) => {
-      const eventExists = state.events.some((event) => event.id === newEvent.id)
-
-      if (eventExists) {
-        return {
-          events: state.events.map((event) =>
-            event.id === newEvent.id ? newEvent : event,
-          ),
-        }
-      }
-
-      return { events: [...state.events, newEvent] }
-    }),
+    set((state: CalendarState) => ({
+      events: mergeEvents(state.events, [newEvent]),
+    })),
 }))
 
 export function CalendarProvider({ children }: { children: React.ReactNode }) {
@@ -117,7 +146,48 @@ export function CalendarProvider({ children }: { children: React.ReactNode }) {
   const events = useCalendarStore((state) => state.events)
   const setCalendars = useCalendarStore((state) => state.setCalendars)
   const setEvents = useCalendarStore((state) => state.setEvents)
+  const loadedRangesRef = useRef(new Set<string>())
   const hydratedRef = useRef(false)
+
+  const saveEvents = useCallback(async (nextEvents: CalendarEvent[]) => {
+    await fetch('/api/blob', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ events: nextEvents }),
+    }).catch(() => undefined)
+  }, [])
+
+  const loadRange = useCallback(
+    async (range: DateRange) => {
+      const key = rangeKey(range)
+      if (loadedRangesRef.current.has(key)) return
+      loadedRangesRef.current.add(key)
+      const params = new URLSearchParams({
+        start: range.start.toISOString(),
+        end: range.end.toISOString(),
+      })
+      const response = await fetch(`/api/blob?${params}`, {
+        cache: 'no-store',
+      }).catch(() => null)
+      if (!response?.ok) return
+      const payload = await response.json()
+      if (Array.isArray(payload.events)) {
+        setEvents((current) => mergeEvents(current, payload.events))
+      }
+      if (Array.isArray(payload.categories)) {
+        setCalendars(payload.categories)
+      }
+    },
+    [setCalendars, setEvents],
+  )
+
+  const deleteEvent = useCallback(async (eventId: string) => {
+    await fetch('/api/blob', {
+      method: 'DELETE',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ eventId }),
+    }).catch(() => undefined)
+  }, [])
 
   useEffect(() => {
     const hydrate = async () => {
@@ -128,24 +198,21 @@ export function CalendarProvider({ children }: { children: React.ReactNode }) {
         'calendar-events',
         [],
       )
-
       setCalendars(storedCalendars)
-      setEvents(
-        storedEvents.map((event) => ({
-          ...event,
-          startDate: new Date(event.startDate),
-          endDate: new Date(event.endDate),
-        })),
-      )
+      setEvents(storedEvents.map(normalizeEvent))
       hydratedRef.current = true
     }
-
     void hydrate()
   }, [setCalendars, setEvents])
 
   useEffect(() => {
     if (!hydratedRef.current) return
     void writeEncryptedLocalStorage('calendar-categories', calendars)
+    void fetch('/api/blob', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ categories: calendars }),
+    }).catch(() => undefined)
   }, [calendars])
 
   useEffect(() => {
@@ -153,6 +220,36 @@ export function CalendarProvider({ children }: { children: React.ReactNode }) {
     void writeEncryptedLocalStorage('calendar-events', events)
   }, [events])
 
+  return (
+    <CalendarContextBridge
+      loadRange={loadRange}
+      saveEvents={saveEvents}
+      deleteEvent={deleteEvent}
+    >
+      {children}
+    </CalendarContextBridge>
+  )
+}
+
+let bridge: Pick<
+  CalendarContextType,
+  'loadRange' | 'saveEvents' | 'deleteEvent'
+> = {
+  loadRange: async () => {},
+  saveEvents: async () => {},
+  deleteEvent: async () => {},
+}
+
+function CalendarContextBridge({
+  children,
+  loadRange,
+  saveEvents,
+  deleteEvent,
+}: { children: React.ReactNode } & typeof bridge) {
+  bridge = useMemo(
+    () => ({ loadRange, saveEvents, deleteEvent }),
+    [deleteEvent, loadRange, saveEvents],
+  )
   return children
 }
 
@@ -168,6 +265,9 @@ export function useCalendar(): CalendarContextType {
     updateCategory: store.updateCategory,
     moveCategory: store.moveCategory,
     addEvent: store.addEvent,
+    loadRange: bridge.loadRange,
+    saveEvents: bridge.saveEvents,
+    deleteEvent: bridge.deleteEvent,
   }
 }
 

--- a/components/ui/calendar.tsx
+++ b/components/ui/calendar.tsx
@@ -87,7 +87,6 @@ function Calendar({
             : "flex items-center gap-1 rounded-(--cell-radius) text-sm [&>svg]:size-3.5 [&>svg]:text-muted-foreground",
           defaultClassNames.caption_label
         ),
-        table: "w-full border-collapse",
         weekdays: cn("flex", defaultClassNames.weekdays),
         weekday: cn(
           "flex-1 rounded-(--cell-radius) text-[0.8rem] font-normal text-muted-foreground select-none",

--- a/components/ui/chart.tsx
+++ b/components/ui/chart.tsx
@@ -252,7 +252,7 @@ function ChartTooltipContent({
                           {itemConfig?.label ?? item.name}
                         </span>
                       </div>
-                      {item.value != null && (
+                      {item.value !== null && (
                         <span className="font-mono font-medium text-foreground tabular-nums">
                           {typeof item.value === "number"
                             ? item.value.toLocaleString()

--- a/components/ui/field.tsx
+++ b/components/ui/field.tsx
@@ -194,7 +194,7 @@ function FieldError({
       ...new Map(errors.map((error) => [error?.message, error])).values(),
     ]
 
-    if (uniqueErrors?.length == 1) {
+    if (uniqueErrors?.length === 1) {
       return uniqueErrors[0]?.message
     }
 

--- a/hooks/useLocalStorage.ts
+++ b/hooks/useLocalStorage.ts
@@ -1,11 +1,6 @@
 'use client'
 
 import { useEffect, useRef, useState, type SetStateAction } from 'react'
-import {
-  decryptPayload,
-  encryptPayload,
-  isEncryptedPayload,
-} from '@/lib/crypto'
 
 type EncryptionState = {
   enabled: boolean
@@ -13,28 +8,14 @@ type EncryptionState = {
   ready: boolean
 }
 
-type EncryptedSnapshot = {
-  value: string | null
-  failed: boolean
-}
-
 const ENCRYPTION_STATE: EncryptionState = {
   enabled: false,
   password: null,
-  ready: false,
+  ready: true,
 }
 
-const encryptedSnapshots = new Map<string, EncryptedSnapshot>()
 const inMemoryStorage = new Map<string, string>()
 const subscribers = new Set<() => void>()
-
-const SENSITIVE_KEYS = new Set([
-  'calendar-events',
-  'calendar-categories',
-  'bookmarked-events',
-  'shared-events',
-  'countdowns',
-])
 
 function tryParse(value: string) {
   try {
@@ -47,14 +28,8 @@ function tryParse(value: string) {
 function coerceStoredValue<T>(raw: string, initialValue: T): T {
   const parsed = tryParse(raw)
   if (parsed.ok) return parsed.parsed as T
-  if (typeof initialValue === 'string' || initialValue === null) {
-    return raw as T
-  }
+  if (typeof initialValue === 'string' || initialValue === null) return raw as T
   return initialValue
-}
-
-function notifySubscribers() {
-  subscribers.forEach((callback) => callback())
 }
 
 function emitStorageWrite(key: string) {
@@ -64,8 +39,12 @@ function emitStorageWrite(key: string) {
   )
 }
 
-export function isSensitiveStorageKey(key: string) {
-  return SENSITIVE_KEYS.has(key)
+function notifySubscribers() {
+  subscribers.forEach((callback) => callback())
+}
+
+export function isSensitiveStorageKey(_key: string) {
+  return false
 }
 
 export function getEncryptionState() {
@@ -77,39 +56,32 @@ export function subscribeEncryptionState(callback: () => void) {
   return () => subscribers.delete(callback)
 }
 
-export async function setEncryptionPassword(password: string) {
-  ENCRYPTION_STATE.password = password
-  ENCRYPTION_STATE.enabled = true
-  ENCRYPTION_STATE.ready = false
-
-  if (password) {
-    await decryptSnapshots(password)
-  }
-
+export async function setEncryptionPassword(_password: string) {
+  ENCRYPTION_STATE.enabled = false
+  ENCRYPTION_STATE.password = null
   ENCRYPTION_STATE.ready = true
   notifySubscribers()
 }
 
 export function clearEncryptionPassword() {
-  ENCRYPTION_STATE.password = null
   ENCRYPTION_STATE.enabled = false
-  ENCRYPTION_STATE.ready = false
-  encryptedSnapshots.clear()
+  ENCRYPTION_STATE.password = null
+  ENCRYPTION_STATE.ready = true
   inMemoryStorage.clear()
   notifySubscribers()
 }
 
 export function resetEncryptionReady() {
-  ENCRYPTION_STATE.ready = false
+  ENCRYPTION_STATE.ready = true
   notifySubscribers()
 }
 
 export function markEncryptedSnapshot(key: string, value: string) {
-  encryptedSnapshots.set(key, { value, failed: false })
+  inMemoryStorage.set(key, value)
 }
 
 export function clearEncryptedSnapshots() {
-  encryptedSnapshots.clear()
+  inMemoryStorage.clear()
 }
 
 export function writeInMemoryStorage(key: string, value: string) {
@@ -128,105 +100,23 @@ export function clearInMemoryStorage() {
   inMemoryStorage.clear()
 }
 
-export async function decryptSnapshots(password: string) {
-  const entries = Array.from(encryptedSnapshots.entries())
-  if (entries.length === 0) return
+export async function decryptSnapshots(_password: string) {}
 
-  await Promise.all(
-    entries.map(async ([key, snapshot]) => {
-      if (!snapshot.value) return
-      try {
-        const parsed = tryParse(snapshot.value)
-        if (!parsed.ok || !isEncryptedPayload(parsed.parsed)) return
-        const plain = await decryptPayload(
-          password,
-          parsed.parsed.ciphertext,
-          parsed.parsed.iv,
-        )
-        snapshot.value = plain
-        snapshot.failed = false
-      } catch {
-        snapshot.failed = true
-      }
-    }),
-  )
-}
+export async function encryptSnapshots(_password: string) {}
 
-export async function encryptSnapshots(password: string) {
-  const entries = Array.from(encryptedSnapshots.entries())
-  if (entries.length === 0) return
-
-  await Promise.all(
-    entries.map(async ([key, snapshot]) => {
-      if (!snapshot.value) return
-      try {
-        const parsed = tryParse(snapshot.value)
-        if (parsed.ok && isEncryptedPayload(parsed.parsed)) {
-          snapshot.failed = false
-          return
-        }
-        const encrypted = await encryptPayload(password, snapshot.value)
-        snapshot.value = JSON.stringify(encrypted)
-        snapshot.failed = false
-      } catch {
-        snapshot.failed = true
-      }
-    }),
-  )
-}
-
-export async function persistEncryptedSnapshots() {
-  encryptedSnapshots.forEach((snapshot, key) => {
-    if (!snapshot.value) return
-    if (isSensitiveStorageKey(key)) return
-    window.localStorage.setItem(key, snapshot.value)
-  })
-}
+export async function persistEncryptedSnapshots() {}
 
 export async function readEncryptedLocalStorage<T>(
   key: string,
   initialValue: T,
 ): Promise<T> {
-  if (typeof window === 'undefined') {
-    return initialValue
-  }
+  if (typeof window === 'undefined') return initialValue
   try {
-    const inMemoryValue = inMemoryStorage.get(key)
-    if (isSensitiveStorageKey(key) && inMemoryValue !== undefined) {
-      return coerceStoredValue(inMemoryValue, initialValue)
-    }
-    const snapshot = encryptedSnapshots.get(key)
-    if (snapshot?.value) {
-      const parsedSnapshot = tryParse(snapshot.value)
-      if (parsedSnapshot.ok && isEncryptedPayload(parsedSnapshot.parsed)) {
-        if (!ENCRYPTION_STATE.password) return initialValue
-        const plain = await decryptPayload(
-          ENCRYPTION_STATE.password,
-          parsedSnapshot.parsed.ciphertext,
-          parsedSnapshot.parsed.iv,
-        )
-        encryptedSnapshots.set(key, { value: plain, failed: false })
-        return coerceStoredValue<T>(plain, initialValue)
-      }
-      return coerceStoredValue(snapshot.value, initialValue)
-    }
+    const memoryValue = inMemoryStorage.get(key)
+    if (memoryValue !== undefined)
+      return coerceStoredValue(memoryValue, initialValue)
     const item = window.localStorage.getItem(key)
     if (!item) return initialValue
-    const parsed = tryParse(item)
-    if (parsed.ok && isEncryptedPayload(parsed.parsed)) {
-      if (!ENCRYPTION_STATE.password) return initialValue
-      const plain = await decryptPayload(
-        ENCRYPTION_STATE.password,
-        parsed.parsed.ciphertext,
-        parsed.parsed.iv,
-      )
-      encryptedSnapshots.set(key, { value: plain, failed: false })
-      if (isSensitiveStorageKey(key)) {
-        inMemoryStorage.set(key, plain)
-        window.localStorage.removeItem(key)
-      }
-      return coerceStoredValue<T>(plain, initialValue)
-    }
     return coerceStoredValue(item, initialValue)
   } catch (error) {
     console.log(error)
@@ -238,23 +128,8 @@ export async function writeEncryptedLocalStorage<T>(key: string, value: T) {
   if (typeof window === 'undefined') return
   try {
     const raw = JSON.stringify(value)
-    if (ENCRYPTION_STATE.enabled && ENCRYPTION_STATE.password) {
-      if (isSensitiveStorageKey(key)) {
-        inMemoryStorage.set(key, raw)
-        encryptedSnapshots.set(key, { value: raw, failed: false })
-        window.localStorage.removeItem(key)
-        emitStorageWrite(key)
-        return
-      }
-      const encrypted = await encryptPayload(ENCRYPTION_STATE.password, raw)
-      const payload = JSON.stringify(encrypted)
-      window.localStorage.setItem(key, payload)
-      encryptedSnapshots.set(key, { value: raw, failed: false })
-      emitStorageWrite(key)
-      return
-    }
     window.localStorage.setItem(key, raw)
-    encryptedSnapshots.set(key, { value: raw, failed: false })
+    inMemoryStorage.set(key, raw)
     emitStorageWrite(key)
   } catch (error) {
     console.log(error)
@@ -262,72 +137,11 @@ export async function writeEncryptedLocalStorage<T>(key: string, value: T) {
 }
 
 async function readLocalStorage<T>(key: string, initialValue: T): Promise<T> {
-  if (typeof window === 'undefined') {
-    return initialValue
-  }
-  try {
-    const inMemoryValue = inMemoryStorage.get(key)
-    if (isSensitiveStorageKey(key) && inMemoryValue !== undefined) {
-      return coerceStoredValue(inMemoryValue, initialValue)
-    }
-    const item = window.localStorage.getItem(key)
-    if (!item) return initialValue
-    const snapshot = encryptedSnapshots.get(key)
-    if (snapshot?.value) {
-      const parsedSnapshot = tryParse(snapshot.value)
-      if (parsedSnapshot.ok && isEncryptedPayload(parsedSnapshot.parsed)) {
-        if (!ENCRYPTION_STATE.password) return initialValue
-        const plain = await decryptPayload(
-          ENCRYPTION_STATE.password,
-          parsedSnapshot.parsed.ciphertext,
-          parsedSnapshot.parsed.iv,
-        )
-        snapshot.value = plain
-        snapshot.failed = false
-        return coerceStoredValue<T>(plain, initialValue)
-      }
-      return coerceStoredValue(snapshot.value, initialValue)
-    }
-    const parsed = tryParse(item)
-    if (parsed.ok && isEncryptedPayload(parsed.parsed)) {
-      encryptedSnapshots.set(key, { value: item, failed: false })
-      if (isSensitiveStorageKey(key)) {
-        window.localStorage.removeItem(key)
-      }
-      return initialValue
-    }
-    return coerceStoredValue(item, initialValue)
-  } catch (error) {
-    console.log(error)
-    return initialValue
-  }
+  return readEncryptedLocalStorage(key, initialValue)
 }
 
 async function writeLocalStorage<T>(key: string, value: T) {
-  if (typeof window === 'undefined') return
-  try {
-    const raw = JSON.stringify(value)
-    if (ENCRYPTION_STATE.enabled && ENCRYPTION_STATE.password) {
-      if (isSensitiveStorageKey(key)) {
-        inMemoryStorage.set(key, raw)
-        encryptedSnapshots.set(key, { value: raw, failed: false })
-        window.localStorage.removeItem(key)
-        emitStorageWrite(key)
-        return
-      }
-      const encrypted = await encryptPayload(ENCRYPTION_STATE.password, raw)
-      const payload = JSON.stringify(encrypted)
-      window.localStorage.setItem(key, payload)
-      encryptedSnapshots.set(key, { value: raw, failed: false })
-      emitStorageWrite(key)
-      return
-    }
-    window.localStorage.setItem(key, raw)
-    encryptedSnapshots.set(key, { value: raw, failed: false })
-    emitStorageWrite(key)
-  } catch (error) {
-    console.log(error)
-  }
+  return writeEncryptedLocalStorage(key, value)
 }
 
 export function useLocalStorage<T>(key: string, initialValue: T) {
@@ -348,14 +162,8 @@ export function useLocalStorage<T>(key: string, initialValue: T) {
     readLocalStorage(key, initialValue).then((value) => {
       if (cancelled) return
       if (localWriteVersionRef.current !== writeVersionWhenReadStarted) return
-      const nextSerializedValue = JSON.stringify(value)
-      setSerializedValue(nextSerializedValue)
-      setStoredValue((prev) => {
-        if (JSON.stringify(prev) === nextSerializedValue) {
-          return prev
-        }
-        return value
-      })
+      setStoredValue(value)
+      setSerializedValue(JSON.stringify(value))
     })
     return () => {
       cancelled = true
@@ -363,49 +171,34 @@ export function useLocalStorage<T>(key: string, initialValue: T) {
   }, [key])
 
   useEffect(() => {
-    const refreshValue = () => {
-      const writeVersionWhenReadStarted = localWriteVersionRef.current
-      readLocalStorage(key, initialValue).then((value) => {
-        if (localWriteVersionRef.current !== writeVersionWhenReadStarted) return
-        const nextSerializedValue = JSON.stringify(value)
-        setSerializedValue(nextSerializedValue)
-        setStoredValue((prev) => {
-          if (JSON.stringify(prev) === nextSerializedValue) {
-            return prev
-          }
-          return value
-        })
+    const handleStorage = (
+      event: StorageEvent | CustomEvent<{ key: string }>,
+    ) => {
+      const changedKey = 'key' in event ? event.key : event.detail?.key
+      if (changedKey !== key) return
+      void readLocalStorage(key, initialValue).then((value) => {
+        setStoredValue(value)
+        setSerializedValue(JSON.stringify(value))
       })
     }
-
-    const unsubscribe = subscribeEncryptionState(() => {
-      const state = getEncryptionState()
-      if (state.ready) {
-        refreshValue()
-      }
-    })
-
-    const handleStorageWritten = (event: Event) => {
-      const customEvent = event as CustomEvent<{ key?: string }>
-      if (customEvent.detail?.key === key) {
-        refreshValue()
-      }
-    }
-
-    window.addEventListener('local-storage-written', handleStorageWritten)
+    window.addEventListener('storage', handleStorage as EventListener)
+    window.addEventListener(
+      'local-storage-written',
+      handleStorage as EventListener,
+    )
     return () => {
-      unsubscribe()
-      window.removeEventListener('local-storage-written', handleStorageWritten)
+      window.removeEventListener('storage', handleStorage as EventListener)
+      window.removeEventListener(
+        'local-storage-written',
+        handleStorage as EventListener,
+      )
     }
-  }, [key, initialValue])
+  }, [key])
 
   useEffect(() => {
-    const nextSerializedValue = JSON.stringify(storedValue)
-    if (nextSerializedValue === serializedValue) {
-      return
-    }
-
-    setSerializedValue(nextSerializedValue)
+    const nextSerialized = JSON.stringify(storedValue)
+    if (nextSerialized === serializedValue) return
+    setSerializedValue(nextSerialized)
     void writeLocalStorage(key, storedValue)
   }, [key, serializedValue, storedValue])
 

--- a/lib/drizzle/schema.ts
+++ b/lib/drizzle/schema.ts
@@ -11,40 +11,12 @@ import {
 } from 'drizzle-orm/pg-core'
 import { relations } from 'drizzle-orm'
 
-// --- Share (@@map("shares")) ---
-export const shares = pgTable(
-  'shares',
-  {
-    id: serial('id').primaryKey(),
-    userId: text('user_id').notNull(),
-    shareId: text('share_id').unique().notNull(),
-    eventId: text('event_id').notNull(),
-    encryptedData: text('encrypted_data').notNull(),
-    iv: text('iv').notNull(),
-    authTag: text('auth_tag').notNull(),
-    timestamp: timestamp('timestamp', {
-      precision: 3,
-      withTimezone: true,
-    }).notNull(),
-    isProtected: boolean('is_protected').default(false).notNull(),
-    isBurn: boolean('is_burn').default(false).notNull(),
-    encVersion: integer('enc_version'),
-  },
-  (table) => ({
-    userIdIdx: index('idx_shares_user_id').on(table.userId),
-    eventIdIdx: index('idx_shares_event_id').on(table.eventId),
-  }),
-)
-
-// --- CalendarBackup (@@map("calendar_backups")) ---
 export const calendarBackups = pgTable(
   'calendar_backups',
   {
     id: text('id').primaryKey(),
     userId: text('user_id').notNull(),
-    encryptedData: text('encrypted_data').notNull(),
-    iv: text('iv').notNull(),
-    authTag: text('auth_tag').notNull(),
+    title: text('title').notNull(),
     startDate: timestamp('start_date', {
       precision: 3,
       withTimezone: true,
@@ -53,8 +25,19 @@ export const calendarBackups = pgTable(
       precision: 3,
       withTimezone: true,
     }).notNull(),
+    isAllDay: boolean('is_all_day').default(false).notNull(),
+    recurrence: text('recurrence').default('none').notNull(),
     calendarId: text('calendar_id'),
-    timestamp: timestamp('timestamp', {
+    color: text('color').default('#3b82f6').notNull(),
+    encryptedData: text('encrypted_data'),
+    iv: text('iv'),
+    authTag: text('auth_tag'),
+    searchableText: text('searchable_text').default('').notNull(),
+    createdAt: timestamp('created_at', {
+      precision: 3,
+      withTimezone: true,
+    }).notNull(),
+    updatedAt: timestamp('updated_at', {
       precision: 3,
       withTimezone: true,
     }).notNull(),
@@ -70,6 +53,10 @@ export const calendarBackups = pgTable(
       table.userId,
       table.calendarId,
     ),
+    searchIdx: index('idx_calendar_backups_user_search').on(
+      table.userId,
+      table.searchableText,
+    ),
   }),
 )
 
@@ -78,11 +65,18 @@ export const calendarCategories = pgTable(
   {
     id: text('id').primaryKey(),
     userId: text('user_id').notNull(),
-    encryptedData: text('encrypted_data').notNull(),
-    iv: text('iv').notNull(),
-    authTag: text('auth_tag').notNull(),
+    name: text('name').notNull(),
+    color: text('color').notNull(),
+    keywords: jsonb('keywords').$type<string[]>().default([]).notNull(),
+    encryptedData: text('encrypted_data'),
+    iv: text('iv'),
+    authTag: text('auth_tag'),
     position: integer('position').default(0).notNull(),
-    timestamp: timestamp('timestamp', {
+    createdAt: timestamp('created_at', {
+      precision: 3,
+      withTimezone: true,
+    }).notNull(),
+    updatedAt: timestamp('updated_at', {
       precision: 3,
       withTimezone: true,
     }).notNull(),
@@ -94,8 +88,12 @@ export const calendarCategories = pgTable(
 
 export const userSettings = pgTable('user_settings', {
   userId: text('user_id').primaryKey(),
-  settings: jsonb('settings').notNull(),
-  timestamp: timestamp('timestamp', {
+  settings: jsonb('settings').$type<Record<string, unknown>>().notNull(),
+  createdAt: timestamp('created_at', {
+    precision: 3,
+    withTimezone: true,
+  }).notNull(),
+  updatedAt: timestamp('updated_at', {
     precision: 3,
     withTimezone: true,
   }).notNull(),
@@ -107,16 +105,34 @@ export const calendarBookmarks = pgTable(
     id: text('id').primaryKey(),
     userId: text('user_id').notNull(),
     eventId: text('event_id').notNull(),
-    encryptedData: text('encrypted_data').notNull(),
-    iv: text('iv').notNull(),
-    authTag: text('auth_tag').notNull(),
-    timestamp: timestamp('timestamp', {
+    title: text('title').notNull(),
+    startDate: timestamp('start_date', {
+      precision: 3,
+      withTimezone: true,
+    }).notNull(),
+    endDate: timestamp('end_date', {
+      precision: 3,
+      withTimezone: true,
+    }).notNull(),
+    color: text('color').default('#3b82f6').notNull(),
+    encryptedData: text('encrypted_data'),
+    iv: text('iv'),
+    authTag: text('auth_tag'),
+    createdAt: timestamp('created_at', {
+      precision: 3,
+      withTimezone: true,
+    }).notNull(),
+    updatedAt: timestamp('updated_at', {
       precision: 3,
       withTimezone: true,
     }).notNull(),
   },
   (table) => ({
     userIdIdx: index('idx_calendar_bookmarks_user_id').on(table.userId),
+    eventIdx: index('idx_calendar_bookmarks_user_event').on(
+      table.userId,
+      table.eventId,
+    ),
   }),
 )
 
@@ -125,20 +141,63 @@ export const calendarCountdowns = pgTable(
   {
     id: text('id').primaryKey(),
     userId: text('user_id').notNull(),
-    encryptedData: text('encrypted_data').notNull(),
-    iv: text('iv').notNull(),
-    authTag: text('auth_tag').notNull(),
-    timestamp: timestamp('timestamp', {
+    title: text('title').notNull(),
+    dueDate: timestamp('due_date', {
+      precision: 3,
+      withTimezone: true,
+    }).notNull(),
+    eventId: text('event_id'),
+    encryptedData: text('encrypted_data'),
+    iv: text('iv'),
+    authTag: text('auth_tag'),
+    createdAt: timestamp('created_at', {
+      precision: 3,
+      withTimezone: true,
+    }).notNull(),
+    updatedAt: timestamp('updated_at', {
       precision: 3,
       withTimezone: true,
     }).notNull(),
   },
   (table) => ({
     userIdIdx: index('idx_calendar_countdowns_user_id').on(table.userId),
+    dueDateIdx: index('idx_calendar_countdowns_user_due').on(
+      table.userId,
+      table.dueDate,
+    ),
   }),
 )
 
-// --- User (Table name: "User") ---
+export const shares = pgTable(
+  'shares',
+  {
+    id: serial('id').primaryKey(),
+    userId: text('user_id').notNull(),
+    shareId: text('share_id').unique().notNull(),
+    eventId: text('event_id'),
+    passwordHash: text('password_hash'),
+    isProtected: boolean('is_protected').default(false).notNull(),
+    isBurn: boolean('is_burn').default(false).notNull(),
+    expiresAt: timestamp('expires_at', {
+      precision: 3,
+      withTimezone: true,
+    }),
+    createdAt: timestamp('created_at', {
+      precision: 3,
+      withTimezone: true,
+    }).notNull(),
+    updatedAt: timestamp('updated_at', {
+      precision: 3,
+      withTimezone: true,
+    }).notNull(),
+  },
+  (table) => ({
+    userIdIdx: index('idx_shares_user_id').on(table.userId),
+    eventIdIdx: index('idx_shares_event_id').on(table.eventId),
+    shareIdIdx: index('idx_shares_share_id').on(table.shareId),
+  }),
+)
+
 export const user = pgTable('User', {
   id: text('id').primaryKey(),
   name: text('name').notNull(),
@@ -156,7 +215,6 @@ export const user = pgTable('User', {
   }).notNull(),
 })
 
-// --- Session (Table name: "Session") ---
 export const session = pgTable('Session', {
   id: text('id').primaryKey(),
   expiresAt: timestamp('expiresAt', {
@@ -179,7 +237,6 @@ export const session = pgTable('Session', {
     .references(() => user.id, { onDelete: 'cascade' }),
 })
 
-// --- Account (Table name: "Account") ---
 export const account = pgTable(
   'Account',
   {
@@ -219,7 +276,6 @@ export const account = pgTable(
   }),
 )
 
-// --- Verification (Table name: "Verification") ---
 export const verification = pgTable('Verification', {
   id: text('id').primaryKey(),
   identifier: text('identifier').notNull(),
@@ -232,7 +288,6 @@ export const verification = pgTable('Verification', {
   updatedAt: timestamp('updatedAt', { precision: 3, withTimezone: true }),
 })
 
-// --- TwoFactor (@@map("twoFactor")) ---
 export const twoFactor = pgTable('twoFactor', {
   id: text('id').primaryKey(),
   secret: text('secret').notNull(),
@@ -244,7 +299,6 @@ export const twoFactor = pgTable('twoFactor', {
     .references(() => user.id, { onDelete: 'cascade' }),
 })
 
-// --- Relations ---
 export const userRelations = relations(user, ({ many, one }) => ({
   sessions: many(session),
   accounts: many(account),

--- a/lib/server-crypto.ts
+++ b/lib/server-crypto.ts
@@ -1,0 +1,59 @@
+import crypto from 'crypto'
+
+const ALGORITHM = 'aes-256-gcm'
+
+export type ServerEncryptedPayload = {
+  encryptedData: string
+  iv: string
+  authTag: string
+}
+
+function getBackupSalt() {
+  const salt = process.env.BACKUP_SALT
+  if (!salt) throw new Error('Missing BACKUP_SALT')
+  return salt
+}
+
+function keyForContext(context: string) {
+  return crypto
+    .createHash('sha256')
+    .update(getBackupSalt(), 'utf8')
+    .update(':')
+    .update(context, 'utf8')
+    .digest()
+}
+
+export function encryptServerJson(
+  value: unknown,
+  context: string,
+): ServerEncryptedPayload {
+  const iv = crypto.randomBytes(12)
+  const cipher = crypto.createCipheriv(ALGORITHM, keyForContext(context), iv)
+  const plain = JSON.stringify(value ?? {})
+  let encryptedData = cipher.update(plain, 'utf8', 'hex')
+  encryptedData += cipher.final('hex')
+  return {
+    encryptedData,
+    iv: iv.toString('hex'),
+    authTag: cipher.getAuthTag().toString('hex'),
+  }
+}
+
+export function decryptServerJson<T>(
+  encryptedData: string | null,
+  iv: string | null,
+  authTag: string | null,
+  context: string,
+  fallback: T,
+): T {
+  if (!encryptedData || !iv || !authTag) return fallback
+  const decipher = crypto.createDecipheriv(
+    ALGORITHM,
+    keyForContext(context),
+    Buffer.from(iv, 'hex'),
+  )
+  decipher.setAuthTag(Buffer.from(authTag, 'hex'))
+  let plain = decipher.update(encryptedData, 'hex', 'utf8')
+  plain += decipher.final('utf8')
+  return JSON.parse(plain) as T
+}


### PR DESCRIPTION
### Motivation
- The app must remove client-side E2EE and old aggregated backup blobs and migrate to a server-managed, event-level storage model for scalability and on-demand loading.
- Sharing must move to a link-driven model where the server controls encryption/decryption and optional password protection, and user-level settings must become a first-class, extensible model.

### Description
- Replaced the old aggregated backup model with an event-level schema in `lib/drizzle/schema.ts` adding `calendar_backups` as event records and new tables for `calendar_categories`, `user_settings`, `calendar_bookmarks`, `calendar_countdowns`, and `shares` with appropriate indexes and metadata fields and support for encrypted extensions.
- Implemented server-side AES-256-GCM helpers in `lib/server-crypto.ts` that derive per-context keys from the environment `BACKUP_SALT` and added `encryptServerJson`/`decryptServerJson` for controlled server encryption of per-record extension data.
- Rewrote `/api/blob` in `app/api/blob/route.ts` to support range-based GETs, event/category upserts via POST, and fine-grained DELETE behavior (single event, category deletion with automatic event unbinding, or full user data purge), while storing extensible encrypted fields server-side.
- Reworked share APIs (`app/api/share/route.ts` and `app/api/share/list/route.ts`) to be link-driven: shares reference an `eventId`, optional password protection is stored as a bcrypt hash, server validates password and returns server-decrypted event payloads, and burn-after-read and expiry are supported.
- Updated frontend data flow by adding range loading, server sync hooks, and event-level sync in `components/providers/calendar-context.tsx` and wiring `components/app/calendar.tsx` to load data on demand and call `saveEvents`/`deleteEvent` on mutations; category deletion now triggers server-side unbinding and local downgrade to uncategorized.
- Removed client-side end-to-end key flows and replaced `hooks/useLocalStorage.ts` with a non-E2EE shim that persists plain JSON to `localStorage` and keeps in-memory copies for sensitive keys, and removed UI flows that required users to manage encryption keys in `components/app/profile/user-profile-button.tsx` while adding a server-managed backup enable path.

### Testing
- Ran `pnpm type-check` which completed successfully with no TypeScript errors.
- Ran `pnpm lint:check` which reported ESLint warnings (unused variables and `no-console`) and therefore failed under the repository's `--max-warnings=0` policy. These warnings are existing repository issues that did not block the core refactor but must be addressed separately.
- Basic local compile/type-check and targeted adjustments were performed to ensure the new server APIs and types integrate with the frontend calls (no runtime API call tests were run here).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a22e33c36e88326bc380442d14aa58a)

## Summary by Sourcery

将日历数据从单一加密备份 Blob 迁移到以事件为粒度、由服务器管理的模型，并支持基于范围的加载、基于链接的分享，以及非端到端加密（非 E2EE）的本地存储。

New Features:
- 引入以事件为粒度的日历存储，支持分类、书签、倒计时和用户设置，并通过 `/api/blob` 端点实现基于范围的导出和导入。
- 添加基于链接的日历事件分享，由服务器托管解密逻辑，支持可选密码保护、阅后即焚和到期元数据。
- 暴露日历上下文辅助方法，以支持按需范围加载、事件和分类的服务器同步，以及在 UI 中触发的服务器端事件删除。

Bug Fixes:
- 修正 UI 组件中的严格相等性检查，避免在工具提示和字段错误渲染中出现宽松比较问题。

Enhancements:
- 用简化的基于 JSON 的存储垫片替换客户端 E2EE 本地存储处理，该垫片保留内存副本并移除面向用户的密钥管理流程。
- 优化与日历相关实体和分享的数据库模式，增加更丰富的元数据、搜索索引以及明确的创建/更新时间戳。
- 简化日历 UI 行为，移除未使用的回调，并改进跨标签页的 `localStorage` 同步。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Migrate calendar data from a single encrypted backup blob to an event-level, server-managed model with range-based loading, link-based sharing, and non-E2EE local storage.

New Features:
- Introduce event-level calendar storage with support for categories, bookmarks, countdowns, and user settings, including range-based export and import via the /api/blob endpoint.
- Add link-based calendar event sharing backed by server-managed decryption, optional password protection, burn-after-read, and expiry metadata.
- Expose calendar context helpers for on-demand range loading, server syncing of events and categories, and server-side deletion of events from the UI.

Bug Fixes:
- Correct strict equality checks in UI components to avoid loose comparison issues in tooltips and field error rendering.

Enhancements:
- Replace client-side E2EE local storage handling with a simplified JSON-based storage shim that keeps an in-memory copy and removes user-facing key management flows.
- Refine database schema for calendar-related entities and shares with richer metadata, search indexes, and explicit created/updated timestamps.
- Simplify calendar UI behaviors by removing unused callbacks and improving cross-tab localStorage synchronization.

</details>