### PR TITLE
fix: encrypt calendar backups and persist auxiliary data

### DIFF
--- a/app/api/blob/route.ts
+++ b/app/api/blob/route.ts
@@ -9,7 +9,7 @@ import {
   calendarCountdowns,
   userSettings,
 } from '@/lib/drizzle/schema'
-import { and, eq, gte, lte, or } from 'drizzle-orm'
+import { and, eq } from 'drizzle-orm'
 import { decryptServerJson, encryptServerJson } from '@/lib/server-crypto'
 import { randomUUID } from 'crypto'
 
@@ -47,6 +47,35 @@ type CalendarCategoryPayload = {
   [key: string]: unknown
 }
 
+type CalendarBookmarkPayload = {
+  id?: string
+  eventId?: string
+  title?: string
+  startDate?: string | Date
+  endDate?: string | Date
+  color?: string
+  [key: string]: unknown
+}
+
+type CalendarCountdownPayload = {
+  id?: string
+  title?: string
+  name?: string
+  dueDate?: string | Date
+  date?: string | Date
+  eventId?: string
+  [key: string]: unknown
+}
+
+type EncryptedSettingsEnvelope = {
+  encryptedData?: string
+  iv?: string
+  authTag?: string
+}
+
+const ENCRYPTED_TEXT_PLACEHOLDER = '[encrypted]'
+const ENCRYPTED_DATE_PLACEHOLDER = new Date(0)
+
 function jsonNoStore(body: unknown, init?: ResponseInit) {
   return NextResponse.json(body, {
     ...init,
@@ -80,43 +109,150 @@ function countdownContext(userId: string, countdownId: string) {
   return `calendar-countdown:${userId}:${countdownId}`
 }
 
+function settingsContext(userId: string) {
+  return `user-settings:${userId}`
+}
+
 function serializeEvent(row: typeof calendarBackups.$inferSelect) {
-  const extra = decryptServerJson<Record<string, unknown>>(
+  const decrypted = decryptServerJson<Record<string, unknown>>(
     row.encryptedData,
     row.iv,
     row.authTag,
     eventContext(row.userId, row.id),
     {},
   )
+  const legacyExtensions =
+    decrypted.extensions && typeof decrypted.extensions === 'object'
+      ? (decrypted.extensions as Record<string, unknown>)
+      : {}
   return {
-    ...extra,
+    ...legacyExtensions,
+    ...decrypted,
     id: row.id,
-    title: row.title,
-    startDate: row.startDate.toISOString(),
-    endDate: row.endDate.toISOString(),
-    isAllDay: row.isAllDay,
-    recurrence: row.recurrence,
-    color: row.color,
-    calendarId: row.calendarId ?? '',
+    title: typeof decrypted.title === 'string' ? decrypted.title : row.title,
+    startDate:
+      typeof decrypted.startDate === 'string'
+        ? decrypted.startDate
+        : row.startDate.toISOString(),
+    endDate:
+      typeof decrypted.endDate === 'string'
+        ? decrypted.endDate
+        : row.endDate.toISOString(),
+    isAllDay:
+      typeof decrypted.isAllDay === 'boolean'
+        ? decrypted.isAllDay
+        : row.isAllDay,
+    recurrence:
+      typeof decrypted.recurrence === 'string'
+        ? decrypted.recurrence
+        : row.recurrence,
+    color: typeof decrypted.color === 'string' ? decrypted.color : row.color,
+    calendarId:
+      typeof decrypted.calendarId === 'string'
+        ? decrypted.calendarId
+        : (row.calendarId ?? ''),
   }
 }
 
 function serializeCategory(row: typeof calendarCategories.$inferSelect) {
-  const extra = decryptServerJson<Record<string, unknown>>(
+  const decrypted = decryptServerJson<Record<string, unknown>>(
     row.encryptedData,
     row.iv,
     row.authTag,
     categoryContext(row.userId, row.id),
     {},
   )
+  const legacyExtensions =
+    decrypted.extensions && typeof decrypted.extensions === 'object'
+      ? (decrypted.extensions as Record<string, unknown>)
+      : {}
   return {
-    ...extra,
+    ...legacyExtensions,
+    ...decrypted,
     id: row.id,
-    name: row.name,
-    color: row.color,
-    keywords: row.keywords,
-    position: row.position,
+    name: typeof decrypted.name === 'string' ? decrypted.name : row.name,
+    color: typeof decrypted.color === 'string' ? decrypted.color : row.color,
+    keywords: Array.isArray(decrypted.keywords)
+      ? decrypted.keywords
+      : row.keywords,
+    position:
+      typeof decrypted.position === 'number'
+        ? decrypted.position
+        : row.position,
   }
+}
+
+function serializeBookmark(row: typeof calendarBookmarks.$inferSelect) {
+  const decrypted = decryptServerJson<Record<string, unknown>>(
+    row.encryptedData,
+    row.iv,
+    row.authTag,
+    bookmarkContext(row.userId, row.id),
+    {},
+  )
+  return {
+    ...decrypted,
+    id: row.id,
+    eventId:
+      typeof decrypted.eventId === 'string' ? decrypted.eventId : row.eventId,
+    title: typeof decrypted.title === 'string' ? decrypted.title : row.title,
+    startDate:
+      typeof decrypted.startDate === 'string'
+        ? decrypted.startDate
+        : row.startDate.toISOString(),
+    endDate:
+      typeof decrypted.endDate === 'string'
+        ? decrypted.endDate
+        : row.endDate.toISOString(),
+    color: typeof decrypted.color === 'string' ? decrypted.color : row.color,
+  }
+}
+
+function serializeCountdown(row: typeof calendarCountdowns.$inferSelect) {
+  const decrypted = decryptServerJson<Record<string, unknown>>(
+    row.encryptedData,
+    row.iv,
+    row.authTag,
+    countdownContext(row.userId, row.id),
+    {},
+  )
+  return {
+    ...decrypted,
+    id: row.id,
+    title:
+      typeof decrypted.title === 'string'
+        ? decrypted.title
+        : typeof decrypted.name === 'string'
+          ? decrypted.name
+          : row.title,
+    dueDate:
+      typeof decrypted.dueDate === 'string'
+        ? decrypted.dueDate
+        : typeof decrypted.date === 'string'
+          ? decrypted.date
+          : row.dueDate.toISOString(),
+    eventId:
+      typeof decrypted.eventId === 'string'
+        ? decrypted.eventId
+        : (row.eventId ?? ''),
+  }
+}
+
+function serializeSettings(
+  userId: string,
+  value: Record<string, unknown> | null | undefined,
+) {
+  const envelope = value as EncryptedSettingsEnvelope | null | undefined
+  if (envelope?.encryptedData && envelope.iv && envelope.authTag) {
+    return decryptServerJson<Record<string, unknown>>(
+      envelope.encryptedData,
+      envelope.iv,
+      envelope.authTag,
+      settingsContext(userId),
+      {},
+    )
+  }
+  return value ?? {}
 }
 
 function eventValues(userId: string, input: CalendarEventPayload) {
@@ -128,46 +264,117 @@ function eventValues(userId: string, input: CalendarEventPayload) {
     typeof input.calendarId === 'string' && input.calendarId
       ? input.calendarId
       : null
-  const extra = {
-    description: input.description ?? '',
-    location: input.location ?? '',
-    participants: Array.isArray(input.participants) ? input.participants : [],
-    notification:
-      typeof input.notification === 'number' ? input.notification : 0,
-    extensions: Object.fromEntries(
-      Object.entries(input).filter(
-        ([key]) =>
-          ![
-            'id',
-            'title',
-            'startDate',
-            'endDate',
-            'isAllDay',
-            'recurrence',
-            'calendarId',
-            'color',
-          ].includes(key),
-      ),
-    ),
-  }
-  const encrypted = encryptServerJson(extra, eventContext(userId, eventId))
+  const recurrence =
+    typeof input.recurrence === 'string' ? input.recurrence : 'none'
+  const color =
+    typeof input.color === 'string' && input.color ? input.color : '#3b82f6'
+  const encrypted = encryptServerJson(
+    {
+      ...input,
+      id: eventId,
+      title,
+      startDate: startDate.toISOString(),
+      endDate: endDate.toISOString(),
+      isAllDay: Boolean(input.isAllDay),
+      recurrence,
+      calendarId: calendarId ?? '',
+      color,
+      participants: Array.isArray(input.participants) ? input.participants : [],
+      notification:
+        typeof input.notification === 'number' ? input.notification : 0,
+      description: input.description ?? '',
+      location: input.location ?? '',
+    },
+    eventContext(userId, eventId),
+  )
   const now = new Date()
   return {
     id: eventId,
     userId,
-    title,
-    startDate,
-    endDate,
-    isAllDay: Boolean(input.isAllDay),
-    recurrence:
-      typeof input.recurrence === 'string' ? input.recurrence : 'none',
+    title: ENCRYPTED_TEXT_PLACEHOLDER,
+    startDate: ENCRYPTED_DATE_PLACEHOLDER,
+    endDate: ENCRYPTED_DATE_PLACEHOLDER,
+    isAllDay: false,
+    recurrence: 'none',
     calendarId,
-    color:
-      typeof input.color === 'string' && input.color ? input.color : '#3b82f6',
-    searchableText: [title, input.description, input.location]
-      .filter(Boolean)
-      .join(' ')
-      .toLowerCase(),
+    color: '#3b82f6',
+    searchableText: '',
+    ...encrypted,
+    createdAt: now,
+    updatedAt: now,
+  }
+}
+
+function settingsValues(userId: string, settings: Record<string, unknown>) {
+  return encryptServerJson(settings, settingsContext(userId))
+}
+
+function bookmarkValues(userId: string, input: CalendarBookmarkPayload) {
+  const bookmarkId = input.id || id('bmk')
+  const startDate = asDate(input.startDate)
+  const endDate = asDate(input.endDate, startDate)
+  const title = typeof input.title === 'string' ? input.title : 'Untitled event'
+  const color =
+    typeof input.color === 'string' && input.color ? input.color : '#3b82f6'
+  const encrypted = encryptServerJson(
+    {
+      ...input,
+      id: bookmarkId,
+      eventId: typeof input.eventId === 'string' ? input.eventId : bookmarkId,
+      title,
+      startDate: startDate.toISOString(),
+      endDate: endDate.toISOString(),
+      color,
+    },
+    bookmarkContext(userId, bookmarkId),
+  )
+  const now = new Date()
+  return {
+    id: bookmarkId,
+    userId,
+    eventId: typeof input.eventId === 'string' ? input.eventId : bookmarkId,
+    title: ENCRYPTED_TEXT_PLACEHOLDER,
+    startDate: ENCRYPTED_DATE_PLACEHOLDER,
+    endDate: ENCRYPTED_DATE_PLACEHOLDER,
+    color: '#3b82f6',
+    ...encrypted,
+    createdAt: now,
+    updatedAt: now,
+  }
+}
+
+function countdownValues(userId: string, input: CalendarCountdownPayload) {
+  const countdownId = input.id || id('cnt')
+  const dueDate = asDate(input.dueDate ?? input.date)
+  const title =
+    typeof input.title === 'string'
+      ? input.title
+      : typeof input.name === 'string'
+        ? input.name
+        : 'Untitled countdown'
+  const encrypted = encryptServerJson(
+    {
+      ...input,
+      id: countdownId,
+      title,
+      name: typeof input.name === 'string' ? input.name : title,
+      dueDate: dueDate.toISOString(),
+      date:
+        typeof input.date === 'string' || input.date instanceof Date
+          ? asDate(input.date).toISOString()
+          : dueDate.toISOString(),
+      eventId: typeof input.eventId === 'string' ? input.eventId : '',
+    },
+    countdownContext(userId, countdownId),
+  )
+  const now = new Date()
+  return {
+    id: countdownId,
+    userId,
+    title: ENCRYPTED_TEXT_PLACEHOLDER,
+    dueDate: ENCRYPTED_DATE_PLACEHOLDER,
+    eventId:
+      typeof input.eventId === 'string' && input.eventId ? input.eventId : null,
     ...encrypted,
     createdAt: now,
     updatedAt: now,
@@ -187,26 +394,15 @@ export const GET = withEvlog(async function GET(req: NextRequest) {
 
     const start = req.nextUrl.searchParams.get('start')
     const end = req.nextUrl.searchParams.get('end')
-    const where =
-      start && end
-        ? and(
-            eq(calendarBackups.userId, userId),
-            or(
-              and(
-                gte(calendarBackups.startDate, asDate(start)),
-                lte(calendarBackups.startDate, asDate(end)),
-              ),
-              and(
-                gte(calendarBackups.endDate, asDate(start)),
-                lte(calendarBackups.endDate, asDate(end)),
-              ),
-            ),
-          )
-        : eq(calendarBackups.userId, userId)
+    const rangeStart = start ? asDate(start) : null
+    const rangeEnd = end ? asDate(end) : null
 
     const [events, categories, settings, bookmarks, countdowns] =
       await Promise.all([
-        db.select().from(calendarBackups).where(where),
+        db
+          .select()
+          .from(calendarBackups)
+          .where(eq(calendarBackups.userId, userId)),
         db
           .select()
           .from(calendarCategories)
@@ -237,38 +433,23 @@ export const GET = withEvlog(async function GET(req: NextRequest) {
           : 'User exported calendar data',
     })
 
+    const serializedEvents = events.map(serializeEvent).filter((event) => {
+      if (!rangeStart || !rangeEnd) return true
+      const eventStart = asDate(event.startDate)
+      const eventEnd = asDate(event.endDate, eventStart)
+      return (
+        (eventStart >= rangeStart && eventStart <= rangeEnd) ||
+        (eventEnd >= rangeStart && eventEnd <= rangeEnd) ||
+        (eventStart <= rangeStart && eventEnd >= rangeEnd)
+      )
+    })
+
     return jsonNoStore({
-      events: events.map(serializeEvent),
+      events: serializedEvents,
       categories: categories.map(serializeCategory),
-      settings: settings[0]?.settings ?? {},
-      bookmarks: bookmarks.map((row) => ({
-        ...decryptServerJson(
-          row.encryptedData,
-          row.iv,
-          row.authTag,
-          bookmarkContext(row.userId, row.id),
-          {},
-        ),
-        id: row.id,
-        eventId: row.eventId,
-        title: row.title,
-        startDate: row.startDate.toISOString(),
-        endDate: row.endDate.toISOString(),
-        color: row.color,
-      })),
-      countdowns: countdowns.map((row) => ({
-        ...decryptServerJson(
-          row.encryptedData,
-          row.iv,
-          row.authTag,
-          countdownContext(row.userId, row.id),
-          {},
-        ),
-        id: row.id,
-        title: row.title,
-        dueDate: row.dueDate.toISOString(),
-        eventId: row.eventId ?? '',
-      })),
+      settings: serializeSettings(userId, settings[0]?.settings),
+      bookmarks: bookmarks.map(serializeBookmark),
+      countdowns: countdowns.map(serializeCountdown),
       backend: 'postgres',
     })
   } catch (e: unknown) {
@@ -295,6 +476,8 @@ export const POST = withEvlog(async function POST(req: NextRequest) {
           ? []
           : []
     const categories = Array.isArray(body?.categories) ? body.categories : []
+    const bookmarks = Array.isArray(body?.bookmarks) ? body.bookmarks : null
+    const countdowns = Array.isArray(body?.countdowns) ? body.countdowns : null
     const now = new Date()
 
     await db.transaction(async (tx) => {
@@ -332,16 +515,25 @@ export const POST = withEvlog(async function POST(req: NextRequest) {
       for (const category of categories as CalendarCategoryPayload[]) {
         const categoryId = category.id || id('cat')
         const encrypted = encryptServerJson(
-          { extensions: category },
+          {
+            ...category,
+            id: categoryId,
+            name:
+              typeof category.name === 'string' ? category.name : 'Untitled',
+            color:
+              typeof category.color === 'string' ? category.color : '#3b82f6',
+            keywords: Array.isArray(category.keywords) ? category.keywords : [],
+            position:
+              typeof category.position === 'number' ? category.position : 0,
+          },
           categoryContext(userId, categoryId),
         )
         const values = {
           id: categoryId,
           userId,
-          name: typeof category.name === 'string' ? category.name : 'Untitled',
-          color:
-            typeof category.color === 'string' ? category.color : '#3b82f6',
-          keywords: Array.isArray(category.keywords) ? category.keywords : [],
+          name: ENCRYPTED_TEXT_PLACEHOLDER,
+          color: '#3b82f6',
+          keywords: [],
           position:
             typeof category.position === 'number' ? category.position : 0,
           ...encrypted,
@@ -373,18 +565,44 @@ export const POST = withEvlog(async function POST(req: NextRequest) {
           })
       }
 
+      if (bookmarks) {
+        await tx
+          .delete(calendarBookmarks)
+          .where(eq(calendarBookmarks.userId, userId))
+        for (const bookmark of bookmarks as CalendarBookmarkPayload[]) {
+          await tx
+            .insert(calendarBookmarks)
+            .values(bookmarkValues(userId, bookmark))
+        }
+      }
+
+      if (countdowns) {
+        await tx
+          .delete(calendarCountdowns)
+          .where(eq(calendarCountdowns.userId, userId))
+        for (const countdown of countdowns as CalendarCountdownPayload[]) {
+          await tx
+            .insert(calendarCountdowns)
+            .values(countdownValues(userId, countdown))
+        }
+      }
+
       if (body?.settings && typeof body.settings === 'object') {
+        const encryptedSettings = settingsValues(
+          userId,
+          body.settings as Record<string, unknown>,
+        )
         await tx
           .insert(userSettings)
           .values({
             userId,
-            settings: body.settings,
+            settings: encryptedSettings,
             createdAt: now,
             updatedAt: now,
           })
           .onConflictDoUpdate({
             target: userSettings.userId,
-            set: { settings: body.settings, updatedAt: now },
+            set: { settings: encryptedSettings, updatedAt: now },
           })
       }
     })

--- a/app/api/blob/route.ts
+++ b/app/api/blob/route.ts
@@ -10,11 +10,20 @@ import {
   userSettings,
 } from '@/lib/drizzle/schema'
 import { and, eq } from 'drizzle-orm'
-import { decryptServerJson, encryptServerJson } from '@/lib/server-crypto'
+import {
+  decryptServerJson,
+  encryptServerJson,
+  hashServerSearchText,
+  validateBackupSalt,
+} from '@/lib/server-crypto'
 import { randomUUID } from 'crypto'
 
 export const runtime = 'nodejs'
 export const dynamic = 'force-dynamic'
+
+function ensureBackupCryptoConfigured() {
+  validateBackupSalt()
+}
 
 const NO_STORE_HEADERS = {
   'Cache-Control': 'no-store, no-cache, must-revalidate',
@@ -268,6 +277,11 @@ function eventValues(userId: string, input: CalendarEventPayload) {
     typeof input.recurrence === 'string' ? input.recurrence : 'none'
   const color =
     typeof input.color === 'string' && input.color ? input.color : '#3b82f6'
+  const searchableText = hashServerSearchText([
+    title,
+    input.description,
+    input.location,
+  ])
   const encrypted = encryptServerJson(
     {
       ...input,
@@ -298,7 +312,7 @@ function eventValues(userId: string, input: CalendarEventPayload) {
     recurrence: 'none',
     calendarId,
     color: '#3b82f6',
-    searchableText: '',
+    searchableText,
     ...encrypted,
     createdAt: now,
     updatedAt: now,
@@ -392,6 +406,8 @@ export const GET = withEvlog(async function GET(req: NextRequest) {
       return jsonNoStore({ error: 'Unauthorized' }, { status: 401 })
     }
 
+    ensureBackupCryptoConfigured()
+
     const start = req.nextUrl.searchParams.get('start')
     const end = req.nextUrl.searchParams.get('end')
     const rangeStart = start ? asDate(start) : null
@@ -467,6 +483,8 @@ export const POST = withEvlog(async function POST(req: NextRequest) {
 
     if (!userId)
       return NextResponse.json({ error: 'Unauthorized' }, { status: 401 })
+
+    ensureBackupCryptoConfigured()
 
     const events = Array.isArray(body?.events)
       ? body.events

--- a/app/api/share/list/route.ts
+++ b/app/api/share/list/route.ts
@@ -4,8 +4,34 @@ import { getServerSession } from '@/lib/auth/server'
 import { db } from '@/lib/drizzle/client'
 import { calendarBackups, shares } from '@/lib/drizzle/schema'
 import { desc, eq } from 'drizzle-orm'
+import { decryptServerJson } from '@/lib/server-crypto'
 
 export const runtime = 'nodejs'
+
+function eventContext(userId: string, eventId: string) {
+  return `calendar-event:${userId}:${eventId}`
+}
+
+function eventTitle(row: {
+  userId: string | null
+  eventId: string | null
+  title: string | null
+  encryptedData: string | null
+  iv: string | null
+  authTag: string | null
+}) {
+  if (!row.userId || !row.eventId) return ''
+  const decrypted = decryptServerJson<Record<string, unknown>>(
+    row.encryptedData,
+    row.iv,
+    row.authTag,
+    eventContext(row.userId, row.eventId),
+    {},
+  )
+  return typeof decrypted.title === 'string'
+    ? decrypted.title
+    : (row.title ?? '')
+}
 
 export const GET = withEvlog(async function GET(_req: NextRequest) {
   const log = useLogger()
@@ -30,6 +56,10 @@ export const GET = withEvlog(async function GET(_req: NextRequest) {
       isBurn: shares.isBurn,
       updatedAt: shares.updatedAt,
       title: calendarBackups.title,
+      userId: calendarBackups.userId,
+      encryptedData: calendarBackups.encryptedData,
+      iv: calendarBackups.iv,
+      authTag: calendarBackups.authTag,
     })
     .from(shares)
     .leftJoin(calendarBackups, eq(shares.eventId, calendarBackups.id))
@@ -39,8 +69,8 @@ export const GET = withEvlog(async function GET(_req: NextRequest) {
   const shareList = result.map((row) => ({
     id: row.shareId,
     eventId: row.eventId ?? '',
-    eventTitle: row.title ?? '',
-    sharedBy: user.id,
+    eventTitle: eventTitle(row),
+    sharedBy: user.name,
     shareDate: row.updatedAt.toISOString(),
     shareLink: `/share/${row.shareId}`,
     isProtected: row.isProtected,

--- a/app/api/share/route.ts
+++ b/app/api/share/route.ts
@@ -102,6 +102,7 @@ export const POST = withEvlog(async function POST(request: NextRequest) {
       return NextResponse.json({ error: 'Event not found' }, { status: 404 })
 
     const hasPassword = typeof password === 'string' && password.length > 0
+    const passwordHash = hasPassword ? await hash(password, 12) : null
     const now = new Date()
     await db
       .insert(shares)
@@ -109,7 +110,7 @@ export const POST = withEvlog(async function POST(request: NextRequest) {
         userId: user.id,
         shareId,
         eventId: targetEventId,
-        passwordHash: hasPassword ? await hash(password, 12) : null,
+        passwordHash,
         isProtected: hasPassword,
         isBurn: Boolean(burnAfterRead),
         createdAt: now,
@@ -120,7 +121,7 @@ export const POST = withEvlog(async function POST(request: NextRequest) {
         set: {
           userId: user.id,
           eventId: targetEventId,
-          passwordHash: hasPassword ? await hash(password, 12) : null,
+          passwordHash,
           isProtected: hasPassword,
           isBurn: Boolean(burnAfterRead),
           updatedAt: now,

--- a/app/api/share/route.ts
+++ b/app/api/share/route.ts
@@ -2,7 +2,7 @@ import { type NextRequest, NextResponse } from 'next/server'
 import { withEvlog, useLogger, getAuditActor } from '@/lib/evlog'
 import { getServerSession } from '@/lib/auth/server'
 import { db } from '@/lib/drizzle/client'
-import { calendarBackups, shares } from '@/lib/drizzle/schema'
+import { calendarBackups, shares, user as users } from '@/lib/drizzle/schema'
 import { and, eq } from 'drizzle-orm'
 import { compare, hash } from 'bcryptjs'
 import { randomUUID } from 'crypto'
@@ -14,25 +14,48 @@ function eventContext(userId: string, eventId: string) {
   return `calendar-event:${userId}:${eventId}`
 }
 
-function serializeEvent(row: typeof calendarBackups.$inferSelect) {
-  const extra = decryptServerJson<Record<string, unknown>>(
+function serializeEvent(
+  row: typeof calendarBackups.$inferSelect,
+  sharedBy: string,
+) {
+  const decrypted = decryptServerJson<Record<string, unknown>>(
     row.encryptedData,
     row.iv,
     row.authTag,
     eventContext(row.userId, row.id),
     {},
   )
+  const legacyExtensions =
+    decrypted.extensions && typeof decrypted.extensions === 'object'
+      ? (decrypted.extensions as Record<string, unknown>)
+      : {}
   return {
-    ...extra,
+    ...legacyExtensions,
+    ...decrypted,
     id: row.id,
-    title: row.title,
-    startDate: row.startDate.toISOString(),
-    endDate: row.endDate.toISOString(),
-    isAllDay: row.isAllDay,
-    recurrence: row.recurrence,
-    color: row.color,
-    calendarId: row.calendarId ?? '',
-    sharedBy: row.userId,
+    title: typeof decrypted.title === 'string' ? decrypted.title : row.title,
+    startDate:
+      typeof decrypted.startDate === 'string'
+        ? decrypted.startDate
+        : row.startDate.toISOString(),
+    endDate:
+      typeof decrypted.endDate === 'string'
+        ? decrypted.endDate
+        : row.endDate.toISOString(),
+    isAllDay:
+      typeof decrypted.isAllDay === 'boolean'
+        ? decrypted.isAllDay
+        : row.isAllDay,
+    recurrence:
+      typeof decrypted.recurrence === 'string'
+        ? decrypted.recurrence
+        : row.recurrence,
+    color: typeof decrypted.color === 'string' ? decrypted.color : row.color,
+    calendarId:
+      typeof decrypted.calendarId === 'string'
+        ? decrypted.calendarId
+        : (row.calendarId ?? ''),
+    sharedBy,
   }
 }
 
@@ -173,11 +196,15 @@ export const GET = withEvlog(async function GET(request: NextRequest) {
           ),
         )
       if (!event) return { status: 404 as const }
+      const [owner] = await tx
+        .select({ name: users.name })
+        .from(users)
+        .where(eq(users.id, share.userId))
       if (share.isBurn) await tx.delete(shares).where(eq(shares.shareId, id))
 
       return {
         status: 200 as const,
-        data: JSON.stringify(serializeEvent(event)),
+        data: JSON.stringify(serializeEvent(event, owner?.name ?? 'Unknown')),
         timestamp: share.updatedAt.toISOString(),
         protected: share.isProtected,
         burnAfterRead: share.isBurn,

--- a/components/app/calendar.tsx
+++ b/components/app/calendar.tsx
@@ -221,6 +221,8 @@ export default function Calendar({ className, ...props }: CalendarProps) {
   }, [defaultView])
 
   useEffect(() => {
+    if (!backupEnabled || !isSignedIn) return
+
     const timeoutId = window.setTimeout(() => {
       void fetch('/api/blob', {
         method: 'POST',
@@ -240,8 +242,10 @@ export default function Calendar({ className, ...props }: CalendarProps) {
     }, 400)
     return () => window.clearTimeout(timeoutId)
   }, [
+    backupEnabled,
     defaultView,
     enableShortcuts,
+    isSignedIn,
     normalizedFirstDayOfWeek,
     notificationSound,
     timeFormat,

--- a/components/app/calendar.tsx
+++ b/components/app/calendar.tsx
@@ -138,6 +138,9 @@ export default function Calendar({ className, ...props }: CalendarProps) {
   const { events, setEvents, calendars, loadRange, saveEvents, deleteEvent } =
     useCalendar()
   const [searchTerm, setSearchTerm] = useState('')
+  const [focusedSearchEventId, setFocusedSearchEventId] = useState<
+    string | null
+  >(null)
   const searchInputRef = useRef<HTMLDivElement>(null)
   const [isSearchFocused, setIsSearchFocused] = useState(false)
   const [selectedCategoryFilters, setSelectedCategoryFilters] = useState<
@@ -216,6 +219,35 @@ export default function Calendar({ className, ...props }: CalendarProps) {
   useEffect(() => {
     setView(isCalendarView(defaultView) ? defaultView : 'week')
   }, [defaultView])
+
+  useEffect(() => {
+    const timeoutId = window.setTimeout(() => {
+      void fetch('/api/blob', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({
+          settings: {
+            'first-day-of-week': normalizedFirstDayOfWeek,
+            timezone,
+            'notification-sound': notificationSound,
+            'default-view': defaultView,
+            'enable-shortcuts': enableShortcuts,
+            'time-format': timeFormat,
+            'toast-position': toastPosition,
+          },
+        }),
+      }).catch(() => undefined)
+    }, 400)
+    return () => window.clearTimeout(timeoutId)
+  }, [
+    defaultView,
+    enableShortcuts,
+    normalizedFirstDayOfWeek,
+    notificationSound,
+    timeFormat,
+    timezone,
+    toastPosition,
+  ])
 
   useEffect(() => {
     const applyRestoredPreferences = () => {
@@ -477,6 +509,18 @@ export default function Calendar({ className, ...props }: CalendarProps) {
     setPreviewOpen(true)
   }
 
+  const jumpToSearchResult = (event: CalendarEvent) => {
+    const eventDate = new Date(event.startDate)
+    setDate(eventDate)
+    setSidebarDate(eventDate)
+    setFocusedSearchEventId(event.id)
+    setSearchTerm(event.title || t.unnamedEvent)
+    setIsSearchFocused(false)
+    setPreviewOpen(false)
+    setPreviewEvent(null)
+    setPreviewAnchorRect(null)
+  }
+
   const handleEventAdd = (event: CalendarEvent) => {
     const newEvent = {
       ...event,
@@ -690,6 +734,12 @@ export default function Calendar({ className, ...props }: CalendarProps) {
   }, [events, selectedCategoryFilters, calendars])
 
   const filteredEvents = useMemo(() => {
+    if (focusedSearchEventId) {
+      return eventsByCategory.filter(
+        (event) => event.id === focusedSearchEventId,
+      )
+    }
+
     const keyword = searchTerm.trim().toLowerCase()
     if (!keyword) return eventsByCategory
 
@@ -708,12 +758,28 @@ export default function Calendar({ className, ...props }: CalendarProps) {
         (a, b) =>
           new Date(a.startDate).getTime() - new Date(b.startDate).getTime(),
       )
-  }, [eventsByCategory, searchTerm])
+  }, [eventsByCategory, focusedSearchEventId, searchTerm])
 
   const searchResultEvents = useMemo(() => {
-    if (!searchTerm.trim()) return []
-    return filteredEvents.slice(0, 8)
-  }, [filteredEvents, searchTerm])
+    const keyword = searchTerm.trim().toLowerCase()
+    if (!keyword) return []
+    return eventsByCategory
+      .filter((event) => {
+        const title = event.title?.toLowerCase() || ''
+        const location = event.location?.toLowerCase() || ''
+        const description = event.description?.toLowerCase() || ''
+        return (
+          title.includes(keyword) ||
+          location.includes(keyword) ||
+          description.includes(keyword)
+        )
+      })
+      .sort(
+        (a, b) =>
+          new Date(a.startDate).getTime() - new Date(b.startDate).getTime(),
+      )
+      .slice(0, 8)
+  }, [eventsByCategory, searchTerm])
 
   useEffect(() => {
     if (!notificationsInitializedRef.current) {
@@ -850,24 +916,20 @@ export default function Calendar({ className, ...props }: CalendarProps) {
                     onBlur={() => {
                       window.setTimeout(() => setIsSearchFocused(false), 120)
                     }}
-                    onChange={(e) => setSearchTerm(e.target.value)}
+                    onChange={(e) => {
+                      setFocusedSearchEventId(null)
+                      setSearchTerm(e.target.value)
+                    }}
                     onKeyDown={(e) => {
                       if (e.key === 'Enter' && searchResultEvents.length > 0) {
-                        setPreviewEvent(searchResultEvents[0])
-                        setPreviewAnchorRect(
-                          searchInputRef.current?.getBoundingClientRect() ??
-                            null,
-                        )
-                        setPreviewOpen(true)
-                        setSearchTerm('')
-                        setIsSearchFocused(false)
+                        jumpToSearchResult(searchResultEvents[0])
                       }
                     }}
                     className="pr-4"
                   />
                 </InputGroup>
                 {isSearchFocused && !!searchTerm && (
-                  <div className="absolute right-0 top-[calc(100%+6px)] w-72 rounded-md border bg-popover p-1 shadow-md z-50">
+                  <div className="absolute right-0 top-[calc(100%+6px)] w-80 overflow-hidden rounded-xl border bg-popover p-1.5 shadow-xl z-50">
                     {searchResultEvents.length > 0 ? (
                       <ScrollArea className="max-h-[320px]">
                         <div className="space-y-1">
@@ -875,25 +937,31 @@ export default function Calendar({ className, ...props }: CalendarProps) {
                             <button
                               key={event.id}
                               type="button"
-                              className="w-full cursor-pointer rounded-sm px-2 py-1.5 text-left hover:bg-accent"
+                              className="w-full cursor-pointer rounded-lg px-3 py-2 text-left transition-colors hover:bg-accent focus:bg-accent focus:outline-none"
                               onMouseDown={(e) => {
                                 e.preventDefault()
-                                setPreviewEvent(event)
-                                setPreviewAnchorRect(
-                                  searchInputRef.current?.getBoundingClientRect() ??
-                                    null,
-                                )
-                                setPreviewOpen(true)
-                                setSearchTerm('')
-                                setIsSearchFocused(false)
+                                jumpToSearchResult(event)
                               }}
                             >
-                              <div className="font-medium leading-none">
+                              <div className="truncate font-medium leading-none">
                                 {event.title || t.unnamedEvent}
                               </div>
-                              <div className="text-xs text-muted-foreground mt-1">
-                                {formatDateDisplay(new Date(event.startDate))}
+                              <div className="mt-1 text-xs text-muted-foreground">
+                                {new Date(event.startDate).toLocaleString(
+                                  language,
+                                  {
+                                    month: 'short',
+                                    day: 'numeric',
+                                    hour: '2-digit',
+                                    minute: '2-digit',
+                                  },
+                                )}
                               </div>
+                              {event.location ? (
+                                <div className="mt-1 truncate text-xs text-muted-foreground/80">
+                                  {event.location}
+                                </div>
+                              ) : null}
                             </button>
                           ))}
                         </div>
@@ -907,13 +975,17 @@ export default function Calendar({ className, ...props }: CalendarProps) {
                 )}
               </div>
               {backupEnabled ? (
-                <div
-                  className="inline-flex h-8 w-8 items-center justify-center rounded-full border"
+                <Button
+                  type="button"
+                  variant="outline"
+                  size="icon"
+                  className="rounded-full h-8 w-8"
                   title="Backup status"
                   aria-label="Backup status"
+                  onClick={() => handleUserProfileSectionNavigate('backup')}
                 >
                   {backupStatusIcon ?? <CloudUpload className="h-4 w-4" />}
-                </div>
+                </Button>
               ) : null}
               <DropdownMenu>
                 <DropdownMenuTrigger asChild>

--- a/components/app/profile/user-profile-button.tsx
+++ b/components/app/profile/user-profile-button.tsx
@@ -670,14 +670,49 @@ export default function UserProfileButton({
   }
 
   async function enableServerBackup() {
-    const [events, categories] = await Promise.all([
+    const [
+      events,
+      categories,
+      bookmarks,
+      countdowns,
+      firstDayOfWeek,
+      timezone,
+      notificationSound,
+      defaultView,
+      enableShortcuts,
+      timeFormat,
+      toastPosition,
+    ] = await Promise.all([
       readEncryptedLocalStorage('calendar-events', []),
       readEncryptedLocalStorage('calendar-categories', []),
+      readEncryptedLocalStorage('bookmarked-events', []),
+      readEncryptedLocalStorage('countdowns', []),
+      readEncryptedLocalStorage('first-day-of-week', 0),
+      readEncryptedLocalStorage(
+        'timezone',
+        Intl.DateTimeFormat().resolvedOptions().timeZone,
+      ),
+      readEncryptedLocalStorage('notification-sound', 'telegram'),
+      readEncryptedLocalStorage('default-view', 'week'),
+      readEncryptedLocalStorage('enable-shortcuts', true),
+      readEncryptedLocalStorage('time-format', '24h'),
+      readEncryptedLocalStorage('toast-position', 'bottom-right'),
     ])
     await apiPost({
       events,
       categories,
-      settings: { backupMode: 'server-managed' },
+      bookmarks,
+      countdowns,
+      settings: {
+        backupMode: 'server-managed',
+        'first-day-of-week': firstDayOfWeek,
+        timezone,
+        'notification-sound': notificationSound,
+        'default-view': defaultView,
+        'enable-shortcuts': enableShortcuts,
+        'time-format': timeFormat,
+        'toast-position': toastPosition,
+      },
     })
     localStorage.setItem(AUTO_KEY, 'true')
     restoredRef.current = true

--- a/components/providers/calendar-context.tsx
+++ b/components/providers/calendar-context.tsx
@@ -87,6 +87,17 @@ function rangeKey(range: DateRange) {
   return `${range.start.toISOString()}..${range.end.toISOString()}`
 }
 
+async function syncAuxiliaryBackupData(key: string) {
+  if (key !== 'bookmarked-events' && key !== 'countdowns') return
+  const payloadKey = key === 'bookmarked-events' ? 'bookmarks' : 'countdowns'
+  const data = await readEncryptedLocalStorage<unknown[]>(key, [])
+  await fetch('/api/blob', {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify({ [payloadKey]: data }),
+  }).catch(() => undefined)
+}
+
 const useCalendarStore = create<CalendarState>()((set) => ({
   calendars: [],
   events: [],
@@ -177,6 +188,19 @@ export function CalendarProvider({ children }: { children: React.ReactNode }) {
       if (Array.isArray(payload.categories)) {
         setCalendars(payload.categories)
       }
+      if (Array.isArray(payload.bookmarks)) {
+        void writeEncryptedLocalStorage('bookmarked-events', payload.bookmarks)
+      }
+      if (Array.isArray(payload.countdowns)) {
+        void writeEncryptedLocalStorage('countdowns', payload.countdowns)
+      }
+      if (payload.settings && typeof payload.settings === 'object') {
+        await Promise.all(
+          Object.entries(payload.settings).map(([key, value]) =>
+            writeEncryptedLocalStorage(key, value),
+          ),
+        )
+      }
     },
     [setCalendars, setEvents],
   )
@@ -219,6 +243,22 @@ export function CalendarProvider({ children }: { children: React.ReactNode }) {
     if (!hydratedRef.current) return
     void writeEncryptedLocalStorage('calendar-events', events)
   }, [events])
+
+  useEffect(() => {
+    const handleLocalStorageWrite = (event: CustomEvent<{ key: string }>) => {
+      void syncAuxiliaryBackupData(event.detail?.key)
+    }
+    window.addEventListener(
+      'local-storage-written',
+      handleLocalStorageWrite as EventListener,
+    )
+    return () => {
+      window.removeEventListener(
+        'local-storage-written',
+        handleLocalStorageWrite as EventListener,
+      )
+    }
+  }, [])
 
   return (
     <CalendarContextBridge

--- a/components/providers/calendar-context.tsx
+++ b/components/providers/calendar-context.tsx
@@ -83,18 +83,40 @@ function mergeEvents(current: CalendarEvent[], incoming: CalendarEvent[]) {
   )
 }
 
+const MAX_LOADED_RANGE_KEYS = 48
+const AUXILIARY_BACKUP_DEBOUNCE_MS = 600
+
 function rangeKey(range: DateRange) {
   return `${range.start.toISOString()}..${range.end.toISOString()}`
 }
 
-async function syncAuxiliaryBackupData(key: string) {
-  if (key !== 'bookmarked-events' && key !== 'countdowns') return
-  const payloadKey = key === 'bookmarked-events' ? 'bookmarks' : 'countdowns'
-  const data = await readEncryptedLocalStorage<unknown[]>(key, [])
+function rememberLoadedRange(loadedRanges: Set<string>, key: string) {
+  if (loadedRanges.has(key)) return true
+  loadedRanges.add(key)
+  while (loadedRanges.size > MAX_LOADED_RANGE_KEYS) {
+    const oldestKey = loadedRanges.keys().next().value
+    if (!oldestKey) break
+    loadedRanges.delete(oldestKey)
+  }
+  return false
+}
+
+async function syncAuxiliaryBackupData(keys: Iterable<string>) {
+  if (typeof window === 'undefined') return
+  if (window.localStorage.getItem('auto-backup-enabled') !== 'true') return
+
+  const payload: Record<string, unknown[]> = {}
+  for (const key of keys) {
+    if (key !== 'bookmarked-events' && key !== 'countdowns') continue
+    const payloadKey = key === 'bookmarked-events' ? 'bookmarks' : 'countdowns'
+    payload[payloadKey] = await readEncryptedLocalStorage<unknown[]>(key, [])
+  }
+  if (Object.keys(payload).length === 0) return
+
   await fetch('/api/blob', {
     method: 'POST',
     headers: { 'Content-Type': 'application/json' },
-    body: JSON.stringify({ [payloadKey]: data }),
+    body: JSON.stringify(payload),
   }).catch(() => undefined)
 }
 
@@ -159,6 +181,10 @@ export function CalendarProvider({ children }: { children: React.ReactNode }) {
   const setEvents = useCalendarStore((state) => state.setEvents)
   const loadedRangesRef = useRef(new Set<string>())
   const hydratedRef = useRef(false)
+  const pendingAuxiliaryBackupKeysRef = useRef(new Set<string>())
+  const auxiliaryBackupTimeoutRef = useRef<ReturnType<
+    typeof setTimeout
+  > | null>(null)
 
   const saveEvents = useCallback(async (nextEvents: CalendarEvent[]) => {
     await fetch('/api/blob', {
@@ -171,8 +197,7 @@ export function CalendarProvider({ children }: { children: React.ReactNode }) {
   const loadRange = useCallback(
     async (range: DateRange) => {
       const key = rangeKey(range)
-      if (loadedRangesRef.current.has(key)) return
-      loadedRangesRef.current.add(key)
+      if (rememberLoadedRange(loadedRangesRef.current, key)) return
       const params = new URLSearchParams({
         start: range.start.toISOString(),
         end: range.end.toISOString(),
@@ -245,8 +270,23 @@ export function CalendarProvider({ children }: { children: React.ReactNode }) {
   }, [events])
 
   useEffect(() => {
+    const flushAuxiliaryBackup = () => {
+      auxiliaryBackupTimeoutRef.current = null
+      const keys = Array.from(pendingAuxiliaryBackupKeysRef.current)
+      pendingAuxiliaryBackupKeysRef.current.clear()
+      void syncAuxiliaryBackupData(keys)
+    }
     const handleLocalStorageWrite = (event: CustomEvent<{ key: string }>) => {
-      void syncAuxiliaryBackupData(event.detail?.key)
+      const key = event.detail?.key
+      if (key !== 'bookmarked-events' && key !== 'countdowns') return
+      pendingAuxiliaryBackupKeysRef.current.add(key)
+      if (auxiliaryBackupTimeoutRef.current) {
+        clearTimeout(auxiliaryBackupTimeoutRef.current)
+      }
+      auxiliaryBackupTimeoutRef.current = setTimeout(
+        flushAuxiliaryBackup,
+        AUXILIARY_BACKUP_DEBOUNCE_MS,
+      )
     }
     window.addEventListener(
       'local-storage-written',
@@ -257,6 +297,9 @@ export function CalendarProvider({ children }: { children: React.ReactNode }) {
         'local-storage-written',
         handleLocalStorageWrite as EventListener,
       )
+      if (auxiliaryBackupTimeoutRef.current) {
+        clearTimeout(auxiliaryBackupTimeoutRef.current)
+      }
     }
   }, [])
 

--- a/hooks/useLocalStorage.ts
+++ b/hooks/useLocalStorage.ts
@@ -150,6 +150,11 @@ export function useLocalStorage<T>(key: string, initialValue: T) {
     JSON.stringify(initialValue),
   )
   const localWriteVersionRef = useRef(0)
+  const initialValueRef = useRef(initialValue)
+
+  useEffect(() => {
+    initialValueRef.current = initialValue
+  }, [initialValue])
 
   const updateStoredValue = (value: SetStateAction<T>) => {
     localWriteVersionRef.current += 1
@@ -159,7 +164,7 @@ export function useLocalStorage<T>(key: string, initialValue: T) {
   useEffect(() => {
     let cancelled = false
     const writeVersionWhenReadStarted = localWriteVersionRef.current
-    readLocalStorage(key, initialValue).then((value) => {
+    readLocalStorage(key, initialValueRef.current).then((value) => {
       if (cancelled) return
       if (localWriteVersionRef.current !== writeVersionWhenReadStarted) return
       setStoredValue(value)
@@ -176,7 +181,7 @@ export function useLocalStorage<T>(key: string, initialValue: T) {
     ) => {
       const changedKey = 'key' in event ? event.key : event.detail?.key
       if (changedKey !== key) return
-      void readLocalStorage(key, initialValue).then((value) => {
+      void readLocalStorage(key, initialValueRef.current).then((value) => {
         setStoredValue(value)
         setSerializedValue(JSON.stringify(value))
       })

--- a/lib/server-crypto.ts
+++ b/lib/server-crypto.ts
@@ -2,6 +2,15 @@ import crypto from 'crypto'
 
 const ALGORITHM = 'aes-256-gcm'
 
+export class BackupCryptoConfigurationError extends Error {
+  constructor() {
+    super(
+      'Missing BACKUP_SALT. Configure BACKUP_SALT to enable encrypted calendar backups.',
+    )
+    this.name = 'BackupCryptoConfigurationError'
+  }
+}
+
 export type ServerEncryptedPayload = {
   encryptedData: string
   iv: string
@@ -10,8 +19,35 @@ export type ServerEncryptedPayload = {
 
 function getBackupSalt() {
   const salt = process.env.BACKUP_SALT
-  if (!salt) throw new Error('Missing BACKUP_SALT')
+  if (!salt) throw new BackupCryptoConfigurationError()
   return salt
+}
+
+export function validateBackupSalt() {
+  return getBackupSalt()
+}
+
+export function hashServerSearchText(values: unknown[]) {
+  const normalizedValues = values
+    .filter((value): value is string => typeof value === 'string')
+    .map((value) => value.trim().toLowerCase())
+    .filter(Boolean)
+  const normalizedText = normalizedValues.join(' ')
+  const tokens = new Set([
+    normalizedText,
+    ...normalizedText.split(/\s+/u).filter(Boolean),
+  ])
+
+  return Array.from(tokens)
+    .map((token) =>
+      crypto
+        .createHash('sha256')
+        .update(getBackupSalt(), 'utf8')
+        .update(':search:')
+        .update(token, 'utf8')
+        .digest('hex'),
+    )
+    .join(' ')
 }
 
 function keyForContext(context: string) {


### PR DESCRIPTION
### Motivation
- Prevent sensitive calendar data from being written to database plaintext by moving event/category/bookmark/countdown/settings content into server-side AES-256-GCM encrypted blobs keyed by `BACKUP_SALT`.
- Ensure auxiliary data (bookmarks, countdowns, categories and user settings) are actually persisted to and restored from the backup API.
- Make backup status UI actionable and improve share/search UX by showing share owner names and jumping to the event period on search selection.

### Description
- Server-side: encrypt payloads for events, categories, bookmarks, countdowns and settings with `encryptServerJson` and store the encrypted blob (`encryptedData`, `iv`, `authTag`) while replacing sensitive DB columns with placeholders; add `serialize*` helpers to decrypt and merge legacy fields for read paths in `app/api/blob/route.ts`.
- Backup API: `GET /api/blob` now returns decrypted categories, bookmarks, countdowns and settings (with compatibility fallback) and filters events by requested range, while `POST /api/blob` accepts and upserts `bookmarks` and `countdowns` and stores encrypted `settings`.
- Share endpoints: `app/api/share/route.ts` and `app/api/share/list/route.ts` now resolve the share owner display name and decrypt event title from the encrypted payload for display instead of returning a `userId`.
- Frontend provider: `components/providers/calendar-context.tsx` restores bookmarks/countdowns/settings from the cloud response, writes them back to local storage, and listens for local write events to sync auxiliary data to the server via `syncAuxiliaryBackupData`.
- UI changes: `components/app/profile/user-profile-button.tsx` includes bookmarks/countdowns and key settings when enabling server backup; `components/app/calendar.tsx` makes the backup status icon clickable (navigates to the backup section), improves the search dropdown styling, and changes selection behavior so click or Enter jumps to the event's date range and limits the view to that event instead of opening the event preview.

### Testing
- Type-check: `npx tsc --noEmit --pretty false` completed successfully.
- Formatting: `npx prettier --write app/api/blob/route.ts app/api/share/route.ts app/api/share/list/route.ts components/providers/calendar-context.tsx components/app/calendar.tsx components/app/profile/user-profile-button.tsx` ran and fixed formatting issues.
- Pre-commit linters ran as part of the commit workflow (`oxlint --fix` and `eslint --fix`) and completed without blocking the commit.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a22f97d9580832cb03746b3e2382006)

## Summary by Sourcery

对日历备份数据进行静态加密，并扩展备份/恢复范围以包含辅助数据和用户设置，同时改进搜索和备份相关的界面行为。

New Features:
- 通过日历备份 API 持久化并恢复书签、倒计时以及用户设置。
- 允许在日历搜索结果中直接跳转到事件的时间范围，并将视图聚焦到所选事件。
- 在共享列表和详情响应中包含共享拥有者的显示名称以及解密后的事件标题。

Bug Fixes:
- 确保书签、倒计时、类别和设置等辅助日历数据在本地存储与服务器备份之间保持同步。

Enhancements:
- 在服务器端使用基于 AES 的辅助工具对事件、类别、书签、倒计时和设置的负载进行加密，并在明文字段中仅存储占位符。
- 为备份事件导出添加范围感知过滤，仅返回请求日期窗口内的结果。
- 当 UI 中的关键日历设置发生更改时，自动将其同步到服务器，并在启用服务器备份时一并纳入备份。
- 优化日历搜索下拉框的样式和内容，以展示更多与结果相关的上下文信息，并将备份状态图标改为可点击的控件，用于导航至备份设置区域。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Encrypt calendar backup data at rest and expand backup/restore coverage to include auxiliary data and user settings while improving search and backup UI behavior.

New Features:
- Persist and restore bookmarks, countdowns, and user settings via the calendar backup API.
- Allow search results in the calendar to jump directly to an event's time range and focus the view on the selected event.
- Include share owner display names and decrypted event titles in share listing and detail responses.

Bug Fixes:
- Ensure auxiliary calendar data like bookmarks, countdowns, categories, and settings are synchronized between local storage and server backups.

Enhancements:
- Encrypt event, category, bookmark, countdown, and settings payloads server-side using AES-backed helpers while storing only placeholders in plaintext columns.
- Add range-aware filtering to backup event exports to limit results to the requested date window.
- Automatically sync key calendar settings to the server when they change in the UI and include them when enabling server backups.
- Refine calendar search dropdown styling and content to show more contextual information for results, and exclude backup status icon into a clickable control that navigates to the backup section.

</details>