### PR TITLE
fix: restore UI component compatibility

### DIFF
--- a/components/app/views/day-view.tsx
+++ b/components/app/views/day-view.tsx
@@ -24,7 +24,7 @@ const ContextMenuTrigger = ({
 }) => <>{children}</>
 const ContextMenuContent = ({
   children,
-  className,
+  className: _className,
 }: {
   children: React.ReactNode
   className?: string
@@ -52,6 +52,7 @@ interface DayViewProps {
     newStartDate: Date,
     newEndDate: Date,
   ) => void
+  onBackToCalendar?: () => void
 }
 
 export default function DayView({

--- a/components/ui/alert-dialog.tsx
+++ b/components/ui/alert-dialog.tsx
@@ -1,8 +1,9 @@
 "use client";
 
 import { AlertDialog as AlertDialogPrimitive } from "@base-ui/react/alert-dialog";
-import type React from "react";
+import * as React from "react";
 import { cn } from "@/lib/utils";
+import { Button } from "@/components/ui/button";
 
 export const AlertDialogCreateHandle: typeof AlertDialogPrimitive.createHandle =
   AlertDialogPrimitive.createHandle;
@@ -157,6 +158,24 @@ export function AlertDialogClose(
 ): React.ReactElement {
   return (
     <AlertDialogPrimitive.Close data-slot="alert-dialog-close" {...props} />
+  );
+}
+
+type AlertDialogButtonProps = AlertDialogPrimitive.Close.Props & React.ComponentProps<typeof Button>;
+
+export function AlertDialogAction({ children, ...props }: AlertDialogButtonProps): React.ReactElement {
+  return (
+    <AlertDialogClose render={<Button {...props} />}>
+      {children}
+    </AlertDialogClose>
+  );
+}
+
+export function AlertDialogCancel({ children, ...props }: AlertDialogButtonProps): React.ReactElement {
+  return (
+    <AlertDialogClose render={<Button variant="outline" {...props} />}>
+      {children}
+    </AlertDialogClose>
   );
 }
 

--- a/components/ui/button.tsx
+++ b/components/ui/button.tsx
@@ -3,7 +3,7 @@
 import { mergeProps } from "@base-ui/react/merge-props";
 import { useRender } from "@base-ui/react/use-render";
 import { cva, type VariantProps } from "class-variance-authority";
-import type * as React from "react";
+import * as React from "react";
 import { cn } from "@/lib/utils";
 import { Spinner } from "@/components/ui/spinner";
 
@@ -49,6 +49,7 @@ export const buttonVariants = cva(
 );
 
 export interface ButtonProps extends useRender.ComponentProps<"button"> {
+  asChild?: boolean;
   variant?: VariantProps<typeof buttonVariants>["variant"];
   size?: VariantProps<typeof buttonVariants>["size"];
   loading?: boolean;
@@ -59,6 +60,7 @@ export function Button({
   variant,
   size,
   render,
+  asChild = false,
   children,
   loading = false,
   disabled: disabledProp,
@@ -68,10 +70,17 @@ export function Button({
   const typeValue: React.ButtonHTMLAttributes<HTMLButtonElement>["type"] =
     render ? undefined : "button";
 
+  const childElement = React.isValidElement<{ children?: React.ReactNode }>(
+    children,
+  )
+    ? children
+    : undefined;
+  const renderedChildren = asChild && childElement ? childElement.props.children : children;
+
   const defaultProps = {
     children: (
       <>
-        {children}
+        {renderedChildren}
         {loading && (
           <Spinner
             className="pointer-events-none absolute"
@@ -88,9 +97,11 @@ export function Button({
     type: typeValue,
   };
 
+  const renderElement = render ?? (asChild ? childElement : undefined);
+
   return useRender({
     defaultTagName: "button",
     props: mergeProps<"button">(defaultProps, props),
-    render,
+    render: renderElement,
   });
 }

--- a/components/ui/calendar.tsx
+++ b/components/ui/calendar.tsx
@@ -18,8 +18,11 @@ export function Calendar({
   showOutsideDays = true,
   components: userComponents,
   mode = "single",
+  initialFocus: _initialFocus,
   ...props
-}: React.ComponentProps<typeof DayPicker>): React.ReactElement {
+}: React.ComponentProps<typeof DayPicker> & {
+  initialFocus?: boolean;
+}): React.ReactElement {
   const defaultClassNames = {
     button_next: buttonClassNames,
     button_previous: buttonClassNames,

--- a/components/ui/dialog.tsx
+++ b/components/ui/dialog.tsx
@@ -4,7 +4,7 @@ import { Dialog as DialogPrimitive } from "@base-ui/react/dialog";
 import { mergeProps } from "@base-ui/react/merge-props";
 import { useRender } from "@base-ui/react/use-render";
 import { XIcon } from "lucide-react";
-import type React from "react";
+import * as React from "react";
 import { cn } from "@/lib/utils";
 import { Button } from "@/components/ui/button";
 import { ScrollArea } from "@/components/ui/scroll-area";
@@ -17,10 +17,29 @@ export const Dialog: typeof DialogPrimitive.Root = DialogPrimitive.Root;
 export const DialogPortal: typeof DialogPrimitive.Portal =
   DialogPrimitive.Portal;
 
-export function DialogTrigger(
-  props: DialogPrimitive.Trigger.Props,
-): React.ReactElement {
-  return <DialogPrimitive.Trigger data-slot="dialog-trigger" {...props} />;
+export function DialogTrigger({
+  asChild = false,
+  children,
+  ...props
+}: DialogPrimitive.Trigger.Props & { asChild?: boolean }): React.ReactElement {
+  if (asChild && React.isValidElement(children)) {
+    return (
+      <DialogPrimitive.Trigger
+        data-slot="dialog-trigger"
+        render={children}
+        {...props}
+      />
+    );
+  }
+
+  return (
+    <DialogPrimitive.Trigger
+      data-slot="dialog-trigger"
+      {...props}
+    >
+      {children}
+    </DialogPrimitive.Trigger>
+  );
 }
 
 export function DialogClose(
@@ -69,7 +88,9 @@ export function DialogPopup({
   closeProps,
   portalProps,
   ...props
-}: DialogPrimitive.Popup.Props & {
+}: Omit<DialogPrimitive.Popup.Props, "onInteractOutside" | "onEscapeKeyDown"> & {
+  onInteractOutside?: (event: Event) => void;
+  onEscapeKeyDown?: (event: KeyboardEvent) => void;
   showCloseButton?: boolean;
   bottomStickOnMobile?: boolean;
   closeProps?: DialogPrimitive.Close.Props;

--- a/components/ui/popover.tsx
+++ b/components/ui/popover.tsx
@@ -1,7 +1,7 @@
 "use client";
 
 import { Popover as PopoverPrimitive } from "@base-ui/react/popover";
-import type React from "react";
+import * as React from "react";
 import { cn } from "@/lib/utils";
 
 export const PopoverCreateHandle: typeof PopoverPrimitive.createHandle =
@@ -10,10 +10,22 @@ export const PopoverCreateHandle: typeof PopoverPrimitive.createHandle =
 export const Popover: typeof PopoverPrimitive.Root = PopoverPrimitive.Root;
 
 export function PopoverTrigger({
+  asChild = false,
   className,
   children,
   ...props
-}: PopoverPrimitive.Trigger.Props): React.ReactElement {
+}: PopoverPrimitive.Trigger.Props & { asChild?: boolean }): React.ReactElement {
+  if (asChild && React.isValidElement(children)) {
+    return (
+      <PopoverPrimitive.Trigger
+        className={className}
+        data-slot="popover-trigger"
+        render={children}
+        {...props}
+      />
+    );
+  }
+
   return (
     <PopoverPrimitive.Trigger
       className={className}
@@ -36,7 +48,9 @@ export function PopoverPopup({
   anchor,
   portalProps,
   ...props
-}: PopoverPrimitive.Popup.Props & {
+}: Omit<PopoverPrimitive.Popup.Props, "onOpenAutoFocus" | "onInteractOutside"> & {
+  onOpenAutoFocus?: (event: Event) => void;
+  onInteractOutside?: (event: Event) => void;
   portalProps?: PopoverPrimitive.Portal.Props;
   side?: PopoverPrimitive.Positioner.Props["side"];
   align?: PopoverPrimitive.Positioner.Props["align"];
@@ -113,6 +127,18 @@ export function PopoverDescription({
       {...props}
     />
   );
+}
+
+export function PopoverAnchor({
+  asChild = false,
+  children,
+  ...props
+}: React.HTMLAttributes<HTMLSpanElement> & { asChild?: boolean }): React.ReactElement {
+  if (asChild && React.isValidElement(children)) {
+    return React.cloneElement(children, props as React.HTMLAttributes<HTMLElement>);
+  }
+
+  return <span {...props}>{children}</span>;
 }
 
 export { PopoverPrimitive, PopoverPopup as PopoverContent };

--- a/components/ui/select.tsx
+++ b/components/ui/select.tsx
@@ -12,7 +12,28 @@ import {
 import type * as React from "react";
 import { cn } from "@/lib/utils";
 
-export const Select: typeof SelectPrimitive.Root = SelectPrimitive.Root;
+type SelectRootProps<T> = Omit<SelectPrimitive.Root.Props<T>, "onValueChange"> & {
+  onValueChange?: (value: T, eventDetails: Parameters<NonNullable<SelectPrimitive.Root.Props<T>["onValueChange"]>>[1]) => void;
+};
+
+export function Select<T>(props: SelectRootProps<T>): React.ReactElement {
+  const { onValueChange, ...rootProps } = props;
+
+  return (
+    <SelectPrimitive.Root
+      {...(rootProps as SelectPrimitive.Root.Props<T>)}
+      onValueChange={
+        onValueChange
+          ? (value, eventDetails) => {
+              if (value !== null) {
+                onValueChange(value as T, eventDetails);
+              }
+            }
+          : undefined
+      }
+    />
+  );
+}
 
 export const selectTriggerVariants = cva(
   "relative inline-flex min-h-9 w-full min-w-36 select-none items-center justify-between gap-2 rounded-lg border border-input bg-background not-dark:bg-clip-padding px-[calc(--spacing(3)-1px)] text-left text-base text-foreground shadow-xs/5 outline-none ring-ring/24 transition-shadow before:pointer-events-none before:absolute before:inset-0 before:rounded-[calc(var(--radius-lg)-1px)] not-data-disabled:not-focus-visible:not-aria-invalid:not-data-pressed:before:shadow-[0_1px_--theme(--color-black/4%)] pointer-coarse:after:absolute pointer-coarse:after:size-full pointer-coarse:after:min-h-11 focus-visible:border-ring focus-visible:ring-[3px] aria-invalid:border-destructive/36 focus-visible:aria-invalid:border-destructive/64 focus-visible:aria-invalid:ring-destructive/16 data-disabled:pointer-events-none data-disabled:opacity-64 sm:min-h-8 sm:text-sm dark:bg-input/32 dark:aria-invalid:ring-destructive/24 dark:not-data-disabled:not-focus-visible:not-aria-invalid:not-data-pressed:before:shadow-[0_-1px_--theme(--color-white/6%)] [&_svg:not([class*='opacity-'])]:opacity-80 [&_svg:not([class*='size-'])]:size-4.5 sm:[&_svg:not([class*='size-'])]:size-4 [&_svg]:pointer-events-none [&_svg]:shrink-0 [[data-disabled],:focus-visible,[aria-invalid],[data-pressed]]:shadow-none",


### PR DESCRIPTION
### Motivation

- After upgrading `components/ui` to new Base UI primitives, many existing imports and call sites started failing due to changed prop names and signatures; this PR restores backward-compatible shims so the app code can keep using the previous APIs.

### Description

- Re-added `asChild` compatibility and preserved children rendering/loading behavior to `Button` so existing `asChild` usage continues to work (`components/ui/button.tsx`).
- Wrapped `Select` root to guard `onValueChange` from `null` values and adapt the Base UI signature to the previous handler shape (`components/ui/select.tsx`).
- Restored `AlertDialogAction` and `AlertDialogCancel` helpers that render `Button` and re-exported them to match previous API (`components/ui/alert-dialog.tsx`).
- Restored `asChild` behavior for `PopoverTrigger` and `DialogTrigger`, added `PopoverAnchor` helper, and reintroduced optional legacy event props (`onOpenAutoFocus`, `onInteractOutside`, `onInteractOutside`, `onEscapeKeyDown`) on the popover/dialog wrappers to maintain prior call sites (`components/ui/popover.tsx`, `components/ui/dialog.tsx`).
- Added optional `initialFocus` compatibility to the `Calendar` wrapper to avoid breaking `react-day-picker` prop differences (`components/ui/calendar.tsx`).
- Allowed `DayView` to accept the existing `onBackToCalendar` prop to match how the calendar container calls it (`components/app/views/day-view.tsx`).

### Testing

- `pnpm run type-check` succeeded after the changes.
- `pnpm exec oxlint` on the modified files passed.
- `git diff --check` reported no issues for the change set.
- `pnpm run lint:check` failed for the repo due to pre-existing lint warnings/errors outside this change set and unrelated files; these are not caused by this PR.
- `pnpm run build` compiled the app but the prerender step for `/opengraph-image` failed due to an unreachable external fetch in the build environment and missing production Better Auth environment variables; the compilation itself was successful.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a3de623baec8326a550a39657135d49)

## Summary by Sourcery

在更新后的 Base UI 原始组件（primitives）外重新添加向后兼容的垫片（shims），以保留现有 UI 组件 API，避免对使用这些组件的代码造成破坏性变更。

Bug 修复：
- 在适配新的 Base UI 回调签名时，为 Select 根节点的 `onValueChange` 处理函数增加对 `null` 值的防护。
- 允许 `DayView` 接受外围日历容器所期望的现有 `onBackToCalendar` 属性。

增强：
- 为 `Button`、`DialogTrigger`、`PopoverTrigger` 以及新的 `PopoverAnchor` 辅助组件重新引入 `asChild` 支持和旧版的 children 渲染行为。
- 在 popover 和 dialog 包装组件上暴露旧版弹层事件属性（`onOpenAutoFocus`、`onInteractOutside`、`onEscapeKeyDown`），以兼容之前的用法。
- 恢复 `AlertDialogAction` 和 `AlertDialogCancel` 辅助组件，它们包装标准 `Button` 组件，以匹配先前的警告对话框 API。
- 为 `Calendar` 包装组件增加可选的 `initialFocus` 兼容处理，以平滑 react-day-picker 属性差异带来的影响。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Restore backward-compatible shims around updated Base UI primitives to preserve existing UI component APIs and prevent breaking changes in consuming code.

Bug Fixes:
- Guard Select root onValueChange handler against null values while adapting to the new Base UI callback signature.
- Allow DayView to accept the existing onBackToCalendar prop expected by the surrounding calendar container.

Enhancements:
- Reintroduce asChild support and legacy children rendering behavior for Button, DialogTrigger, PopoverTrigger, and a new PopoverAnchor helper.
- Expose legacy popup event props on popover and dialog wrappers (onOpenAutoFocus, onInteractOutside, onEscapeKeyDown) for compatibility with prior usage.
- Restore AlertDialogAction and AlertDialogCancel helpers that wrap the standard Button component to match the previous alert dialog API.
- Add optional initialFocus compatibility handling to the Calendar wrapper to smooth over react-day-picker prop differences.

</details>