### PR TITLE
fix: complete coss ui migration

### DIFF
--- a/components/app/analytics/import-export.tsx
+++ b/components/app/analytics/import-export.tsx
@@ -1103,7 +1103,9 @@ END:VEVENT
                 </Label>
                 <Select
                   value={importCalendarId}
-                  onValueChange={setImportCalendarId}
+                  onValueChange={(value) =>
+                    value !== null && setImportCalendarId(value)
+                  }
                 >
                   <SelectTrigger id="import-calendar-category">
                     <SelectValue />
@@ -1226,7 +1228,12 @@ END:VEVENT
           <div className="space-y-4 py-4">
             <div className="space-y-2">
               <Label htmlFor="export-format">{t.exportFormat}</Label>
-              <Select value={exportFormat} onValueChange={setExportFormat}>
+              <Select
+                value={exportFormat}
+                onValueChange={(value) =>
+                  value !== null && setExportFormat(value)
+                }
+              >
                 <SelectTrigger id="export-format">
                   <SelectValue />
                 </SelectTrigger>
@@ -1242,7 +1249,9 @@ END:VEVENT
               <Label htmlFor="date-range">{t.dateRange}</Label>
               <Select
                 value={dateRangeOption}
-                onValueChange={setDateRangeOption}
+                onValueChange={(value) =>
+                  value !== null && setDateRangeOption(value)
+                }
               >
                 <SelectTrigger id="date-range">
                   <SelectValue />

--- a/components/app/analytics/share-management.tsx
+++ b/components/app/analytics/share-management.tsx
@@ -5,8 +5,7 @@ import {
   AlertDialogTitle,
   AlertDialogDescription,
   AlertDialogFooter,
-  AlertDialogCancel,
-  AlertDialogAction,
+  AlertDialogClose,
 } from '@/components/ui/alert-dialog'
 import { Copy, ExternalLink, Lock, Trash2 } from 'lucide-react'
 import { translations, useLanguage } from '@/lib/i18n'
@@ -240,8 +239,8 @@ export default function ShareManagement() {
             </AlertDialogDescription>
           </AlertDialogHeader>
           <AlertDialogFooter>
-            <AlertDialogCancel>{t.cancel}</AlertDialogCancel>
-            <AlertDialogAction
+            <AlertDialogClose>{t.cancel}</AlertDialogClose>
+            <AlertDialogClose
               onClick={deleteShare}
               disabled={isDeleting}
               variant="destructive"
@@ -273,7 +272,7 @@ export default function ShareManagement() {
               ) : (
                 <>{t.delete}</>
               )}
-            </AlertDialogAction>
+            </AlertDialogClose>
           </AlertDialogFooter>
         </AlertDialogContent>
       </AlertDialog>
@@ -303,18 +302,18 @@ export default function ShareManagement() {
           </div>
 
           <AlertDialogFooter>
-            <AlertDialogCancel
+            <AlertDialogClose
               onClick={() => {
                 setDecryptingShare(null)
                 setPasswordInput('')
               }}
             >
               {t.cancel}
-            </AlertDialogCancel>
+            </AlertDialogClose>
 
-            <AlertDialogAction onClick={handleDecrypt} disabled={isDecrypting}>
+            <AlertDialogClose onClick={handleDecrypt} disabled={isDecrypting}>
               {isDecrypting ? t.decrypting : t.decrypt}
-            </AlertDialogAction>
+            </AlertDialogClose>
           </AlertDialogFooter>
         </AlertDialogContent>
       </AlertDialog>

--- a/components/app/calendar.tsx
+++ b/components/app/calendar.tsx
@@ -69,8 +69,7 @@ import {
 } from '@/components/ui/dropdown-menu'
 import {
   AlertDialog,
-  AlertDialogAction,
-  AlertDialogCancel,
+  AlertDialogClose,
   AlertDialogContent,
   AlertDialogDescription,
   AlertDialogFooter,
@@ -789,7 +788,7 @@ export default function Calendar({ className, ...props }: CalendarProps) {
                         : 'week'
                   }
                   onValueChange={(value) => {
-                    if (isCalendarView(value)) {
+                    if (value !== null && isCalendarView(value)) {
                       setView(value)
                     }
                   }}
@@ -1147,15 +1146,15 @@ export default function Calendar({ className, ...props }: CalendarProps) {
               </AlertDialogDescription>
             </AlertDialogHeader>
             <AlertDialogFooter>
-              <AlertDialogCancel onClick={() => setPendingDeleteEvent(null)}>
+              <AlertDialogClose onClick={() => setPendingDeleteEvent(null)}>
                 {t.cancel}
-              </AlertDialogCancel>
-              <AlertDialogAction
+              </AlertDialogClose>
+              <AlertDialogClose
                 className="bg-destructive text-destructive-foreground"
                 onClick={confirmEventDelete}
               >
                 {t.delete}
-              </AlertDialogAction>
+              </AlertDialogClose>
             </AlertDialogFooter>
           </AlertDialogContent>
         </AlertDialog>

--- a/components/app/event/event-dialog.tsx
+++ b/components/app/event/event-dialog.tsx
@@ -526,7 +526,9 @@ export default function EventDialog({
             <div className="flex items-center space-x-2">
               <Select
                 value={value.hours}
-                onValueChange={(newHour) => onChange(newHour, value.minutes)}
+                onValueChange={(newHour) =>
+                  newHour !== null && onChange(newHour, value.minutes)
+                }
               >
                 <SelectTrigger className="w-[70px]">
                   <SelectValue placeholder={isZh ? '时' : 'Hour'} />
@@ -544,7 +546,9 @@ export default function EventDialog({
 
               <Select
                 value={value.minutes}
-                onValueChange={(newMinute) => onChange(value.hours, newMinute)}
+                onValueChange={(newMinute) =>
+                  newMinute !== null && onChange(value.hours, newMinute)
+                }
               >
                 <SelectTrigger className="w-[70px]">
                   <SelectValue placeholder={isZh ? '分' : 'Min'} />
@@ -654,7 +658,6 @@ export default function EventDialog({
                           setStartDateOpen(false)
                         }
                       }}
-                      initialFocus
                     />
                   </PopoverContent>
                 </Popover>
@@ -703,7 +706,6 @@ export default function EventDialog({
                           }
                         }
                       }}
-                      initialFocus
                       disabled={(date) => date < startDate}
                     />
                   </PopoverContent>
@@ -746,6 +748,7 @@ export default function EventDialog({
             <Select
               value={calendarSelectValue}
               onValueChange={(value) => {
+                if (value === null) return
                 setSelectedCalendar(value)
                 if (value !== '__uncategorized__') {
                   setColor(getEventColorByCalendarId(value))
@@ -783,7 +786,10 @@ export default function EventDialog({
 
           <div className="space-y-2">
             <Label htmlFor="color">{t.color}</Label>
-            <Select value={color} onValueChange={setColor}>
+            <Select
+              value={color}
+              onValueChange={(value) => value !== null && setColor(value)}
+            >
               <SelectTrigger>
                 <SelectValue placeholder={t.selectColor} />
               </SelectTrigger>
@@ -824,7 +830,12 @@ export default function EventDialog({
 
           <div className="space-y-2">
             <Label htmlFor="notification">{t.notification}</Label>
-            <Select value={notification} onValueChange={setNotification}>
+            <Select
+              value={notification}
+              onValueChange={(value) =>
+                value !== null && setNotification(value)
+              }
+            >
               <SelectTrigger>
                 <SelectValue placeholder={t.selectNotification} />
               </SelectTrigger>

--- a/components/app/event/event-preview.tsx
+++ b/components/app/event/event-preview.tsx
@@ -29,7 +29,7 @@ import type { Language } from '@/lib/i18n'
 import { isZhLanguage, translations } from '@/lib/i18n'
 import { cn } from '@/lib/utils'
 import { useCalendar } from '@/components/providers/calendar-context'
-import { Popover, PopoverAnchor, PopoverContent } from '@/components/ui/popover'
+import { Popover, PopoverContent } from '@/components/ui/popover'
 import {
   Dialog,
   DialogContent,
@@ -94,6 +94,7 @@ export default function EventPreview({
   const [sharePassword, setSharePassword] = useState('')
   const [burnAfterRead, setBurnAfterRead] = useState(false)
   const ignoreOutsideUntilRef = useRef(0)
+  const popoverAnchorRef = useRef<HTMLDivElement>(null)
   const colorMapping: Record<string, string> = {
     'bg-[#E6F6FD]': '#3B82F6',
     'bg-[#E7F8F2]': '#10B981',
@@ -560,24 +561,13 @@ export default function EventPreview({
     <>
       {!shareOnlyMode && (
         <Popover open={open} onOpenChange={onOpenChange} modal={modal}>
-          <PopoverAnchor asChild>
-            <div style={anchorStyle} />
-          </PopoverAnchor>
+          <div ref={popoverAnchorRef} style={anchorStyle} />
           <PopoverContent
+            anchor={popoverAnchorRef}
             side={popoverSide}
             align="center"
             sideOffset={12}
             className="w-[min(96vw,28rem)] rounded-xl p-0 overflow-hidden"
-            onOpenAutoFocus={(e) => e.preventDefault()}
-            onInteractOutside={(e) => {
-              if (!modal) {
-                if (Date.now() < ignoreOutsideUntilRef.current) {
-                  e.preventDefault()
-                  return
-                }
-                onOpenChange(false)
-              }
-            }}
           >
             <div className="flex justify-between items-center p-5">
               <div className="w-24" />

--- a/components/app/profile/settings.tsx
+++ b/components/app/profile/settings.tsx
@@ -46,7 +46,7 @@ import {
   Palette,
   ArrowLeft,
 } from 'lucide-react'
-import { Kbd } from "@/components/ui/kbd"
+import { Kbd } from '@/components/ui/kbd'
 
 interface SettingsProps {
   language: Language
@@ -191,7 +191,12 @@ export default function Settings({
               <Palette className="h-4 w-4" />
               {t.theme}
             </div>
-            <Select value={theme || 'system'} onValueChange={handleThemeChange}>
+            <Select
+              value={theme || 'system'}
+              onValueChange={(value) =>
+                value !== null && handleThemeChange(value)
+              }
+            >
               <SelectTrigger id="theme">
                 <SelectValue />
               </SelectTrigger>
@@ -209,7 +214,9 @@ export default function Settings({
             </div>
             <Select
               value={language}
-              onValueChange={(value: Language) => handleLanguageChange(value)}
+              onValueChange={(value) =>
+                value !== null && handleLanguageChange(value)
+              }
             >
               <SelectTrigger id="language">
                 <SelectValue />
@@ -253,7 +260,7 @@ export default function Settings({
             <Select
               value={defaultView}
               onValueChange={(value) => {
-                if (isCalendarView(value)) {
+                if (value !== null && isCalendarView(value)) {
                   setDefaultView(value)
                 }
               }}
@@ -275,7 +282,10 @@ export default function Settings({
               <Globe2 className="h-4 w-4" />
               {t.timezone}
             </div>
-            <Select value={timezone} onValueChange={setTimezone}>
+            <Select
+              value={timezone}
+              onValueChange={(value) => value !== null && setTimezone(value)}
+            >
               <SelectTrigger id="timezone">
                 <SelectValue />
               </SelectTrigger>
@@ -295,7 +305,7 @@ export default function Settings({
             </div>
             <Select
               value={timeFormat}
-              onValueChange={(value: '24h' | '12h') => setTimeFormat(value)}
+              onValueChange={(value) => value !== null && setTimeFormat(value)}
             >
               <SelectTrigger id="time-format">
                 <SelectValue />
@@ -334,63 +344,43 @@ export default function Settings({
                   </DialogHeader>
                   <div className="space-y-2 text-sm">
                     <div className="flex justify-between gap-3">
-                      <Kbd>
-                        N
-                      </Kbd>
+                      <Kbd>N</Kbd>
                       <span>{t.newEvent}</span>
                     </div>
                     <div className="flex justify-between gap-3">
-                      <Kbd>
-                        /
-                      </Kbd>
+                      <Kbd>/</Kbd>
                       <span>{t.searchEvents}</span>
                     </div>
                     <div className="flex justify-between gap-3">
-                      <Kbd>
-                        T
-                      </Kbd>
+                      <Kbd>T</Kbd>
                       <span>{t.today}</span>
                     </div>
                     <div className="flex justify-between gap-3">
-                      <Kbd>
-                        1
-                      </Kbd>
+                      <Kbd>1</Kbd>
                       <span>{t.day}</span>
                     </div>
                     <div className="flex justify-between gap-3">
-                      <Kbd>
-                        2
-                      </Kbd>
+                      <Kbd>2</Kbd>
                       <span>{t.week}</span>
                     </div>
                     <div className="flex justify-between gap-3">
-                      <Kbd>
-                        3
-                      </Kbd>
+                      <Kbd>3</Kbd>
                       <span>{t.month}</span>
                     </div>
                     <div className="flex justify-between gap-3">
-                      <Kbd>
-                        4
-                      </Kbd>
+                      <Kbd>4</Kbd>
                       <span>{t.year}</span>
                     </div>
                     <div className="flex justify-between gap-3">
-                      <Kbd>
-                        5
-                      </Kbd>
+                      <Kbd>5</Kbd>
                       <span>{t.fourDay}</span>
                     </div>
                     <div className="flex justify-between gap-3">
-                      <Kbd>
-                        ←
-                      </Kbd>
+                      <Kbd>←</Kbd>
                       <span>{t.previousPeriod}</span>
                     </div>
                     <div className="flex justify-between gap-3">
-                      <Kbd>
-                        →
-                      </Kbd>
+                      <Kbd>→</Kbd>
                       <span>{t.nextPeriod}</span>
                     </div>
                   </div>

--- a/components/app/profile/user-profile-button.tsx
+++ b/components/app/profile/user-profile-button.tsx
@@ -24,8 +24,7 @@ import {
 } from '@/components/ui/dialog'
 import {
   AlertDialog,
-  AlertDialogAction,
-  AlertDialogCancel,
+  AlertDialogClose,
   AlertDialogContent,
   AlertDialogDescription,
   AlertDialogFooter,
@@ -1423,8 +1422,8 @@ export default function UserProfileButton({
             />
           </div>
           <AlertDialogFooter>
-            <AlertDialogCancel>{t.cancel}</AlertDialogCancel>
-            <AlertDialogAction
+            <AlertDialogClose>{t.cancel}</AlertDialogClose>
+            <AlertDialogClose
               className="bg-destructive text-destructive-foreground hover:bg-destructive/90"
               onClick={(e) => {
                 e.preventDefault()
@@ -1436,7 +1435,7 @@ export default function UserProfileButton({
               }
             >
               {isDeletingAccount ? t.deleting : t.confirmDeleteAccount}
-            </AlertDialogAction>
+            </AlertDialogClose>
           </AlertDialogFooter>
         </AlertDialogContent>
       </AlertDialog>
@@ -1465,8 +1464,8 @@ export default function UserProfileButton({
             />
           </div>
           <AlertDialogFooter>
-            <AlertDialogCancel>{t.cancel}</AlertDialogCancel>
-            <AlertDialogAction
+            <AlertDialogClose>{t.cancel}</AlertDialogClose>
+            <AlertDialogClose
               className="bg-destructive text-destructive-foreground hover:bg-destructive/90"
               onClick={(e) => {
                 e.preventDefault()
@@ -1479,7 +1478,7 @@ export default function UserProfileButton({
               disabled={deleteCloudConfirmText !== 'DELETE CLOUD DATA'}
             >
               {t.confirmDeleteData}
-            </AlertDialogAction>
+            </AlertDialogClose>
           </AlertDialogFooter>
         </AlertDialogContent>
       </AlertDialog>
@@ -1538,10 +1537,7 @@ export default function UserProfileButton({
           if (open) setUnlockOpen(true)
         }}
       >
-        <DialogContent
-          onInteractOutside={(e: Event) => e.preventDefault()}
-          onEscapeKeyDown={(e: KeyboardEvent) => e.preventDefault()}
-        >
+        <DialogContent>
           <DialogHeader>
             <DialogTitle>{t.enterPasswordTitle}</DialogTitle>
             <DialogDescription>{t.enterPasswordDescription}</DialogDescription>

--- a/components/app/sidebar/countdown.tsx
+++ b/components/app/sidebar/countdown.tsx
@@ -568,6 +568,7 @@ export function CountdownTool({ open, onOpenChange }: CountdownToolProps) {
             <Select
               value={newCountdown.color}
               onValueChange={(value) =>
+                value !== null &&
                 setNewCountdown({ ...newCountdown, color: value })
               }
             >
@@ -670,7 +671,6 @@ export function CountdownTool({ open, onOpenChange }: CountdownToolProps) {
                     setSelectedDate(date)
                     setCalendarOpen(false)
                   }}
-                  initialFocus
                   locale={isZh ? zhCN : enUS}
                 />
               </PopoverContent>
@@ -681,7 +681,8 @@ export function CountdownTool({ open, onOpenChange }: CountdownToolProps) {
             <Label>{t.countdownRepeat}</Label>
             <Select
               value={newCountdown.repeat || 'none'}
-              onValueChange={(value: Countdown['repeat']) =>
+              onValueChange={(value) =>
+                value !== null &&
                 setNewCountdown({ ...newCountdown, repeat: value })
               }
             >

--- a/components/app/sidebar/sidebar.tsx
+++ b/components/app/sidebar/sidebar.tsx
@@ -452,7 +452,9 @@ export default function Sidebar({
               <Label htmlFor="category-color">{t.color}</Label>
               <Select
                 value={newCategoryColor}
-                onValueChange={setNewCategoryColor}
+                onValueChange={(value) =>
+                  value !== null && setNewCategoryColor(value)
+                }
               >
                 <SelectTrigger id="category-color">
                   <SelectValue placeholder={t.selectColor} />
@@ -509,7 +511,9 @@ export default function Sidebar({
               <Label htmlFor="edit-category-color">{t.color}</Label>
               <Select
                 value={editingCategoryColor}
-                onValueChange={setEditingCategoryColor}
+                onValueChange={(value) =>
+                  value !== null && setEditingCategoryColor(value)
+                }
               >
                 <SelectTrigger id="edit-category-color">
                   <SelectValue placeholder={t.selectColor} />

--- a/components/app/views/day-view.tsx
+++ b/components/app/views/day-view.tsx
@@ -47,6 +47,7 @@ interface DayViewProps {
   onDeleteEvent?: (event: CalendarEvent) => void
   onShareEvent?: (event: CalendarEvent) => void
   onBookmarkEvent?: (event: CalendarEvent) => void
+  onBackToCalendar?: () => void
   onEventDrop?: (
     event: CalendarEvent,
     newStartDate: Date,

--- a/components/ui/alert-dialog.tsx
+++ b/components/ui/alert-dialog.tsx
@@ -3,6 +3,7 @@
 import { AlertDialog as AlertDialogPrimitive } from "@base-ui/react/alert-dialog";
 import type React from "react";
 import { cn } from "@/lib/utils";
+import { Button, type ButtonProps } from "@/components/ui/button";
 
 export const AlertDialogCreateHandle: typeof AlertDialogPrimitive.createHandle =
   AlertDialogPrimitive.createHandle;
@@ -152,11 +153,19 @@ export function AlertDialogDescription({
   );
 }
 
-export function AlertDialogClose(
-  props: AlertDialogPrimitive.Close.Props,
-): React.ReactElement {
+export function AlertDialogClose({
+  variant,
+  size,
+  className,
+  ...props
+}: AlertDialogPrimitive.Close.Props & Pick<ButtonProps, "variant" | "size">): React.ReactElement {
   return (
-    <AlertDialogPrimitive.Close data-slot="alert-dialog-close" {...props} />
+    <AlertDialogPrimitive.Close
+      className={className}
+      data-slot="alert-dialog-close"
+      render={variant || size ? <Button size={size} variant={variant} /> : undefined}
+      {...props}
+    />
   );
 }
 
@@ -165,3 +174,5 @@ export {
   AlertDialogBackdrop as AlertDialogOverlay,
   AlertDialogPopup as AlertDialogContent,
 };
+
+export { AlertDialogClose as AlertDialogAction, AlertDialogClose as AlertDialogCancel };

--- a/components/ui/button.tsx
+++ b/components/ui/button.tsx
@@ -3,7 +3,7 @@
 import { mergeProps } from "@base-ui/react/merge-props";
 import { useRender } from "@base-ui/react/use-render";
 import { cva, type VariantProps } from "class-variance-authority";
-import type * as React from "react";
+import * as React from "react";
 import { cn } from "@/lib/utils";
 import { Spinner } from "@/components/ui/spinner";
 
@@ -52,6 +52,7 @@ export interface ButtonProps extends useRender.ComponentProps<"button"> {
   variant?: VariantProps<typeof buttonVariants>["variant"];
   size?: VariantProps<typeof buttonVariants>["size"];
   loading?: boolean;
+  asChild?: boolean;
 }
 
 export function Button({
@@ -59,19 +60,25 @@ export function Button({
   variant,
   size,
   render,
+  asChild,
   children,
   loading = false,
   disabled: disabledProp,
   ...props
 }: ButtonProps): React.ReactElement {
   const isDisabled: boolean = Boolean(loading || disabledProp);
+  const child = asChild && React.isValidElement(children) ? children : null;
+  const renderElement = render ?? child ?? undefined;
+  const content = child
+    ? (child.props as { children?: React.ReactNode }).children
+    : children;
   const typeValue: React.ButtonHTMLAttributes<HTMLButtonElement>["type"] =
-    render ? undefined : "button";
+    renderElement ? undefined : "button";
 
   const defaultProps = {
     children: (
       <>
-        {children}
+        {content}
         {loading && (
           <Spinner
             className="pointer-events-none absolute"
@@ -91,6 +98,6 @@ export function Button({
   return useRender({
     defaultTagName: "button",
     props: mergeProps<"button">(defaultProps, props),
-    render,
+    render: renderElement,
   });
 }

--- a/components/ui/chart.tsx
+++ b/components/ui/chart.tsx
@@ -252,7 +252,7 @@ function ChartTooltipContent({
                           {itemConfig?.label ?? item.name}
                         </span>
                       </div>
-                      {item.value != null && (
+                      {item.value !== null && item.value !== undefined && (
                         <span className="font-mono font-medium text-foreground tabular-nums">
                           {typeof item.value === "number"
                             ? item.value.toLocaleString()

--- a/components/ui/dialog.tsx
+++ b/components/ui/dialog.tsx
@@ -4,7 +4,7 @@ import { Dialog as DialogPrimitive } from "@base-ui/react/dialog";
 import { mergeProps } from "@base-ui/react/merge-props";
 import { useRender } from "@base-ui/react/use-render";
 import { XIcon } from "lucide-react";
-import type React from "react";
+import * as React from "react";
 import { cn } from "@/lib/utils";
 import { Button } from "@/components/ui/button";
 import { ScrollArea } from "@/components/ui/scroll-area";
@@ -18,9 +18,18 @@ export const DialogPortal: typeof DialogPrimitive.Portal =
   DialogPrimitive.Portal;
 
 export function DialogTrigger(
-  props: DialogPrimitive.Trigger.Props,
+  props: DialogPrimitive.Trigger.Props & { asChild?: boolean },
 ): React.ReactElement {
-  return <DialogPrimitive.Trigger data-slot="dialog-trigger" {...props} />;
+  const { asChild, children, ...triggerProps } = props;
+  return (
+    <DialogPrimitive.Trigger
+      data-slot="dialog-trigger"
+      render={asChild && React.isValidElement(children) ? children : undefined}
+      {...triggerProps}
+    >
+      {asChild && React.isValidElement(children) ? (children.props as { children?: React.ReactNode }).children : children}
+    </DialogPrimitive.Trigger>
+  );
 }
 
 export function DialogClose(

--- a/components/ui/popover.tsx
+++ b/components/ui/popover.tsx
@@ -1,7 +1,7 @@
 "use client";
 
 import { Popover as PopoverPrimitive } from "@base-ui/react/popover";
-import type React from "react";
+import * as React from "react";
 import { cn } from "@/lib/utils";
 
 export const PopoverCreateHandle: typeof PopoverPrimitive.createHandle =
@@ -13,14 +13,16 @@ export function PopoverTrigger({
   className,
   children,
   ...props
-}: PopoverPrimitive.Trigger.Props): React.ReactElement {
+}: PopoverPrimitive.Trigger.Props & { asChild?: boolean }): React.ReactElement {
+  const { asChild, ...triggerProps } = props as PopoverPrimitive.Trigger.Props & { asChild?: boolean };
   return (
     <PopoverPrimitive.Trigger
       className={className}
       data-slot="popover-trigger"
-      {...props}
+      render={asChild && React.isValidElement(children) ? children : undefined}
+      {...triggerProps}
     >
-      {children}
+      {asChild && React.isValidElement(children) ? (children.props as { children?: React.ReactNode }).children : children}
     </PopoverPrimitive.Trigger>
   );
 }


### PR DESCRIPTION
### Motivation
- The project migrated from Radix/shadcn UI to coss ui (Base UI) and many components still used old props/parts (e.g. `asChild`, `AlertDialogAction`/`AlertDialogCancel`, Radix anchors), causing TypeScript and runtime errors and broken popup anchoring/layouts.  
- `Select` handlers started supplying `null` values (Base UI `Select` can pass `null`) which broke existing state setters typed for non-null strings/enums.  
- Some overlay parts and focus props used previously are not supported by the new primitives and needed replacement or removal to restore stable behavior and layout.

### Description
- Added backward-compatible `asChild` support by mapping legacy patterns to Base UI’s `render` model for composed components, specifically updating `Button`, `DialogTrigger`, and `PopoverTrigger` to accept `asChild` and forward the correct `render` element. (see `components/ui/button.tsx`, `components/ui/dialog.tsx`, `components/ui/popover.tsx`).
- Reworked `AlertDialog` close/action API by rendering `Button` for styled actions and exporting aliases so existing uses of `AlertDialogAction` / `AlertDialogCancel` keep working (see `components/ui/alert-dialog.tsx`).
- Fixed `Popover` anchoring by replacing the removed Radix `PopoverAnchor` usage with a `ref` and forwarding it to Base UI via the `anchor` prop; removed unsupported overlay callbacks like `onOpenAutoFocus` / `onInteractOutside` that aren’t present on the new popup API (see `components/app/event/event-preview.tsx` and `components/ui/popover.tsx`).
- Guarded `Select` `onValueChange` handlers across the app to handle `null` from Base UI safely before calling state setters (time, calendar, color, theme, language, timezone, view, etc.), preventing invalid `null` assignments that caused TypeScript errors (see changes in files under `components/app/*`).
- Removed or adjusted unsupported props such as `initialFocus` on `Calendar` usages and removed overlay `onInteractOutside`/`onEscapeKeyDown` usages where the migrated primitives don’t accept them.  
- Small type/lint safety fixes: added explicit null/undefined checks for chart tooltip values and minor formatting/`Kbd` content normalization to satisfy linters (see `components/ui/chart.tsx`, `components/app/profile/settings.tsx`).

### Testing
- Ran `pnpm run type-check` and TypeScript typecheck completed with no `tsc` errors after the fixes.  
- Ran `pnpm run lint:check`; ESLint reports repository warnings (existing console/log and minor unused params) and the command failed because the repo enforces `--max-warnings=0`.  
- Attempted `pnpm run build`; Next.js compiled but static prerender for `/opengraph-image` failed in this environment due to missing Better Auth environment variables and an unreachable fetch during prerender (external/network constraints), not due to the UI migration changes.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a3deba7258c8326b54648d1a664faff)

## Summary by Sourcery

完成将 dialog、popover、select 以及相关 UI 原语迁移到 Base UI（coss ui）API 的工作，同时保持对现有调用方的向后兼容。

New Features:
- 为 Button、DialogTrigger 和 PopoverTrigger 新增可选的 `asChild` 支持，以更好地支持与 Base UI 原语组合使用的触发器/内容模式。

Bug Fixes:
- 防止来自 Base UI Select 的 `null` 值在设置、事件、分析、侧边栏和倒计时流程中被传递到状态 setter 中。
- 修复事件预览中的 popover 锚定方式，将已移除的 Radix anchor 组件替换为与 Base UI 兼容的基于 ref 的锚点。
- 确保图表 tooltip 渲染时能优雅地跳过 `undefined` 或 `null` 值，以避免运行时问题。

Enhancements:
- 统一 AlertDialog 的 action/close 处理方式，将 AlertDialogClose 样式化为按钮，并将其以向后兼容的方式暴露为 AlertDialogAction 和 AlertDialogCancel 的别名。
- 删除或调整 dialogs、popovers 和 calendars 上不再受支持的 overlay 与 focus 相关 props（例如 `initialFocus`、`onInteractOutside`、`onEscapeKeyDown`），以与新的原语保持一致。
- 规范键盘快捷键 `Kbd` 标记和部分轻微的 import 调整，以满足 lint/代码风格要求。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Finalize the migration of dialog, popover, select, and related UI primitives to the Base UI (coss ui) APIs while preserving backward compatibility for existing call sites.

New Features:
- Add optional asChild support to Button, DialogTrigger, and PopoverTrigger to better support composed trigger/content patterns with Base UI primitives.

Bug Fixes:
- Prevent null values from Base UI Select from propagating into state setters across settings, events, analytics, sidebar, and countdown flows.
- Fix popover anchoring for event previews by switching from the removed Radix anchor component to a ref-based anchor compatible with Base UI.
- Ensure chart tooltip rendering gracefully skips undefined or null values to avoid runtime issues.

Enhancements:
- Unify AlertDialog action/close handling by styling AlertDialogClose as a button and exposing it as backward-compatible AlertDialogAction and AlertDialogCancel aliases.
- Remove or adjust unsupported overlay and focus props (e.g., initialFocus, onInteractOutside, onEscapeKeyDown) on dialogs, popovers, and calendars to align with the new primitives.
- Normalize keyboard shortcut Kbd markup and minor imports to satisfy lint/style expectations.

</details>